### PR TITLE
fix(github): implement resumable pagination and graceful degradation for search

### DIFF
--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -347,6 +347,7 @@ export class GitHubService {
     const items: SearchIssueItem[] = [];
     let attempt = 0;
     let pagesFetched = 0;
+    let currentPage = 1;
 
     while (attempt < MAX_PAGINATION_RETRIES) {
       try {
@@ -357,6 +358,7 @@ export class GitHubService {
             sort: 'updated',
             order: 'desc',
             per_page: SEARCH_RESULTS_PER_PAGE,
+            page: currentPage,
           },
         )) {
           const pageItems: SearchIssueItem[] = Array.isArray((response as any).data)
@@ -365,6 +367,7 @@ export class GitHubService {
 
           items.push(...pageItems);
           pagesFetched++;
+          currentPage++;
 
           if (pagesFetched >= MAX_SEARCH_PAGES) {
             logger.debug(`Reached page limit (${MAX_SEARCH_PAGES}). Stopping pagination.`);
@@ -378,26 +381,30 @@ export class GitHubService {
         const isRateLimit = err.status === 403 || err.status === 429;
 
         if (isRateLimit) {
-          if (items.length > 0) {
-            logger.warn(`Rate limited during pagination after fetching ${items.length} items. Returning partial results.`);
-            return items;
-          }
-
           if (attempt < MAX_PAGINATION_RETRIES) {
             const resetHeader = err.headers?.['x-ratelimit-reset'];
-            let delayMs = RATE_LIMIT_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+            const retryAfterHeader = err.headers?.['retry-after'];
 
-            if (resetHeader) {
+            // Default conservative fallback if no headers are provided (60s + slight exponential backoff)
+            let delayMs = 60_000 + RATE_LIMIT_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+
+            if (retryAfterHeader) {
+              delayMs = parseInt(retryAfterHeader, 10) * 1000 + 500;
+            } else if (resetHeader) {
               const resetTime = parseInt(resetHeader, 10) * 1000;
               const waitMs = resetTime - Date.now();
               if (waitMs > 0) {
-                delayMs = Math.min(waitMs + 500, 60_000);
+                delayMs = waitMs + 500; // Trust GitHub's reset time without arbitrary 60s math.min cap
               }
             }
 
             logger.warn(`Rate limited during pagination (attempt ${attempt}/${MAX_PAGINATION_RETRIES}). Retrying in ${Math.round(delayMs / 1000)}s...`);
             await this.delay(delayMs);
             continue;
+          } else if (items.length > 0) {
+            // MAX_PAGINATION_RETRIES exhausted, but we have some data. Graceful return.
+            logger.warn(`Pagination retries exhausted. Yielding ${items.length} items collected so far.`);
+            return items;
           }
         }
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -23,6 +23,7 @@ const ACTION_BLOCKING_LABELS = [
 const SEARCH_RESULTS_PER_PAGE = 30;
 const SEARCH_CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_PAGINATION_RETRIES = 3;
+const MAX_SEARCH_PAGES = 8;
 const RATE_LIMIT_RETRY_BASE_DELAY_MS = 1000;
 
 type SearchIssueItem =
@@ -343,10 +344,12 @@ export class GitHubService {
       throw new Error('GitHub service not initialized');
     }
 
+    const items: SearchIssueItem[] = [];
     let attempt = 0;
+    let pagesFetched = 0;
+
     while (attempt < MAX_PAGINATION_RETRIES) {
       try {
-        const items: SearchIssueItem[] = [];
         for await (const response of this.octokit.paginate.iterator(
           this.octokit.rest.search.issuesAndPullRequests,
           {
@@ -356,13 +359,17 @@ export class GitHubService {
             per_page: SEARCH_RESULTS_PER_PAGE,
           },
         )) {
-          // @octokit/plugin-paginate-rest normalizes the paginated responses.
-          // For search endpoints, it places the items array directly in response.data.
           const pageItems: SearchIssueItem[] = Array.isArray((response as any).data)
             ? (response as any).data
             : [];
-          
+
           items.push(...pageItems);
+          pagesFetched++;
+
+          if (pagesFetched >= MAX_SEARCH_PAGES) {
+            logger.debug(`Reached page limit (${MAX_SEARCH_PAGES}). Stopping pagination.`);
+            return items;
+          }
         }
         return items;
       } catch (error) {
@@ -370,21 +377,28 @@ export class GitHubService {
         const err = error as { status?: number; headers?: Record<string, string> };
         const isRateLimit = err.status === 403 || err.status === 429;
 
-        if (isRateLimit && attempt < MAX_PAGINATION_RETRIES) {
-          const resetHeader = err.headers?.['x-ratelimit-reset'];
-          let delayMs = RATE_LIMIT_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
-
-          if (resetHeader) {
-            const resetTime = parseInt(resetHeader, 10) * 1000;
-            const waitMs = resetTime - Date.now();
-            if (waitMs > 0 && waitMs < 60_000) {
-              delayMs = Math.min(waitMs + 500, 60_000);
-            }
+        if (isRateLimit) {
+          if (items.length > 0) {
+            logger.warn(`Rate limited during pagination after fetching ${items.length} items. Returning partial results.`);
+            return items;
           }
 
-          logger.warn(`Rate limited during pagination (attempt ${attempt}/${MAX_PAGINATION_RETRIES}). Retrying in ${Math.round(delayMs / 1000)}s...`);
-          await this.delay(delayMs);
-          continue;
+          if (attempt < MAX_PAGINATION_RETRIES) {
+            const resetHeader = err.headers?.['x-ratelimit-reset'];
+            let delayMs = RATE_LIMIT_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+
+            if (resetHeader) {
+              const resetTime = parseInt(resetHeader, 10) * 1000;
+              const waitMs = resetTime - Date.now();
+              if (waitMs > 0) {
+                delayMs = Math.min(waitMs + 500, 60_000);
+              }
+            }
+
+            logger.warn(`Rate limited during pagination (attempt ${attempt}/${MAX_PAGINATION_RETRIES}). Retrying in ${Math.round(delayMs / 1000)}s...`);
+            await this.delay(delayMs);
+            continue;
+          }
         }
 
         throw error;


### PR DESCRIPTION
fix https://github.com/NianJiuZst/openmeta-cli/issues/33

## Problem
Currently, executing `openmeta scout` triggers a GitHub Search API 403 secondary rate limit quickly. The previous retry implementation would discard already fetched items and restart from page 1, resulting in a fatal loop. Additionally, the fallback retry delay of `1s` was insufficient for GitHub's secondary limits, causing the script to exhaust its `MAX_PAGINATION_RETRIES` almost instantly.

## Changes Made
1. **Resumable Pagination (`currentPage`)**: The loop now tracks `currentPage` and passes it to the Octokit iterator so subsequent retries append to the already collected dataset instead of starting over.
2. **Smarter Rate-Limit Delays**: The backoff logic now explicitly intercepts the `retry-after` header (often returned in secondary limits). If no headers are provided, it assumes a conservative 60-second base delay.
3. **Graceful Degradation**: If `MAX_PAGINATION_RETRIES` (3 times) is fully exhausted but we have successfully scraped a partial list of issues, the script will gracefully return the scraped items rather than throwing an error and dumping the data.

## Before / After
openmeta only fetch 56 results beforechange

<img width="799" height="276" alt="屏幕截图 2026-05-18 235443" src="https://github.com/user-attachments/assets/0d8130c3-0ecb-4cb3-9620-3ce0ca8d9ff2" />

and i increase to 289 after the change
<img width="806" height="67" alt="屏幕截图 2026-05-18 235600" src="https://github.com/user-attachments/assets/6c14f164-b6e6-4ea4-92fe-4eb688b45328" />


### Backoff Strategy Changes (Detailed)
- **`retry-after` header parsing**: GitHub's secondary rate limit returns `retry-after` (in seconds), which was previously ignored. Now it's checked as the highest-priority source for wait time.
- **Default fallback raised from 1s → 60s**: When no rate-limit headers are present, the delay was previously `1s → 2s → 4s` (exponential from 1s base). This is useless against secondary limits. Now it defaults to `61s → 62s → 64s`.
- **Removed `x-ratelimit-reset` 60s cap**: The old code had `Math.min(waitMs + 500, 60_000)`, which truncated GitHub's recommended wait time to 60s max. Now we trust the server's reset time without an artificial cap.

## For Discussion / Review
- **Incomplete Pagination**: With the current retry limits, it's highly likely we won't hit the `MAX_SEARCH_PAGES` limit before exhausting our attempts. Should we consider:
  1. Making the maximum page limit (`MAX_SEARCH_PAGES`) a user-configurable option?
  2. Further optimizing the backoff strategy to handle severe throttling?
- **Asynchronous Execution**: Given that the fetch and waiting process can now take a significantly long time, is it necessary/worthwhile to make this operation run asynchronously?