### PR TITLE
Feat/provider profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,15 +535,15 @@ If you already built the binary:
 | `openmeta pow` | Show proof-of-work history |
 | `openmeta runs` | Show recent command runs, durations, and failure reasons |
 | `openmeta runs <id>` | Inspect one recorded run |
+| `openmeta automation status` | Show automation status |
+| `openmeta automation enable` | Enable daily unattended automation |
+| `openmeta automation disable` | Disable daily unattended automation |
+| `openmeta provider config` | Configure a reusable LLM provider profile interactively |
 | `openmeta provider list` | List saved LLM provider profiles |
-| `openmeta provider config` | Configure a provider profile interactively |
 | `openmeta provider save <name>` | Save current LLM settings as a reusable provider profile |
 | `openmeta provider add <name>` | Add a provider profile from command-line values |
 | `openmeta provider use <name>` | Switch the active LLM provider to a saved profile |
 | `openmeta provider remove <name>` | Remove a saved provider profile |
-| `openmeta automation status` | Show automation status |
-| `openmeta automation enable` | Enable daily unattended automation |
-| `openmeta automation disable` | Disable daily unattended automation |
 | `openmeta config view` | Show current configuration |
 | `openmeta config set <key> <value>` | Update a config value |
 | `openmeta config reset` | Reset configuration |

--- a/README.md
+++ b/README.md
@@ -535,6 +535,11 @@ If you already built the binary:
 | `openmeta pow` | Show proof-of-work history |
 | `openmeta runs` | Show recent command runs, durations, and failure reasons |
 | `openmeta runs <id>` | Inspect one recorded run |
+| `openmeta provider list` | List saved LLM provider profiles |
+| `openmeta provider save <name>` | Save current LLM settings as a reusable provider profile |
+| `openmeta provider add <name>` | Add a provider profile from command-line values |
+| `openmeta provider use <name>` | Switch the active LLM provider to a saved profile |
+| `openmeta provider remove <name>` | Remove a saved provider profile |
 | `openmeta automation status` | Show automation status |
 | `openmeta automation enable` | Enable daily unattended automation |
 | `openmeta automation disable` | Disable daily unattended automation |

--- a/README.md
+++ b/README.md
@@ -548,6 +548,14 @@ If you already built the binary:
 | `openmeta config set <key> <value>` | Update a config value |
 | `openmeta config reset` | Reset configuration |
 
+Example provider workflow:
+
+```bash
+openmeta provider config
+openmeta provider save production
+openmeta provider use production --validate
+```
+
 ### Local Paths and Assets
 
 OpenMeta keeps a clear local footprint:

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ If you already built the binary:
 | `openmeta runs` | Show recent command runs, durations, and failure reasons |
 | `openmeta runs <id>` | Inspect one recorded run |
 | `openmeta provider list` | List saved LLM provider profiles |
+| `openmeta provider config` | Configure a provider profile interactively |
 | `openmeta provider save <name>` | Save current LLM settings as a reusable provider profile |
 | `openmeta provider add <name>` | Add a provider profile from command-line values |
 | `openmeta provider use <name>` | Switch the active LLM provider to a saved profile |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
   registerInboxCommand,
   registerInitCommand,
   registerPowCommand,
+  registerProviderCommand,
   registerRunsCommand,
   registerScoutCommand,
 } from './commands/index.js';
