### PR TITLE
chore: upgrade typecheck to tsgo native preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,9 +21,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/crypto-js": "^4.2.2",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
+        "@typescript/native-preview": "^7.0.0-dev",
       },
     },
   },
@@ -75,6 +73,22 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/tinycolor2": ["@types/tinycolor2@1.4.6", "", {}, "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260509.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260509.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260509.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260509.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260509.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260509.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260509.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260509.2" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-JAJpEX0yBaEle2zzbX5z9QAhmEfML1SyQafLwbKCdcOtnkGdk5xD8NKIVxq+nTwYjRwuV7kKnQ+fqU3gpWY0qQ=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260509.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oG9KahiCpx4q70Ood/rRJhYio4oIMHEHfX0g0LhfenlSIjIonitZWjUmUVG9N9q1ev9QWcM8pWpDrGGP0Osp3Q=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260509.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-xdEkp23Gu8I7PJCMmSMYtSLX76NKODWj74AoWFPi6MM59ICsjnTSqZf/HmXKSvuNZ5MGb4CMpP3c40dLjGB2PQ=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260509.2", "", { "os": "linux", "cpu": "arm" }, "sha512-ar5HN/V/4HLF4FZCoVVFj+ET1Soi758hb4WhhzYQfSUXQ/bpVGUGP86JAy8EhVMoeN6qxqWet93MkLSszJOIVg=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260509.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-rd+bMRtUAFBClOAKi9p2rOu6jPmnrjZVljoFyxHw+6bIRLerEQlxP+nIH1olC3HOZPyZ6/x75WtfzTHYeqffiQ=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260509.2", "", { "os": "linux", "cpu": "x64" }, "sha512-lB26mGzdolYIZiOdBII8roVJCxCUR8zkYszvvHyjB1IPs7d5fmOhT6OzI1zYPYujiSRJi4HVYM1iXTcIfp7KDg=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260509.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-gH3UmtyxHiRNEP0LgQXCVlB5+ZN/U+/Z7jM/zULQtTOxIIFK3Y4b8gbGLvP7uW3u2cqYOg2hc2nuN8OdsCmOig=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260509.2", "", { "os": "win32", "cpu": "x64" }, "sha512-kZV0Vh64hp10saOghPlFZE1qahonqvRgU3iubt8pUY4XLe8IQIofwWCN5vzNNeULE4W4mRtAJbHuvP/muOFomw=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 

--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "build": "bun build --target=bun --outfile=bin/openmeta.js ./src/cli.ts",
     "dev": "bun run ./src/cli.ts",
     "start": "bun run ./src/cli.ts",
-    "typecheck": "bunx tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/crypto-js": "^4.2.2"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
+    "@types/crypto-js": "^4.2.2",
+    "@typescript/native-preview": "^7.0.0-dev"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",

--- a/src/orchestration/doctor.ts
+++ b/src/orchestration/doctor.ts
@@ -79,7 +79,7 @@ export class DoctorOrchestrator {
       this.checkDirectory('openmeta-home', 'OpenMeta home', homePath, 'Run "openmeta agent" or create the directory manually with write permissions.'),
       this.checkDirectory('workspace-root', 'Workspace root', getOpenMetaWorkspaceRoot(), 'Run "openmeta agent" after configuration is complete.'),
       this.checkDirectory('artifact-root', 'Artifact root', getOpenMetaArtifactRoot(), 'Run "openmeta agent" after configuration is complete.'),
-      this.checkCommand('runtime-bun', 'Bun runtime', 'bun', ['--version'], 'Install Bun 1.0+ and ensure it is available on PATH.'),
+      this.checkBunRuntime(),
       this.checkCommand('runtime-git', 'Git runtime', 'git', ['--version'], 'Install Git and ensure it is available on PATH.'),
       this.checkGitHubConfig(resolvedConfig),
       this.checkLlmConfig(resolvedConfig),
@@ -212,6 +212,21 @@ export class DoctorOrchestrator {
       summary: `${command} is available.`,
       detail: (result.stdout || result.stderr || '').trim().split(/\r?\n/)[0],
     };
+  }
+
+  private checkBunRuntime(): DoctorCheck {
+    const bunVersion = process.versions.bun;
+    if (bunVersion) {
+      return {
+        id: 'runtime-bun',
+        label: 'Bun runtime',
+        status: 'pass',
+        summary: 'bun is available.',
+        detail: bunVersion,
+      };
+    }
+
+    return this.checkCommand('runtime-bun', 'Bun runtime', 'bun', ['--version'], 'Install Bun 1.0+ and ensure it is available on PATH.');
   }
 
   private checkGitHubConfig(config: AppConfig): DoctorCheck {


### PR DESCRIPTION
## Summary
- Switch type checking from tsc to tsgo via @typescript/native-preview.
- Update Bun lockfile for the TypeScript native preview package.
- Make doctor detect the current Bun runtime before falling back to PATH lookup.

## Validation
- bun run typecheck
- bun test
- bun run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NianJiuZst/codesmith/openmeta-cli/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->