### PR TITLE
fix(github): handle normalized octokit pagination response to prevent runtime crash

### DIFF
--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -356,7 +356,12 @@ export class GitHubService {
             per_page: SEARCH_RESULTS_PER_PAGE,
           },
         )) {
-          const pageItems = (response as unknown as { data: { items: SearchIssueItem[] } }).data.items;
+          // @octokit/plugin-paginate-rest normalizes the paginated responses.
+          // For search endpoints, it places the items array directly in response.data.
+          const pageItems: SearchIssueItem[] = Array.isArray((response as any).data)
+            ? (response as any).data
+            : [];
+          
           items.push(...pageItems);
         }
         return items;

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -227,10 +227,7 @@ describe('GitHubService internals', () => {
         iterator: async function* () {
           searchCalls += 1;
           yield {
-            data: {
-              total_count: 0,
-              items: [],
-            },
+            data: [],
           };
         },
       },


### PR DESCRIPTION
### Problem
When `GitHubService.fetchTrendingIssues()` attempts to paginate through search results, the CLI crashes under real runtime conditions with:
```text
TypeError: Spread syntax requires ...iterable not be null or undefined
```

### Root Cause
1. **Octokit Normalization**: `@octokit/plugin-paginate-rest` automatically normalizes paginated responses. For the Search API, it extracts the `items` array and assigns it directly to `response.data`.
2. **Structural Mismatch**: The code expected `response.data.items` to be the array. Since `response.data` is already the array, `.items` evaluates to `undefined`, causing the spread operator `...pageItems` to crash the application.

### Why this slipped past existing checks:
This issue was understandably masked during local development and CI:
- **TypeScript Error Bypassed**: In commit `e2dbd9a`, an `as unknown as { data: { items: ... } }` cast was introduced. This legitimately silenced TypeScript (which correctly inferred `response.data` was an array and didn't have an `.items` property).
- **Misaligned Test Mocks**: In commit `65411d5`, the mock for `paginate.iterator` was updated to yield `{ data: { total_count: 0, items: [] } }`. This false mock aligned perfectly with the flawed type cast, causing tests to pass green while the actual runtime structure was entirely different.

### Changes Included
- **`src/services/github.ts`**: Removed the `as unknown` cast and updated the iterator loop to extract the array directly from `response.data` (with safe fallback checks).
- **`test/github.test.ts`**: Corrected the `paginate.iterator` mock to yield `{ data: [] }` so it accurately represents the real Octokit output, ensuring tests provide genuine safety moving forward.

### Testing
- `bun test` passes successfully with the updated, accurate mock structure.
- Local execution of the trend-fetching logic successfully retrieves issues without crashing.