@@ -34,6 +35,7 @@ async function main(): Promise<void> {
   registerInboxCommand(program);
   registerPowCommand(program);
   registerConfigCommand(program);
+  registerProviderCommand(program);
   registerAutomationCommand(program);
   registerDoctorCommand(program);
   registerRunsCommand(program);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,6 +5,7 @@ export { registerScoutCommand } from './scout.js';
 export { registerInboxCommand } from './inbox.js';
 export { registerPowCommand } from './pow.js';
 export { registerConfigCommand } from './config.js';
+export { registerProviderCommand } from './provider.js';
 export { registerAutomationCommand } from './automation.js';
 export { registerDoctorCommand } from './doctor.js';
 export { registerRunsCommand } from './runs.js';

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander';
+import { providerOrchestrator } from '../orchestration/index.js';
+import { runCommand } from './run-command.js';
+
+export function registerProviderCommand(program: Command): void {
+  const provider = program
+    .command('provider')
+    .description('Manage reusable LLM provider profiles');
+
+  provider
+    .command('list')
+    .alias('ls')
+    .description('List saved provider profiles')
+    .action(() => runCommand('OpenMeta Provider', () => providerOrchestrator.list()));
+
+  provider
+    .command('save <name>')
+    .description('Save the current LLM settings as a provider profile')
+    .action((name: string) => runCommand('OpenMeta Provider', () => providerOrchestrator.save(name)));
+
+  provider
+    .command('add <name>')
+    .description('Add a provider profile from command-line values')
+    .option('--provider <provider>', 'Provider type, defaults to custom')
+    .requiredOption('--base-url <url>', 'OpenAI-compatible API base URL')
+    .requiredOption('--model <model>', 'Model name')
+    .requiredOption('--api-key <key>', 'LLM API key')
+    .option('--header <key=value>', 'Extra API header; repeat for multiple headers', (value, previous: string[] = []) => [...previous, value], [])
+    .action((name: string, options: {
+      provider?: string;
+      baseUrl: string;
+      model: string;
+      apiKey: string;
+      header: string[];
+    }) => runCommand('OpenMeta Provider', () => providerOrchestrator.add(name, options)));
+
+  provider
+    .command('use <name>')
+    .description('Switch the active LLM provider to a saved profile')
+    .option('--validate', 'Validate the selected provider after switching')
+    .action((name: string, options: { validate?: boolean }) => runCommand(
+      'OpenMeta Provider',
+      () => providerOrchestrator.use(name, options),
+    ));
+
+  provider
+    .command('remove <name>')
+    .alias('rm')
+    .description('Remove a saved provider profile')
+    .action((name: string) => runCommand('OpenMeta Provider', () => providerOrchestrator.remove(name)));
+}

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -19,6 +19,12 @@ export function registerProviderCommand(program: Command): void {
     .action((name: string) => runCommand('OpenMeta Provider', () => providerOrchestrator.save(name)));
 
   provider
+    .command('config')
+    .alias('configure')
+    .description('Configure a provider profile interactively')
+    .action(() => runCommand('OpenMeta Provider', () => providerOrchestrator.configure()));
+
+  provider
     .command('add <name>')
     .description('Add a provider profile from command-line values')
     .option('--provider <provider>', 'Provider type, defaults to custom')

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -43,6 +43,8 @@ function createDefaultConfig(): AppConfig {
       apiKey: '',
       modelName: 'gpt-4o-mini',
       apiHeaders: {},
+      activeProfile: '',
+      profiles: {},
     },
     automation: {
       enabled: false,
@@ -133,6 +135,10 @@ export class ConfigService {
     if (encrypted.llm.apiKey) {
       encrypted.llm = { ...encrypted.llm, apiKey: CryptoService.encrypt(encrypted.llm.apiKey) };
     }
+    encrypted.llm = {
+      ...encrypted.llm,
+      profiles: this.encryptProviderProfiles(encrypted.llm.profiles),
+    };
     return encrypted;
   }
 
@@ -144,6 +150,10 @@ export class ConfigService {
     if (decrypted.llm.apiKey && CryptoService.isEncrypted(decrypted.llm.apiKey)) {
       decrypted.llm = { ...decrypted.llm, apiKey: CryptoService.decrypt(decrypted.llm.apiKey) };
     }
+    decrypted.llm = {
+      ...decrypted.llm,
+      profiles: this.decryptProviderProfiles(decrypted.llm.profiles),
+    };
     return decrypted;
   }
 
@@ -168,12 +178,46 @@ export class ConfigService {
       llm: {
         ...defaults.llm,
         ...config.llm,
+        apiHeaders: {
+          ...defaults.llm.apiHeaders,
+          ...config.llm?.apiHeaders,
+        },
+        profiles: {
+          ...defaults.llm.profiles,
+          ...config.llm?.profiles,
+        },
       },
       automation: {
         ...defaults.automation,
         ...config.automation,
       },
     };
+  }
+
+  private encryptProviderProfiles(
+    profiles: AppConfig['llm']['profiles'] = {},
+  ): AppConfig['llm']['profiles'] {
+    return Object.fromEntries(Object.entries(profiles).map(([name, profile]) => [
+      name,
+      {
+        ...profile,
+        apiKey: profile.apiKey ? CryptoService.encrypt(profile.apiKey) : '',
+      },
+    ]));
+  }
+
+  private decryptProviderProfiles(
+    profiles: AppConfig['llm']['profiles'] = {},
+  ): AppConfig['llm']['profiles'] {
+    return Object.fromEntries(Object.entries(profiles).map(([name, profile]) => [
+      name,
+      {
+        ...profile,
+        apiKey: profile.apiKey && CryptoService.isEncrypted(profile.apiKey)
+          ? CryptoService.decrypt(profile.apiKey)
+          : profile.apiKey,
+      },
+    ]));
   }
 }
 

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -58,11 +58,13 @@ export class ConfigOrchestrator {
     ]);
 
     ui.keyValues('LLM', [
+      { label: 'Active profile', value: config.llm.activeProfile || '(none)', tone: config.llm.activeProfile ? 'success' : 'muted' },
       { label: 'Provider', value: config.llm.provider || '(not set)', tone: config.llm.provider ? 'info' : 'warning' },
       { label: 'Base URL', value: config.llm.apiBaseUrl || '(not set)', tone: config.llm.apiBaseUrl ? 'info' : 'warning' },
       { label: 'Model', value: config.llm.modelName || '(not set)', tone: config.llm.modelName ? 'info' : 'warning' },
       { label: 'Extra headers', value: Object.keys(config.llm.apiHeaders || {}).length > 0 ? JSON.stringify(config.llm.apiHeaders) : '(none)', tone: 'info' },
       { label: 'API key', value: ui.maskSecret(config.llm.apiKey), tone: config.llm.apiKey ? 'info' : 'warning' },
+      { label: 'Saved profiles', value: String(Object.keys(config.llm.profiles || {}).length), tone: Object.keys(config.llm.profiles || {}).length > 0 ? 'info' : 'muted' },
     ]);
 
     ui.keyValues('Automation', [

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -2,6 +2,7 @@ export { dailyOrchestrator, DailyOrchestrator } from './daily.js';
 export { agentOrchestrator, AgentOrchestrator } from './agent.js';
 export { initOrchestrator, InitOrchestrator } from './init.js';
 export { configOrchestrator, ConfigOrchestrator } from './config.js';
+export { providerOrchestrator, ProviderOrchestrator } from './provider.js';
 export { automationOrchestrator, AutomationOrchestrator } from './automation.js';
 export { doctorOrchestrator, DoctorOrchestrator } from './doctor.js';
 export { runsOrchestrator, RunsOrchestrator } from './runs.js';

--- a/src/orchestration/provider.ts
+++ b/src/orchestration/provider.ts
@@ -16,10 +16,6 @@ interface ProviderUseOptions {
   validate?: boolean;
 }
 
-function normalizeProviderName(name: string): string {
-  return name.trim();
-}
-
 function parseHeaders(values: string[] = []): Record<string, string> {
   const headers: Record<string, string> = {};
 
@@ -140,7 +136,7 @@ export class ProviderOrchestrator {
       apiBaseUrl: requireValue(options.baseUrl, 'base URL'),
       modelName: requireValue(options.model, 'model'),
       apiKey: requireValue(options.apiKey, 'API key'),
-      apiHeaders: parseHeaders(options.header),
+      apiHeaders: parseHeaders(options.header?.filter(Boolean) ?? []),
     };
     const updated = await this.saveProfile(config, name, profile, config.llm.activeProfile);
 
@@ -335,8 +331,9 @@ export class ProviderOrchestrator {
       llm: {
         ...config.llm,
         ...profile,
+        apiHeaders: profile.apiHeaders ?? config.llm.apiHeaders ?? {},
         activeProfile: name,
-        profiles: config.llm.profiles || {},
+        profiles: config.llm.profiles ?? {},
       },
     });
 
@@ -396,7 +393,7 @@ export class ProviderOrchestrator {
   }
 
   private normalizeProfileName(nameInput: string): string {
-    const name = normalizeProviderName(nameInput);
+    const name = nameInput.trim();
     if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
       throw new Error('Provider profile name must start with a letter or number and may contain letters, numbers, dots, underscores, or dashes.');
     }
@@ -431,11 +428,11 @@ export class ProviderOrchestrator {
 
   private currentProfileFromConfig(config: AppConfig): LLMProviderProfile {
     return {
-      provider: config.llm.provider,
+      provider: parseProvider(config.llm.provider),
       apiBaseUrl: config.llm.apiBaseUrl,
       apiKey: config.llm.apiKey,
       modelName: config.llm.modelName,
-      apiHeaders: config.llm.apiHeaders || {},
+      apiHeaders: config.llm.apiHeaders ?? {},
     };
   }
 
@@ -450,8 +447,11 @@ export class ProviderOrchestrator {
         ...config.llm,
         activeProfile: activeProfile || '',
         profiles: {
-          ...(config.llm.profiles || {}),
-          [name]: profile,
+          ...(config.llm.profiles ?? {}),
+          [name]: {
+            ...profile,
+            apiHeaders: profile.apiHeaders ?? {},
+          },
         },
       },
     });

--- a/src/orchestration/provider.ts
+++ b/src/orchestration/provider.ts
@@ -1,0 +1,274 @@
+import { configService, ui } from '../infra/index.js';
+import { llmService } from '../services/index.js';
+import type { AppConfig, LLMProvider, LLMProviderProfile } from '../types/index.js';
+
+interface ProviderAddOptions {
+  provider?: string;
+  baseUrl?: string;
+  model?: string;
+  apiKey?: string;
+  header?: string[];
+  validate?: boolean;
+}
+
+interface ProviderUseOptions {
+  validate?: boolean;
+}
+
+function normalizeProviderName(name: string): string {
+  return name.trim();
+}
+
+function parseHeaders(values: string[] = []): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  for (const value of values) {
+    const separator = value.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`Provider header "${value}" must use key=value format.`);
+    }
+
+    const key = value.slice(0, separator).trim();
+    const headerValue = value.slice(separator + 1).trim();
+    if (!key || !headerValue) {
+      throw new Error(`Provider header "${value}" must include both key and value.`);
+    }
+
+    headers[key] = headerValue;
+  }
+
+  return headers;
+}
+
+function parseProvider(value: string | undefined): LLMProvider {
+  const provider = (value || 'custom').trim();
+  if (!['openai', 'minimax', 'moonshot', 'zhipu', 'gemini', 'claude', 'custom'].includes(provider)) {
+    throw new Error('provider must be "openai", "minimax", "moonshot", "zhipu", "gemini", "claude", or "custom".');
+  }
+
+  return provider as LLMProvider;
+}
+
+function requireValue(value: string | undefined, label: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new Error(`${label} is required.`);
+  }
+
+  return trimmed;
+}
+
+export class ProviderOrchestrator {
+  async list(): Promise<void> {
+    const config = await configService.get();
+    const profiles = config.llm.profiles || {};
+    const names = Object.keys(profiles).sort();
+
+    ui.hero({
+      label: 'OpenMeta Provider',
+      title: names.length > 0 ? 'Saved provider profiles are ready to switch' : 'No provider profiles saved yet',
+      subtitle: 'Provider profiles let you keep multiple LLM backends available without repeating config set commands.',
+      lines: [
+        `Active profile: ${config.llm.activeProfile || '(none)'}`,
+      ],
+      tone: names.length > 0 ? 'accent' : 'warning',
+    });
+
+    if (names.length === 0) {
+      ui.emptyState(
+        'OpenMeta Provider',
+        'No profiles found',
+        'Run "openmeta provider save <name>" or "openmeta provider add <name> --base-url <url> --model <model> --api-key <key>".',
+      );
+      return;
+    }
+
+    ui.recordList('Provider profiles', names.map((name) => {
+      const profile = profiles[name]!;
+      return {
+        title: name,
+        subtitle: `${profile.provider} / ${profile.modelName}`,
+        meta: [
+          profile.apiBaseUrl,
+          config.llm.activeProfile === name ? 'active' : 'saved',
+        ],
+        lines: [
+          `API key: ${ui.maskSecret(profile.apiKey)}`,
+          `Extra headers: ${Object.keys(profile.apiHeaders || {}).length > 0 ? JSON.stringify(profile.apiHeaders) : '(none)'}`,
+        ],
+        tone: config.llm.activeProfile === name ? 'success' : 'info',
+      };
+    }));
+  }
+
+  async save(nameInput: string): Promise<void> {
+    const name = this.normalizeProfileName(nameInput);
+    const config = await configService.get();
+    const profile = this.currentProfileFromConfig(config);
+    const updated = await this.saveProfile(config, name, profile, name);
+
+    ui.card({
+      label: 'OpenMeta Provider',
+      title: 'Current provider saved as a reusable profile',
+      subtitle: 'You can switch back to this LLM backend with one command.',
+      lines: [
+        `Profile: ${name}`,
+        `Provider: ${profile.provider}`,
+        `Model: ${profile.modelName}`,
+        `Endpoint: ${profile.apiBaseUrl}`,
+        `Config path: ${configService.getConfigPath()}`,
+      ],
+      tone: updated.llm.activeProfile === name ? 'success' : 'info',
+    });
+  }
+
+  async add(nameInput: string, options: ProviderAddOptions): Promise<void> {
+    const name = this.normalizeProfileName(nameInput);
+    const config = await configService.get();
+    const profile: LLMProviderProfile = {
+      provider: parseProvider(options.provider),
+      apiBaseUrl: requireValue(options.baseUrl, 'base URL'),
+      modelName: requireValue(options.model, 'model'),
+      apiKey: requireValue(options.apiKey, 'API key'),
+      apiHeaders: parseHeaders(options.header),
+    };
+    const updated = await this.saveProfile(config, name, profile, config.llm.activeProfile);
+
+    ui.card({
+      label: 'OpenMeta Provider',
+      title: 'Provider profile saved',
+      subtitle: options.validate ? 'The profile was saved. Run provider use to activate and validate it.' : 'The profile is available for fast switching.',
+      lines: [
+        `Profile: ${name}`,
+        `Provider: ${profile.provider}`,
+        `Model: ${profile.modelName}`,
+        `Endpoint: ${profile.apiBaseUrl}`,
+        `Active profile: ${updated.llm.activeProfile || '(none)'}`,
+      ],
+      tone: 'success',
+    });
+  }
+
+  async use(nameInput: string, options: ProviderUseOptions = {}): Promise<void> {
+    const name = this.normalizeProfileName(nameInput);
+    const config = await configService.get();
+    const profile = config.llm.profiles?.[name];
+    if (!profile) {
+      throw new Error(`Provider profile "${name}" does not exist. Run "openmeta provider list" to see saved profiles.`);
+    }
+
+    const updated = await configService.update({
+      llm: {
+        ...config.llm,
+        ...profile,
+        activeProfile: name,
+        profiles: config.llm.profiles || {},
+      },
+    });
+
+    let validationDetail = 'Validation skipped.';
+    let tone: 'success' | 'warning' = 'success';
+    if (options.validate) {
+      const valid = await this.validateProfile(profile);
+      validationDetail = valid
+        ? 'Provider validation succeeded.'
+        : `Provider validation failed: ${llmService.getLastValidationError() || 'unknown reason'}`;
+      tone = valid ? 'success' : 'warning';
+    }
+
+    ui.card({
+      label: 'OpenMeta Provider',
+      title: 'Active provider switched',
+      subtitle: 'OpenMeta will use this LLM backend for the next agent or scout run.',
+      lines: [
+        `Profile: ${name}`,
+        `Provider: ${updated.llm.provider}`,
+        `Model: ${updated.llm.modelName}`,
+        `Endpoint: ${updated.llm.apiBaseUrl}`,
+        validationDetail,
+      ],
+      tone,
+    });
+  }
+
+  async remove(nameInput: string): Promise<void> {
+    const name = this.normalizeProfileName(nameInput);
+    const config = await configService.get();
+    const profiles = { ...(config.llm.profiles || {}) };
+    if (!profiles[name]) {
+      throw new Error(`Provider profile "${name}" does not exist.`);
+    }
+
+    delete profiles[name];
+    const activeProfile = config.llm.activeProfile === name ? '' : config.llm.activeProfile;
+    await configService.update({
+      llm: {
+        ...config.llm,
+        activeProfile,
+        profiles,
+      },
+    });
+
+    ui.card({
+      label: 'OpenMeta Provider',
+      title: 'Provider profile removed',
+      subtitle: activeProfile ? 'The active provider remained unchanged.' : 'The removed profile was active, so no profile is now marked active.',
+      lines: [
+        `Profile: ${name}`,
+        `Active profile: ${activeProfile || '(none)'}`,
+      ],
+      tone: 'success',
+    });
+  }
+
+  private normalizeProfileName(nameInput: string): string {
+    const name = normalizeProviderName(nameInput);
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
+      throw new Error('Provider profile name must start with a letter or number and may contain letters, numbers, dots, underscores, or dashes.');
+    }
+
+    return name;
+  }
+
+  private currentProfileFromConfig(config: AppConfig): LLMProviderProfile {
+    return {
+      provider: config.llm.provider,
+      apiBaseUrl: config.llm.apiBaseUrl,
+      apiKey: config.llm.apiKey,
+      modelName: config.llm.modelName,
+      apiHeaders: config.llm.apiHeaders || {},
+    };
+  }
+
+  private async saveProfile(
+    config: AppConfig,
+    name: string,
+    profile: LLMProviderProfile,
+    activeProfile: string | undefined,
+  ): Promise<AppConfig> {
+    return configService.update({
+      llm: {
+        ...config.llm,
+        activeProfile: activeProfile || '',
+        profiles: {
+          ...(config.llm.profiles || {}),
+          [name]: profile,
+        },
+      },
+    });
+  }
+
+  private async validateProfile(profile: LLMProviderProfile): Promise<boolean> {
+    llmService.initialize(
+      profile.apiKey,
+      profile.apiBaseUrl,
+      profile.modelName,
+      profile.apiHeaders,
+      profile.provider,
+    );
+
+    return llmService.validateConnection();
+  }
+}
+
+export const providerOrchestrator = new ProviderOrchestrator();

--- a/src/orchestration/provider.ts
+++ b/src/orchestration/provider.ts
@@ -1,4 +1,5 @@
-import { configService, ui } from '../infra/index.js';
+import { configService, prompt, selectPrompt, ui } from '../infra/index.js';
+import { LLM_PROVIDER_PRESETS, findLLMProviderPreset } from '../services/index.js';
 import { llmService } from '../services/index.js';
 import type { AppConfig, LLMProvider, LLMProviderProfile } from '../types/index.js';
 
@@ -38,6 +39,15 @@ function parseHeaders(values: string[] = []): Record<string, string> {
   }
 
   return headers;
+}
+
+function parseHeaderInput(value: string): Record<string, string> {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  return parseHeaders(trimmed.split(',').map((item) => item.trim()).filter(Boolean));
 }
 
 function parseProvider(value: string | undefined): LLMProvider {
@@ -149,6 +159,170 @@ export class ProviderOrchestrator {
     });
   }
 
+  async configure(): Promise<void> {
+    const config = await configService.get();
+
+    ui.hero({
+      label: 'OpenMeta Provider',
+      title: 'Configure a provider profile without memorizing flags',
+      subtitle: 'Save one LLM backend as a named profile, then switch to it whenever OpenMeta needs a different model route.',
+      lines: [
+        `Current provider: ${config.llm.provider} / ${config.llm.modelName || '(no model)'}`,
+        `Active profile: ${config.llm.activeProfile || '(none)'}`,
+      ],
+      tone: 'accent',
+    });
+
+    const { profileName } = await prompt<{ profileName: string }>([
+      {
+        type: 'input',
+        name: 'profileName',
+        message: 'Provider profile name:',
+        default: this.suggestProfileName(config),
+        filter: (input: string) => input.trim(),
+        validate: (input: string) => {
+          try {
+            this.normalizeProfileName(input);
+            return true;
+          } catch (error) {
+            return error instanceof Error ? error.message : 'Invalid provider profile name.';
+          }
+        },
+      },
+    ]);
+    const name = this.normalizeProfileName(profileName);
+
+    const provider = await selectPrompt<LLMProvider>({
+      message: 'Select LLM provider:',
+      default: this.getProviderDefault(config.llm.provider),
+      choices: LLM_PROVIDER_PRESETS.map((preset) => ({
+        name: preset.name,
+        value: preset.value,
+        description: preset.baseUrl || 'Bring your own OpenAI-compatible endpoint',
+      })),
+    });
+    const preset = findLLMProviderPreset(provider);
+    if (!preset) {
+      throw new Error(`Provider not found: ${provider}`);
+    }
+
+    let apiBaseUrl = preset.baseUrl;
+    if (preset.allowCustomBaseUrl) {
+      ({ apiBaseUrl } = await prompt<{ apiBaseUrl: string }>([
+        {
+          type: 'input',
+          name: 'apiBaseUrl',
+          message: 'OpenAI-compatible API base URL:',
+          default: config.llm.apiBaseUrl || 'https://api.openai.com/v1',
+          filter: (input: string) => input.trim(),
+          validate: (input: string) => input.length > 0 || 'API base URL is required.',
+        },
+      ]));
+    }
+
+    let modelName = config.llm.modelName;
+    if (preset.allowCustomModel) {
+      ({ modelName } = await prompt<{ modelName: string }>([
+        {
+          type: 'input',
+          name: 'modelName',
+          message: 'Model name:',
+          default: config.llm.modelName || 'gpt-4o-mini',
+          filter: (input: string) => input.trim(),
+          validate: (input: string) => input.length > 0 || 'Model name is required.',
+        },
+      ]));
+    } else {
+      modelName = await selectPrompt<string>({
+        message: 'Select model:',
+        default: preset.models.some((model) => model.value === config.llm.modelName)
+          ? config.llm.modelName
+          : preset.models[0]?.value,
+        choices: preset.models.map((model) => ({ name: model.name, value: model.value })),
+      });
+    }
+
+    const { apiKey } = await prompt<{ apiKey: string }>([
+      {
+        type: 'password',
+        name: 'apiKey',
+        message: 'LLM API key:',
+        mask: '*',
+        validate: (input: string) => input.trim().length > 0 || 'API key is required.',
+      },
+    ]);
+
+    const { extraHeaders } = await prompt<{ extraHeaders: string }>([
+      {
+        type: 'input',
+        name: 'extraHeaders',
+        message: 'Extra headers (optional, comma-separated key=value):',
+        default: this.formatHeaderInput(preset.apiHeaders || config.llm.apiHeaders || {}),
+        filter: (input: string) => input.trim(),
+        validate: (input: string) => {
+          try {
+            parseHeaderInput(input);
+            return true;
+          } catch (error) {
+            return error instanceof Error ? error.message : 'Invalid header format.';
+          }
+        },
+      },
+    ]);
+
+    const { activate } = await prompt<{ activate: boolean }>([
+      {
+        type: 'confirm',
+        name: 'activate',
+        message: 'Use this provider profile now?',
+        default: true,
+      },
+    ]);
+
+    let validate = false;
+    if (activate) {
+      ({ validate } = await prompt<{ validate: boolean }>([
+        {
+          type: 'confirm',
+          name: 'validate',
+          message: 'Validate this provider after switching?',
+          default: true,
+        },
+      ]));
+    }
+
+    const profile: LLMProviderProfile = {
+      provider,
+      apiBaseUrl,
+      modelName,
+      apiKey: apiKey.trim(),
+      apiHeaders: {
+        ...(preset.apiHeaders || {}),
+        ...parseHeaderInput(extraHeaders),
+      },
+    };
+
+    await this.saveProfile(config, name, profile, config.llm.activeProfile);
+
+    if (activate) {
+      await this.use(name, { validate });
+      return;
+    }
+
+    ui.card({
+      label: 'OpenMeta Provider',
+      title: 'Provider profile saved',
+      subtitle: 'Switch to it later with "openmeta provider use <name>".',
+      lines: [
+        `Profile: ${name}`,
+        `Provider: ${profile.provider}`,
+        `Model: ${profile.modelName}`,
+        `Endpoint: ${profile.apiBaseUrl}`,
+      ],
+      tone: 'success',
+    });
+  }
+
   async use(nameInput: string, options: ProviderUseOptions = {}): Promise<void> {
     const name = this.normalizeProfileName(nameInput);
     const config = await configService.get();
@@ -228,6 +402,31 @@ export class ProviderOrchestrator {
     }
 
     return name;
+  }
+
+  private getProviderDefault(provider: LLMProvider): LLMProvider {
+    return LLM_PROVIDER_PRESETS.some((option) => option.value === provider)
+      ? provider
+      : 'custom';
+  }
+
+  private suggestProfileName(config: AppConfig): string {
+    if (config.llm.activeProfile) {
+      return config.llm.activeProfile;
+    }
+
+    const model = config.llm.modelName || 'default';
+    return `${config.llm.provider}-${model}`
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/^[^a-z0-9]+/, '')
+      .slice(0, 64) || 'default';
+  }
+
+  private formatHeaderInput(headers: Record<string, string>): string {
+    return Object.entries(headers)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(', ');
   }
 
   private currentProfileFromConfig(config: AppConfig): LLMProviderProfile {

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -22,7 +22,7 @@ export interface LLMProviderProfile {
   apiBaseUrl: string;
   apiKey: string;
   modelName: string;
-  apiHeaders?: Record<string, string>;
+  apiHeaders: Record<string, string>;
 }
 
 export interface LLMConfig {

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -17,12 +17,22 @@ export interface GitHubConfig {
 
 export type LLMProvider = 'openai' | 'minimax' | 'moonshot' | 'zhipu' | 'gemini' | 'claude' | 'custom';
 
+export interface LLMProviderProfile {
+  provider: LLMProvider;
+  apiBaseUrl: string;
+  apiKey: string;
+  modelName: string;
+  apiHeaders?: Record<string, string>;
+}
+
 export interface LLMConfig {
   provider: LLMProvider;
   apiBaseUrl: string;
   apiKey: string;
   modelName: string;
   apiHeaders?: Record<string, string>;
+  activeProfile?: string;
+  profiles?: Record<string, LLMProviderProfile>;
 }
 
 export interface AutomationConfig {

--- a/test/provider-orchestrator.test.ts
+++ b/test/provider-orchestrator.test.ts
@@ -82,6 +82,69 @@ describe('ProviderOrchestrator', () => {
     expect(loaded.llm.activeProfile).toBe('henng-gpt54');
   });
 
+  test('preserves config apiHeaders when a saved profile omits them', async () => {
+    const config = await configService.get();
+    await configService.save({
+      ...config,
+      llm: {
+        ...config.llm,
+        provider: 'custom',
+        apiBaseUrl: 'https://example.com/v1',
+        modelName: 'example-model',
+        apiKey: 'sk-secret',
+        apiHeaders: { 'X-Keep': 'yes' },
+        profiles: {
+          legacy: {
+            provider: 'custom',
+            apiBaseUrl: 'https://legacy.example.com/v1',
+            modelName: 'legacy-model',
+            apiKey: 'sk-legacy',
+          } as never,
+        },
+      },
+    });
+
+    const orchestrator = new ProviderOrchestrator();
+    await orchestrator.use('legacy');
+
+    const loaded = await configService.get();
+    expect(loaded.llm.apiHeaders).toEqual({ 'X-Keep': 'yes' });
+  });
+
+  test('rejects invalid providers when saving the current config as a profile', async () => {
+    const orchestrator = new ProviderOrchestrator();
+    const config = await configService.get();
+    await configService.save({
+      ...config,
+      llm: {
+        ...config.llm,
+        provider: 'invalid-provider' as never,
+      },
+    });
+
+    await expect(orchestrator.save('broken')).rejects.toThrow('provider must be');
+  });
+
+  test('rejects invalid header values when adding a provider profile', async () => {
+    const orchestrator = new ProviderOrchestrator();
+
+    await expect(orchestrator.add('broken-header', {
+      provider: 'custom',
+      baseUrl: 'https://example.com/v1',
+      model: 'example-model',
+      apiKey: 'sk-secret',
+      header: [''],
+    })).resolves.toBeUndefined();
+
+    await expect(orchestrator.add('invalid-header', {
+      provider: 'custom',
+      baseUrl: 'https://example.com/v1',
+      model: 'example-model',
+      apiKey: 'sk-secret',
+      header: ['not-a-header'],
+    })).rejects.toThrow('must use key=value format');
+  });
+
   test('removes provider profiles without changing the active provider settings', async () => {
     const orchestrator = new ProviderOrchestrator();
 

--- a/test/provider-orchestrator.test.ts
+++ b/test/provider-orchestrator.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ConfigService, configService } from '../src/infra/config.js';
+import { ProviderOrchestrator } from '../src/orchestration/provider.js';
+import type { AppConfig } from '../src/types/index.js';
+
+let tempRoot = '';
+
+function clearSharedConfigCache(): void {
+  (configService as unknown as { config: AppConfig | null }).config = null;
+}
+
+describe('ProviderOrchestrator', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'openmeta-provider-orchestrator-'));
+    process.env['OPENMETA_CONFIG_DIR'] = join(tempRoot, '.config', 'openmeta');
+    process.env['OPENMETA_HOME'] = join(tempRoot, '.openmeta');
+    clearSharedConfigCache();
+  });
+
+  afterEach(() => {
+    clearSharedConfigCache();
+    delete process.env['OPENMETA_CONFIG_DIR'];
+    delete process.env['OPENMETA_HOME'];
+
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = '';
+    }
+  });
+
+  test('saves the current LLM settings as an encrypted provider profile', async () => {
+    const orchestrator = new ProviderOrchestrator();
+    const config = await configService.get();
+    await configService.save({
+      ...config,
+      llm: {
+        ...config.llm,
+        provider: 'custom',
+        apiBaseUrl: 'https://example.com/v1',
+        modelName: 'example-model',
+        apiKey: 'sk-profile-secret',
+      },
+    });
+
+    await orchestrator.save('example');
+
+    const raw = readFileSync(configService.getConfigPath(), 'utf-8');
+    const loaded = await new ConfigService().load();
+
+    expect(raw).not.toContain('sk-profile-secret');
+    expect(loaded.llm.profiles?.['example']).toEqual({
+      provider: 'custom',
+      apiBaseUrl: 'https://example.com/v1',
+      modelName: 'example-model',
+      apiKey: 'sk-profile-secret',
+      apiHeaders: {},
+    });
+    expect(loaded.llm.activeProfile).toBe('example');
+  });
+
+  test('adds and switches to a named provider profile', async () => {
+    const orchestrator = new ProviderOrchestrator();
+
+    await orchestrator.add('henng-gpt54', {
+      provider: 'custom',
+      baseUrl: 'https://api2.henng.cn/v1',
+      model: 'gpt-5.4',
+      apiKey: 'sk-henng-secret',
+      header: ['X-Test=yes'],
+    });
+    await orchestrator.use('henng-gpt54');
+
+    const loaded = await configService.get();
+    expect(loaded.llm.provider).toBe('custom');
+    expect(loaded.llm.apiBaseUrl).toBe('https://api2.henng.cn/v1');
+    expect(loaded.llm.modelName).toBe('gpt-5.4');
+    expect(loaded.llm.apiKey).toBe('sk-henng-secret');
+    expect(loaded.llm.apiHeaders).toEqual({ 'X-Test': 'yes' });
+    expect(loaded.llm.activeProfile).toBe('henng-gpt54');
+  });
+
+  test('removes provider profiles without changing the active provider settings', async () => {
+    const orchestrator = new ProviderOrchestrator();
+
+    await orchestrator.add('temporary', {
+      provider: 'custom',
+      baseUrl: 'https://example.com/v1',
+      model: 'temporary-model',
+      apiKey: 'sk-temporary-secret',
+    });
+    await orchestrator.use('temporary');
+    await orchestrator.remove('temporary');
+
+    const loaded = await configService.get();
+    expect(loaded.llm.profiles?.['temporary']).toBeUndefined();
+    expect(loaded.llm.activeProfile).toBe('');
+    expect(loaded.llm.modelName).toBe('temporary-model');
+  });
+});


### PR DESCRIPTION
### 关联 issue: Closes #20
---
## 概要

这个 PR 增加了可复用的 LLM provider profile，用户可以保存多套模型/供应商配置，并通过一条命令快速切换，不需要重新跑 `openmeta init`，也不需要手动连续执行多条 `openmeta config set`。

## 主要改动

- 新增 `openmeta provider` 命令组。
- 支持把当前 LLM 配置保存为一个命名 profile。
- 支持通过 CLI flags 非交互式添加 provider profile，方便脚本化配置。
- 支持通过 `openmeta provider config` 交互式配置 provider profile。
- 支持切换当前启用的 provider，并可选执行 validation。
- profile 中保存的 API key 会沿用现有配置加密逻辑。
- `openmeta config view` 中展示当前 active profile 和已保存 profile 数量。
- README 命令一览中补充 provider 相关命令。

## 新增命令

```bash
openmeta provider config
openmeta provider list
openmeta provider save <name>
openmeta provider add <name>
openmeta provider use <name> --validate
openmeta provider remove <name>
```

## 背景

目前如果想从一个 provider 切换到另一个 provider，需要手动修改多项配置，例如：

```bash
openmeta config set llm.provider custom
openmeta config set llm.apiBaseUrl https://example.com/v1
openmeta config set llm.modelName some-model
openmeta config set llm.apiKey sk-...
```

这个流程比较繁琐，也容易漏改某一项。对于经常在多个 OpenAI-compatible endpoint、官方 provider 或 fallback model 之间切换的用户来说，provider profile 会更直观一些。

## 使用示例

```bash
openmeta provider config
openmeta provider use my-provider --validate
openmeta provider list
```

## 验证

```bash
bun x tsc --noEmit
bun test
bun run build
bun run ./src/cli.ts provider --help
bun run ./src/cli.ts provider config --help
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NianJiuZst/codesmith/openmeta-cli/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->