### PR TITLE
feat(agent): support targeted repos and configurable LLM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,15 @@ openmeta doctor
 | `openmeta agent` | 运行自治贡献主流程 |
 | `openmeta agent --draft-only` | 只生成 dossier、patch draft 和 PR draft，不改仓库、不创建 PR |
 | `openmeta agent --refresh` | 忽略本地 issue 搜索缓存，重新从 GitHub 发现机会 |
+| `openmeta agent --repo <repository>` | 限定到一个 GitHub 仓库 URL 或 `owner/name` 进行发现、分析和 PR 创建 |
+| `openmeta agent --repo <repository> --issue <number>` | 直接解决指定仓库里的某个 issue，并沿用 agent 的 patch / PR 流程 |
+| `openmeta agent --issue <issue-url>` | 直接从 GitHub issue URL 推导仓库并解决该 issue |
 | `openmeta agent --headless` | 使用已保存设置进行无人值守执行 |
 | `openmeta agent --run-checks` | 执行检测到的基础校验命令 |
 | `openmeta daily` | `agent` 的兼容别名，支持相同运行参数 |
 | `openmeta scout --limit <count>` | 查看高价值贡献机会排名 |
 | `openmeta scout --refresh` | 强制刷新 GitHub issue discovery 缓存 |
+| `openmeta scout --repo <repository>` | 从一个 GitHub 仓库 URL 或 `owner/name` 中筛选贡献机会 |
 | `openmeta scout --local` | 使用本地启发式评分，不调用 LLM，适合模型服务暂时不可用时先筛机会 |
 | `openmeta inbox` | 查看已起草的贡献机会收件箱 |
 | `openmeta pow` | 查看贡献工作量证明记录 |
@@ -513,11 +517,15 @@ openmeta doctor
 | `openmeta agent` | Run the autonomous contribution workflow |
 | `openmeta agent --draft-only` | Generate dossier, patch draft, and PR draft artifacts without editing files or opening a PR |
 | `openmeta agent --refresh` | Ignore the local issue search cache and discover fresh GitHub opportunities |
+| `openmeta agent --repo <repository>` | Limit issue discovery, ranking, workspace prep, and draft PR creation to one upstream GitHub repository URL or `owner/name` |
+| `openmeta agent --repo <repository> --issue <number>` | Solve one issue from the specified repository and continue through the normal patch / PR flow |
+| `openmeta agent --issue <issue-url>` | Infer the repository from a GitHub issue URL and solve that issue directly |
 | `openmeta agent --headless` | Execute unattended using saved automation defaults |
 | `openmeta agent --run-checks` | Run detected baseline validation commands |
 | `openmeta daily` | Compatibility alias for `agent` with the same runtime options |
 | `openmeta scout --limit <count>` | Show ranked contribution opportunities |
 | `openmeta scout --refresh` | Force-refresh the GitHub issue discovery cache |
+| `openmeta scout --repo <repository>` | Rank opportunities from one upstream GitHub repository URL or `owner/name` |
 | `openmeta scout --local` | Use local heuristic scoring without calling the LLM provider |
 | `openmeta inbox` | Show drafted contribution opportunities |
 | `openmeta pow` | Show proof-of-work history |

--- a/docs/superpowers/plans/2026-06-04-repository-analysis.md
+++ b/docs/superpowers/plans/2026-06-04-repository-analysis.md
@@ -1,0 +1,86 @@
+# Repository Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `openmeta analyze --repo <repository>` to generate LLM-backed contribution suggestions from repository code when no issue exists.
+
+**Architecture:** Add a thin command and a focused analyzer orchestration path. Reuse repo parsing, workspace cloning, LLM structured output parsing, content rendering, and existing patch/PR draft generators where possible.
+
+**Tech Stack:** Bun, Commander, TypeScript, Zod, OpenAI-compatible chat completions, existing OpenMeta service layer.
+
+---
+
+### Task 1: Structured Suggestion Contract
+
+**Files:**
+- Modify: `src/contracts/agent-contracts.ts`
+- Modify: `src/types/agent.types.ts`
+- Modify: `test/llm.test.ts`
+
+- [x] Write a failing test that parses a `repository_suggestion_list` envelope and deduplicates/validates suggestions.
+- [x] Add `RepositoryImprovementSuggestionSchema` and `RepositorySuggestionListEnvelopeSchema`.
+- [x] Export `RepositoryImprovementSuggestion` and structured result types.
+- [x] Run `bun test test/llm.test.ts`.
+
+### Task 2: LLM Repository Analysis
+
+**Files:**
+- Modify: `src/infra/prompt-templates.ts`
+- Modify: `src/services/llm.ts`
+- Modify: `test/llm.test.ts`
+
+- [x] Write a failing test for `LLMService.analyzeRepository(...)` that verifies repository context and streaming/reasoning options still flow through `chat(...)`.
+- [x] Add `REPOSITORY_ANALYSIS_PROMPT` and repair prompt.
+- [x] Implement `analyzeRepository(repoFullName, workspace, memory)`.
+- [x] Run `bun test test/llm.test.ts`.
+
+### Task 3: Repository Workspace Context
+
+**Files:**
+- Modify: `src/services/workspace.ts`
+- Modify: `test/workspace.test.ts`
+
+- [x] Write a failing test for preparing a repository workspace without a real issue object.
+- [x] Add `prepareRepositoryWorkspace(repoFullName, memory, runChecks, executionMode)`.
+- [x] Share clone/default-branch/test-command logic with `prepareWorkspace(...)`.
+- [x] Rank repo analysis candidate files using README/config/source/test path signals and repo memory.
+- [x] Run `bun test test/workspace.test.ts`.
+
+### Task 4: Artifact Rendering
+
+**Files:**
+- Modify: `src/services/content.ts`
+- Modify: `test/content.test.ts`
+
+- [x] Write a failing test for repository analysis markdown output.
+- [x] Add `formatRepositoryAnalysisMarkdown(repoFullName, workspace, suggestions, selectedSuggestion?)`.
+- [x] Include target files, proposed changes, validation plan, risks, and selected marker.
+- [x] Run `bun test test/content.test.ts`.
+
+### Task 5: Analyze Command and Orchestration
+
+**Files:**
+- Create: `src/commands/analyze.ts`
+- Create: `src/orchestration/analyze.ts`
+- Modify: `src/commands/index.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/orchestration/index.ts`
+- Modify: `test/agent-run.test.ts` or add `test/analyze-run.test.ts`
+
+- [x] Write a failing command/orchestration test for `openmeta analyze --repo owner/name`.
+- [x] Implement provider validation and workspace preparation.
+- [x] Generate suggestions and render artifacts.
+- [x] Select the highest-score suggestion in headless mode; prompt in interactive mode if existing prompt helpers support it.
+- [x] Convert the selected suggestion into a synthetic ranked issue and generate patch/PR drafts.
+- [x] Run targeted analyze tests.
+
+### Task 6: Verification and PR Update
+
+**Files:**
+- No new code unless verification finds a defect.
+
+- [x] Run `bun test`.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun run build`.
+- [ ] Commit only repository analysis files, excluding untracked `AGENTS.md`.
+- [ ] Push `codex/agent-targeting-llm-options` to the fork so PR #38 updates.

--- a/docs/superpowers/specs/2026-06-04-repository-analysis-design.md
+++ b/docs/superpowers/specs/2026-06-04-repository-analysis-design.md
@@ -1,0 +1,71 @@
+# Repository Analysis Design
+
+## Goal
+
+Add a repository-first contribution flow for projects that do not have a suitable GitHub issue. The first version should analyze a target GitHub repository, generate structured improvement suggestions, let the user pick one, and reuse the existing patch and PR draft pipeline.
+
+## Command
+
+Add:
+
+```bash
+openmeta analyze --repo <owner/name-or-github-url>
+```
+
+Supported repository values match the existing `--repo` parsing: `owner/name`, `https://github.com/owner/name`, and `git@github.com:owner/name.git`.
+
+## Behavior
+
+1. Validate GitHub and LLM providers with the same config path used by `agent`.
+2. Prepare a local workspace for the target repository.
+3. Build a repository analysis context from top-level files, candidate files, snippets, detected validation commands, and repo memory.
+4. Ask the LLM for 3-5 structured improvement suggestions.
+5. Show the ranked suggestions and allow the user to select one in interactive mode.
+6. Convert the selected suggestion into a synthetic ranked issue so existing patch draft, optional implementation draft, validation, and PR draft logic can be reused later.
+7. First implementation produces repository analysis artifacts and a patch/PR draft for the selected suggestion. Direct PR publication remains a follow-up unless explicitly wired through an existing safe path.
+
+## Data Shape
+
+The LLM returns a structured envelope:
+
+```ts
+{
+  version: '1',
+  kind: 'repository_suggestion_list',
+  status: 'success' | 'needs_review',
+  data: {
+    suggestions: RepositoryImprovementSuggestion[]
+  }
+}
+```
+
+Each suggestion includes title, summary, rationale, target files, proposed changes, validation plan, risks, estimated workload, and PR potential score.
+
+## Architecture
+
+- Keep `src/commands/analyze.ts` thin.
+- Add orchestration in `src/orchestration/analyze.ts`.
+- Extend `src/contracts/agent-contracts.ts` with the new structured output schema.
+- Extend `src/services/llm.ts` with `analyzeRepository(...)`.
+- Extend `src/services/workspace.ts` with repository-level workspace preparation that does not require a real issue.
+- Extend `src/services/content.ts` with repository analysis markdown rendering.
+
+The first implementation should share code with existing agent services rather than duplicating patch generation, validation command detection, or LLM parsing.
+
+## Testing
+
+Add focused tests for:
+
+- Parsing and normalizing repository suggestion envelopes.
+- LLM request generation for repository analysis.
+- Repository-level workspace preparation without a real issue.
+- Markdown rendering for repository analysis artifacts.
+- CLI command registration/help for `openmeta analyze`.
+
+Full verification before commit:
+
+```bash
+bun test
+bun run typecheck
+bun run build
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { Command } from 'commander';
 import {
   registerAgentCommand,
+  registerAnalyzeCommand,
   registerAutomationCommand,
   registerConfigCommand,
   registerDailyCommand,
@@ -30,6 +31,7 @@ async function main(): Promise<void> {
 
   registerInitCommand(program);
   registerAgentCommand(program);
+  registerAnalyzeCommand(program);
   registerDailyCommand(program);
   registerScoutCommand(program);
   registerInboxCommand(program);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -11,9 +11,11 @@ export function registerAgentCommand(program: Command): void {
     .option('--run-checks', 'Execute detected baseline validation commands')
     .option('--draft-only', 'Generate dossier and PR draft artifacts without applying file edits or opening a PR')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
+    .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
     .option('--dry-run', 'Preview artifacts without writing to git')
     .addOption(new Option('--scheduler-run', 'Internal flag for scheduled automation').hideHelp())
-    .action((options: { headless?: boolean; force?: boolean; runChecks?: boolean; draftOnly?: boolean; refresh?: boolean; dryRun?: boolean; schedulerRun?: boolean }) => runCommand(
+    .action((options: { headless?: boolean; force?: boolean; runChecks?: boolean; draftOnly?: boolean; refresh?: boolean; repo?: string; issue?: string; dryRun?: boolean; schedulerRun?: boolean }) => runCommand(
       'OpenMeta Agent',
       () => agentOrchestrator.run({
         headless: options.headless,
@@ -21,6 +23,8 @@ export function registerAgentCommand(program: Command): void {
         runChecks: options.runChecks,
         draftOnly: options.draftOnly,
         refresh: options.refresh,
+        repo: options.repo,
+        issue: options.issue,
         dryRun: options.dryRun,
         schedulerRun: options.schedulerRun,
       }),

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander';
+import { analyzeOrchestrator } from '../orchestration/index.js';
+import { runCommand } from './run-command.js';
+
+export function registerAnalyzeCommand(program: Command): void {
+  program
+    .command('analyze')
+    .description('Analyze a repository and draft contribution suggestions without relying on existing issues')
+    .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name to analyze')
+    .option('--headless', 'Select the highest-scoring suggestion without prompting')
+    .option('--run-checks', 'Execute detected baseline validation commands during workspace preparation')
+    .option('--dry-run', 'Preview artifact paths without writing local analysis files')
+    .action((options: { repo?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) => runCommand(
+      'OpenMeta Analyze',
+      () => analyzeOrchestrator.run({
+        repo: options.repo,
+        headless: options.headless,
+        runChecks: options.runChecks,
+        dryRun: options.dryRun,
+      }),
+    ));
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,5 @@
 export { registerAgentCommand } from './agent.js';
+export { registerAnalyzeCommand } from './analyze.js';
 export { registerInitCommand } from './init.js';
 export { registerDailyCommand } from './daily.js';
 export { registerScoutCommand } from './scout.js';

--- a/src/commands/provider.ts
+++ b/src/commands/provider.ts
@@ -31,12 +31,16 @@ export function registerProviderCommand(program: Command): void {
     .requiredOption('--base-url <url>', 'OpenAI-compatible API base URL')
     .requiredOption('--model <model>', 'Model name')
     .requiredOption('--api-key <key>', 'LLM API key')
+    .option('--reasoning-effort <effort>', 'Reasoning effort: none, minimal, low, medium, high, or xhigh')
+    .option('--stream <enabled>', 'Use streaming chat completions: true or false')
     .option('--header <key=value>', 'Extra API header; repeat for multiple headers', (value, previous: string[] = []) => [...previous, value], [])
     .action((name: string, options: {
       provider?: string;
       baseUrl: string;
       model: string;
       apiKey: string;
+      reasoningEffort?: string;
+      stream?: string;
       header: string[];
     }) => runCommand('OpenMeta Provider', () => providerOrchestrator.add(name, options)));
 

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -8,12 +8,14 @@ export function registerScoutCommand(program: Command): void {
     .description('Rank the highest-value contribution opportunities')
     .option('--limit <count>', 'Number of opportunities to show', '10')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
     .option('--local', 'Use local heuristic scoring without calling the LLM provider')
-    .action((options: { limit?: string; refresh?: boolean; local?: boolean }) => runCommand(
+    .action((options: { limit?: string; refresh?: boolean; repo?: string; local?: boolean }) => runCommand(
       'OpenMeta Scout',
       () => agentOrchestrator.scout({
         limit: Number.parseInt(options.limit || '10', 10) || 10,
         refresh: options.refresh,
+        repo: options.repo,
         localOnly: options.local,
       }),
     ));

--- a/src/contracts/agent-contracts.ts
+++ b/src/contracts/agent-contracts.ts
@@ -89,10 +89,39 @@ export const PullRequestDraftSchema = z.object({
   risks: z.array(nonEmptyTrimmedString).default([]),
 });
 
+export const RepositoryImprovementSuggestionSchema = z.object({
+  id: nonEmptyTrimmedString,
+  title: nonEmptyTrimmedString,
+  summary: nonEmptyTrimmedString,
+  rationale: nonEmptyTrimmedString,
+  targetFiles: z.array(PatchTargetFileSchema).min(1).max(8),
+  proposedChanges: z.array(nonEmptyTrimmedString).min(1).max(8),
+  validationPlan: z.array(nonEmptyTrimmedString).default([]),
+  risks: z.array(nonEmptyTrimmedString).default([]),
+  estimatedWorkload: z.enum(['small', 'medium', 'large']),
+  prPotentialScore: z.coerce.number().int().min(0).max(100),
+});
+
+export const RepositorySuggestionListSchema = z.object({
+  suggestions: z.array(RepositoryImprovementSuggestionSchema).default([]).transform((suggestions) => {
+    const dedupedSuggestions = new Map<string, RepositoryImprovementSuggestion>();
+
+    for (const suggestion of suggestions) {
+      const existing = dedupedSuggestions.get(suggestion.id);
+      if (!existing || suggestion.prPotentialScore >= existing.prPotentialScore) {
+        dedupedSuggestions.set(suggestion.id, suggestion);
+      }
+    }
+
+    return [...dedupedSuggestions.values()].sort((left, right) => right.prPotentialScore - left.prPotentialScore);
+  }),
+});
+
 export const IssueMatchListEnvelopeSchema = createStructuredOutputEnvelopeSchema('issue_match_list', IssueMatchListSchema);
 export const PatchDraftEnvelopeSchema = createStructuredOutputEnvelopeSchema('patch_draft', PatchDraftSchema);
 export const ImplementationDraftEnvelopeSchema = createStructuredOutputEnvelopeSchema('implementation_draft', ImplementationDraftSchema);
 export const PullRequestDraftEnvelopeSchema = createStructuredOutputEnvelopeSchema('pull_request_draft', PullRequestDraftSchema);
+export const RepositorySuggestionListEnvelopeSchema = createStructuredOutputEnvelopeSchema('repository_suggestion_list', RepositorySuggestionListSchema);
 
 export type IssueMatch = z.infer<typeof IssueMatchSchema>;
 export type IssueMatchList = z.infer<typeof IssueMatchListSchema>;
@@ -102,6 +131,8 @@ export type PatchDraft = z.infer<typeof PatchDraftSchema>;
 export type GeneratedFileChange = z.infer<typeof GeneratedFileChangeSchema>;
 export type ImplementationDraft = z.infer<typeof ImplementationDraftSchema>;
 export type PullRequestDraft = z.infer<typeof PullRequestDraftSchema>;
+export type RepositoryImprovementSuggestion = z.infer<typeof RepositoryImprovementSuggestionSchema>;
+export type RepositorySuggestionList = z.infer<typeof RepositorySuggestionListSchema>;
 export type StructuredOutputStatus = z.infer<typeof StructuredOutputStatusSchema>;
 export interface StructuredOutputResult<TKind extends string, TData> {
   version: '1';
@@ -113,3 +144,4 @@ export type IssueMatchListEnvelope = z.infer<typeof IssueMatchListEnvelopeSchema
 export type PatchDraftEnvelope = z.infer<typeof PatchDraftEnvelopeSchema>;
 export type ImplementationDraftEnvelope = z.infer<typeof ImplementationDraftEnvelopeSchema>;
 export type PullRequestDraftEnvelope = z.infer<typeof PullRequestDraftEnvelopeSchema>;
+export type RepositorySuggestionListEnvelope = z.infer<typeof RepositorySuggestionListEnvelopeSchema>;

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import type { AppConfig } from '../types/index.js';
 import { CryptoService } from './crypto.js';
 import { logger } from './logger.js';
+import { DEFAULT_LLM_REASONING_EFFORT, parseLLMReasoningEffort } from './llm-reasoning.js';
 
 function getConfigDirPath(): string {
   return process.env['OPENMETA_CONFIG_DIR'] || join(homedir(), '.config', 'openmeta');
@@ -43,6 +44,8 @@ function createDefaultConfig(): AppConfig {
       apiKey: '',
       modelName: 'gpt-4o-mini',
       apiHeaders: {},
+      reasoningEffort: DEFAULT_LLM_REASONING_EFFORT,
+      stream: false,
       activeProfile: '',
       profiles: {},
     },
@@ -182,10 +185,9 @@ export class ConfigService {
           ...defaults.llm.apiHeaders,
           ...config.llm?.apiHeaders,
         },
-        profiles: {
-          ...defaults.llm.profiles,
-          ...config.llm?.profiles,
-        },
+        reasoningEffort: this.normalizeReasoningEffort(config.llm?.reasoningEffort),
+        stream: config.llm?.stream === true,
+        profiles: this.normalizeProviderProfiles(config.llm?.profiles),
       },
       automation: {
         ...defaults.automation,
@@ -216,6 +218,32 @@ export class ConfigService {
         apiKey: profile.apiKey && CryptoService.isEncrypted(profile.apiKey)
           ? CryptoService.decrypt(profile.apiKey)
           : profile.apiKey,
+      },
+    ]));
+  }
+
+  private normalizeReasoningEffort(value: unknown): AppConfig['llm']['reasoningEffort'] {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      return DEFAULT_LLM_REASONING_EFFORT;
+    }
+
+    try {
+      return parseLLMReasoningEffort(value);
+    } catch {
+      return DEFAULT_LLM_REASONING_EFFORT;
+    }
+  }
+
+  private normalizeProviderProfiles(
+    profiles: AppConfig['llm']['profiles'] = {},
+  ): AppConfig['llm']['profiles'] {
+    return Object.fromEntries(Object.entries(profiles).map(([name, profile]) => [
+      name,
+      {
+        ...profile,
+        apiHeaders: profile.apiHeaders ?? {},
+        reasoningEffort: this.normalizeReasoningEffort(profile.reasoningEffort),
+        stream: profile.stream === true,
       },
     ]));
   }

--- a/src/infra/github-repo.ts
+++ b/src/infra/github-repo.ts
@@ -1,0 +1,122 @@
+export function parseGitHubRepoFullName(value: string): string {
+  const normalized = value.trim();
+  const shorthand = normalizeRepoPath(normalized);
+  if (shorthand) {
+    return shorthand;
+  }
+
+  const sshMatch = normalized.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i);
+  if (sshMatch?.[1] && sshMatch[2]) {
+    return `${sshMatch[1]}/${stripGitSuffix(sshMatch[2])}`;
+  }
+
+  try {
+    const url = new URL(normalized);
+    if (url.hostname.toLowerCase() !== 'github.com') {
+      throw new Error('Repository must be a GitHub repository, for example: https://github.com/vercel/next.js.');
+    }
+
+    const [owner, repo] = url.pathname.split('/').filter(Boolean);
+    const fullName = owner && repo ? normalizeRepoPath(`${owner}/${stripGitSuffix(repo)}`) : null;
+    if (fullName) {
+      return fullName;
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('GitHub repository')) {
+      throw error;
+    }
+  }
+
+  throw new Error('Repository must be owner/name or a GitHub repository URL, for example: vercel/next.js or https://github.com/vercel/next.js.');
+}
+
+export interface GitHubIssueReference {
+  repoFullName?: string;
+  issueNumber: number;
+}
+
+export interface GitHubIssueTarget {
+  repoFullName: string;
+  issueNumber: number;
+}
+
+export function parseGitHubIssueReference(value: string): GitHubIssueReference {
+  const normalized = value.trim();
+  const issueNumber = parsePositiveIssueNumber(normalized);
+  if (issueNumber) {
+    return { issueNumber };
+  }
+
+  try {
+    const url = new URL(normalized);
+    if (url.hostname.toLowerCase() !== 'github.com') {
+      throw new Error('Issue must be a GitHub issue URL or positive issue number.');
+    }
+
+    const [owner, repo, marker, issueNumberText] = url.pathname.split('/').filter(Boolean);
+    if (owner && repo && marker === 'issues') {
+      const parsedIssueNumber = parsePositiveIssueNumber(issueNumberText ?? '');
+      if (parsedIssueNumber) {
+        return {
+          repoFullName: parseGitHubRepoFullName(`${owner}/${repo}`),
+          issueNumber: parsedIssueNumber,
+        };
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Issue must')) {
+      throw error;
+    }
+  }
+
+  throw new Error('Issue must be a GitHub issue URL or positive issue number.');
+}
+
+export function resolveGitHubIssueTarget(issue: string, repo?: string): GitHubIssueTarget {
+  const issueReference = parseGitHubIssueReference(issue);
+  const repoFullName = repo ? parseGitHubRepoFullName(repo) : undefined;
+
+  if (issueReference.repoFullName && repoFullName && issueReference.repoFullName !== repoFullName) {
+    throw new Error(`Issue URL repository ${issueReference.repoFullName} does not match --repo ${repoFullName}.`);
+  }
+
+  const resolvedRepo = issueReference.repoFullName ?? repoFullName;
+  if (!resolvedRepo) {
+    throw new Error('Issue number targets require --repo, for example: openmeta agent --repo owner/name --issue 123.');
+  }
+
+  return {
+    repoFullName: resolvedRepo,
+    issueNumber: issueReference.issueNumber,
+  };
+}
+
+function normalizeRepoPath(value: string): string | null {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    return null;
+  }
+
+  const [owner, repo] = value.split('/');
+  if (!owner || !repo) {
+    return null;
+  }
+
+  return `${owner}/${stripGitSuffix(repo)}`;
+}
+
+function stripGitSuffix(repo: string): string {
+  return repo.endsWith('.git') ? repo.slice(0, -4) : repo;
+}
+
+function parsePositiveIssueNumber(value: string): number | null {
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error('Issue must be a positive issue number.');
+  }
+
+  return parsed;
+}

--- a/src/infra/index.ts
+++ b/src/infra/index.ts
@@ -3,7 +3,17 @@ export { CryptoService } from './crypto.js';
 export { configService, ConfigService } from './config.js';
 export { getLocalDateStamp, getDailyNoteFileName } from './date.js';
 export { getOpenMetaHomePath, getOpenMetaWorkspaceRoot, getOpenMetaArtifactRoot, getOpenMetaStateDir, ensureDirectory } from './paths.js';
+export {
+  parseGitHubIssueReference,
+  parseGitHubRepoFullName,
+  resolveGitHubIssueTarget,
+} from './github-repo.js';
+export type {
+  GitHubIssueReference,
+  GitHubIssueTarget,
+} from './github-repo.js';
 export { UserCancelledError, isPromptAbortError, isUserCancelledError, getErrorMessage } from './errors.js';
+export { DEFAULT_LLM_REASONING_EFFORT, LLM_REASONING_EFFORTS, parseLLMReasoningEffort } from './llm-reasoning.js';
 export { prompt } from './prompts.js';
 export { selectPrompt } from './select.js';
 export { ui } from './ui.js';

--- a/src/infra/llm-reasoning.ts
+++ b/src/infra/llm-reasoning.ts
@@ -1,0 +1,13 @@
+import type { LLMReasoningEffort } from '../types/index.js';
+
+export const LLM_REASONING_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly LLMReasoningEffort[];
+export const DEFAULT_LLM_REASONING_EFFORT: LLMReasoningEffort = 'none';
+
+export function parseLLMReasoningEffort(value: string): LLMReasoningEffort {
+  const normalized = value.trim().toLowerCase();
+  if (LLM_REASONING_EFFORTS.includes(normalized as LLMReasoningEffort)) {
+    return normalized as LLMReasoningEffort;
+  }
+
+  throw new Error(`llm.reasoningEffort must be one of: ${LLM_REASONING_EFFORTS.join(', ')}.`);
+}

--- a/src/infra/prompt-templates.ts
+++ b/src/infra/prompt-templates.ts
@@ -320,6 +320,95 @@ Validation Context:
 {{validationContext}}
 `;
 
+export const REPOSITORY_ANALYSIS_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.
+
+Analyze the repository context and propose concrete contribution opportunities that could become useful pull requests even when no GitHub issue exists.
+
+Requirements:
+1. Return one valid JSON object only. No markdown. No commentary.
+2. Generate 3-5 suggestions when enough context exists.
+3. Suggestions must be small enough for a focused pull request.
+4. Prefer improvements grounded in the provided files, tests, README, config, or repo memory.
+5. Do not invent files that are not implied by the repository context.
+6. Rank each suggestion by practical PR potential from 0-100.
+7. Use stable lowercase kebab-case ids.
+
+Output schema:
+{
+  "version": "1",
+  "kind": "repository_suggestion_list",
+  "status": "success",
+  "data": {
+    "suggestions": [
+      {
+        "id": "docs-install",
+        "title": "short contribution title",
+        "summary": "one sentence",
+        "rationale": "why this matters for the project",
+        "targetFiles": [
+          {
+            "path": "relative/path",
+            "reason": "why this file matters"
+          }
+        ],
+        "proposedChanges": ["specific change"],
+        "validationPlan": ["concrete validation step"],
+        "risks": ["honest risk"],
+        "estimatedWorkload": "small",
+        "prPotentialScore": 84
+      }
+    ]
+  }
+}
+
+Repository Context:
+{{repoContext}}
+
+Repo Memory:
+{{repoMemory}}
+`;
+
+export const REPOSITORY_ANALYSIS_REPAIR_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.
+
+The previous repository analysis response was not parseable or did not match the required schema. Reformat it into strict JSON.
+
+Required schema:
+{
+  "version": "1",
+  "kind": "repository_suggestion_list",
+  "status": "success" | "needs_review",
+  "data": {
+    "suggestions": [
+      {
+        "id": "stable-kebab-case-id",
+        "title": "short contribution title",
+        "summary": "one sentence",
+        "rationale": "why this matters for the project",
+        "targetFiles": [
+          {
+            "path": "relative/path",
+            "reason": "why this file matters"
+          }
+        ],
+        "proposedChanges": ["specific change"],
+        "validationPlan": ["concrete validation step"],
+        "risks": ["honest risk"],
+        "estimatedWorkload": "small" | "medium" | "large",
+        "prPotentialScore": 84
+      }
+    ]
+  }
+}
+
+Rules:
+1. Return only one valid JSON object. No commentary.
+2. Keep only concrete, repository-grounded suggestions.
+3. If the previous response is unusable, return {"version":"1","kind":"repository_suggestion_list","status":"needs_review","data":{"suggestions":[]}}.
+
+Previous response:
+{{invalidResponse}}
+`;
+
 export function fillPrompt(template: string, data: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(data)) {

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -19,6 +19,8 @@ import {
   getOpenMetaArtifactRoot,
   isUserCancelledError,
   logger,
+  parseGitHubRepoFullName,
+  resolveGitHubIssueTarget,
   prompt,
   selectPrompt,
   ui,
@@ -43,12 +45,15 @@ export interface AgentRunOptions {
   runChecks?: boolean;
   draftOnly?: boolean;
   refresh?: boolean;
+  repo?: string;
+  issue?: string;
   dryRun?: boolean;
 }
 
 export interface ScoutRunOptions {
   limit?: number;
   refresh?: boolean;
+  repo?: string;
   localOnly?: boolean;
 }
 
@@ -124,6 +129,8 @@ export class AgentOrchestrator {
     const runChecks = typeof options.runChecks === 'boolean' ? options.runChecks : !headless;
     const draftOnly = Boolean(options.draftOnly);
     const refresh = Boolean(options.refresh);
+    const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
+    const repoFullName = issueTarget?.repoFullName ?? (options.repo ? parseGitHubRepoFullName(options.repo) : undefined);
     const completedStages = new Set<AgentStageId>();
 
     ui.hero({
@@ -135,7 +142,16 @@ export class AgentOrchestrator {
       lines: [
         runChecks ? 'Baseline checks will fire wherever the repository exposes a safe command path.' : 'This pass will stay light and skip baseline checks.',
         draftOnly ? 'Draft-only mode will preserve artifacts without applying generated file edits or opening a PR.' : 'Generated patches can be applied after repository safety checks pass.',
-        refresh ? 'Issue discovery will bypass the local search cache for this run.' : 'Issue discovery may reuse the short local search cache.',
+        issueTarget
+          ? `Target issue is locked to ${issueTarget.repoFullName}#${issueTarget.issueNumber}.`
+          : refresh
+            ? 'Issue discovery will bypass the local search cache for this run.'
+            : 'Issue discovery may reuse the short local search cache.',
+        issueTarget
+          ? 'Issue discovery and interactive selection are skipped for this run.'
+          : repoFullName
+            ? `Issue discovery is limited to ${repoFullName}.`
+            : 'Issue discovery will scan the broader GitHub issue stream.',
         headless ? `Unattended selection honors the saved threshold at ${config.automation.minMatchScore}/100.` : 'You stay in control at each decision gate before anything is published.',
       ],
     });
@@ -146,39 +162,54 @@ export class AgentOrchestrator {
       await this.confirmManualHeadlessRun(config);
     }
 
-    this.renderAgentStage('scout', completedStages, 'Verifying provider access and loading ranked opportunities.');
+    this.renderAgentStage('scout', completedStages, issueTarget
+      ? `Verifying provider access and loading ${issueTarget.repoFullName}#${issueTarget.issueNumber}.`
+      : 'Verifying provider access and loading ranked opportunities.');
     await this.initializeClients(config);
 
     const rankedIssues = await ui.task({
-      title: 'Ranking contribution opportunities',
+      title: issueTarget ? 'Loading target issue' : 'Ranking contribution opportunities',
       doneMessage: 'Opportunity ranking complete',
       failedMessage: 'Opportunity ranking failed',
       tone: 'info',
-    }, async (task) => issueRankingService.loadRankedIssues(config, {
-      refresh,
-      onStatus: (message) => task.setMessage(message),
-    }));
+    }, async (task) => issueTarget
+      ? issueRankingService.loadTargetIssue(config, issueTarget)
+      : issueRankingService.loadRankedIssues(config, {
+        refresh,
+        repoFullName,
+        onStatus: (message) => task.setMessage(message),
+      }));
     if (rankedIssues.length === 0) {
       ui.emptyState(
         'OpenMeta Agent',
-        'No viable issues found',
-        'No issues met the current technical match threshold. Broaden your profile or try again later.',
+        issueTarget ? 'Target issue could not be ranked' : 'No viable issues found',
+        issueTarget
+          ? 'OpenMeta could not build a contribution target from the specified issue.'
+          : 'No issues met the current technical match threshold. Broaden your profile or try again later.',
       );
       return;
     }
     completedStages.add('scout');
 
-    this.renderAgentStage('select', completedStages, 'Review the top ranked issues and choose the next contribution target.');
-    this.renderOpportunityList('Top ranked opportunities', rankedIssues.slice(0, 5));
-    const selectedIssue = headless
-      ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
-      : await this.promptForIssue(rankedIssues);
+    this.renderAgentStage('select', completedStages, issueTarget
+      ? 'Using the explicitly targeted issue as the contribution target.'
+      : 'Review the top ranked issues and choose the next contribution target.');
+    if (!issueTarget) {
+      this.renderOpportunityList('Top ranked opportunities', rankedIssues.slice(0, 5));
+    }
+    const selectedIssue = issueTarget
+      ? rankedIssues[0]
+      : headless
+        ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+        : await this.promptForIssue(rankedIssues);
 
     if (!selectedIssue) {
       ui.emptyState(
         'OpenMeta Agent',
-        'No issue met the automation threshold',
-        `Top opportunities were below ${config.automation.minMatchScore}/100. Lower the threshold or widen your profile.`,
+        issueTarget ? 'Target issue could not be selected' : 'No issue met the automation threshold',
+        issueTarget
+          ? 'OpenMeta could not select the specified target issue after scoring.'
+          : `Top opportunities were below ${config.automation.minMatchScore}/100. Lower the threshold or widen your profile.`,
       );
       return;
     }
@@ -397,6 +428,7 @@ export class AgentOrchestrator {
   async scout(options: ScoutRunOptions | number = {}): Promise<void> {
     const limit = typeof options === 'number' ? options : options.limit ?? 10;
     const refresh = typeof options === 'number' ? false : Boolean(options.refresh);
+    const repoFullName = typeof options === 'number' || !options.repo ? undefined : parseGitHubRepoFullName(options.repo);
     const localOnly = typeof options === 'number' ? false : Boolean(options.localOnly);
     const config = await configService.get();
     await this.validateConfig(config, { requireLlm: !localOnly });
@@ -411,6 +443,7 @@ export class AgentOrchestrator {
       lines: [
         `Saved threshold reference: ${config.automation.minMatchScore}/100.`,
         refresh ? 'This scout run will ignore the local GitHub issue cache.' : 'This scout run may reuse the short local GitHub issue cache.',
+        repoFullName ? `Issue discovery is limited to ${repoFullName}.` : 'Issue discovery will scan the broader GitHub issue stream.',
         localOnly ? 'LLM validation and model scoring are skipped for this run.' : 'LLM scoring will refine the local candidate shortlist.',
       ],
     });
@@ -422,6 +455,7 @@ export class AgentOrchestrator {
       tone: 'info',
     }, async (task) => issueRankingService.loadRankedIssues(config, {
       refresh,
+      repoFullName,
       localOnly,
       onStatus: (message) => task.setMessage(message),
     }));
@@ -766,7 +800,15 @@ export class AgentOrchestrator {
       return;
     }
 
-    llmService.initialize(config.llm.apiKey, config.llm.apiBaseUrl, config.llm.modelName, config.llm.apiHeaders, config.llm.provider);
+    llmService.initialize(
+      config.llm.apiKey,
+      config.llm.apiBaseUrl,
+      config.llm.modelName,
+      config.llm.apiHeaders,
+      config.llm.provider,
+      config.llm.reasoningEffort,
+      config.llm.stream === true,
+    );
     const llmValid = await ui.task({
       title: 'Validating LLM provider',
       doneMessage: 'LLM provider verified',
@@ -1593,13 +1635,13 @@ export class AgentOrchestrator {
       const git = simpleGit(config.github.targetRepoPath);
       const remoteUrl = await this.getOriginRemoteUrl(git);
       const parsedRepo = this.parseGitHubRepository(remoteUrl);
-      const repoInfo = await this.getGitHubRepositoryInfo(parsedRepo.owner, parsedRepo.repo);
+      const defaultBranch = await this.resolveConfiguredTargetDefaultBranch(git, parsedRepo.owner, parsedRepo.repo);
 
       return {
         path: config.github.targetRepoPath,
         owner: parsedRepo.owner,
         repo: parsedRepo.repo,
-        defaultBranch: repoInfo.default_branch || 'main',
+        defaultBranch,
       };
     }
 
@@ -1723,6 +1765,36 @@ export class AgentOrchestrator {
 
     const { data } = await this.octokit.rest.repos.get({ owner, repo });
     return data;
+  }
+
+  private async resolveConfiguredTargetDefaultBranch(git: SimpleGit, owner: string, repo: string): Promise<string> {
+    try {
+      const repoInfo = await this.getGitHubRepositoryInfo(owner, repo);
+      return repoInfo.default_branch || 'main';
+    } catch (error) {
+      logger.warn(`Unable to read GitHub metadata for ${owner}/${repo}. Falling back to the local target repository branch.`, error);
+      return this.detectLocalDefaultBranch(git);
+    }
+  }
+
+  private async detectLocalDefaultBranch(git: SimpleGit): Promise<string> {
+    try {
+      const branchReference = await git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+      const segments = branchReference.trim().split('/');
+      return segments.at(-1) || 'main';
+    } catch {
+      const branches = await git.branch();
+
+      if (branches.all.includes('main')) {
+        return 'main';
+      }
+
+      if (branches.all.includes('master')) {
+        return 'master';
+      }
+
+      return branches.current || 'main';
+    }
   }
 
   private showStructuredReviewNotice(input: {

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -1,0 +1,381 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { PatchDraft, PullRequestDraft, RepositoryImprovementSuggestion } from '../contracts/index.js';
+import type { AppConfig, RankedIssue, RepoWorkspaceContext } from '../types/index.js';
+import {
+  configService,
+  ensureDirectory,
+  getLocalDateStamp,
+  getOpenMetaArtifactRoot,
+  logger,
+  parseGitHubRepoFullName,
+  selectPrompt,
+  ui,
+} from '../infra/index.js';
+import {
+  contentService,
+  githubService,
+  llmService,
+  memoryService,
+  workspaceService,
+} from '../services/index.js';
+
+export interface AnalyzeRunOptions {
+  repo?: string;
+  headless?: boolean;
+  runChecks?: boolean;
+  dryRun?: boolean;
+}
+
+interface AnalyzeArtifacts {
+  artifactDir: string;
+  analysisPath: string;
+  patchDraftPath: string;
+  prDraftPath: string;
+}
+
+interface AnalyzeResult {
+  repoFullName: string;
+  workspace: RepoWorkspaceContext;
+  selectedSuggestion: RepositoryImprovementSuggestion;
+  patchDraft: PatchDraft;
+  prDraft: PullRequestDraft;
+  artifacts: AnalyzeArtifacts;
+}
+
+export class AnalyzeOrchestrator {
+  async run(options: AnalyzeRunOptions = {}): Promise<void> {
+    if (!options.repo) {
+      throw new Error('Repository analysis requires --repo, for example: openmeta analyze --repo owner/name.');
+    }
+
+    const repoFullName = parseGitHubRepoFullName(options.repo);
+    const config = await configService.get();
+    const headless = Boolean(options.headless);
+    const runChecks = Boolean(options.runChecks);
+
+    ui.hero({
+      label: 'OpenMeta Analyze',
+      title: 'Find a contribution path even when the issue tracker is quiet',
+      subtitle: 'OpenMeta will inspect the repository, ask the model for grounded improvement ideas, and draft PR-ready artifacts for the strongest suggestion.',
+      lines: [
+        `Repository: ${repoFullName}`,
+        runChecks ? 'Detected validation commands may run during workspace preparation.' : 'This analysis will skip baseline validation commands.',
+        headless ? 'Headless mode will select the highest-scoring suggestion automatically.' : 'You can choose which suggestion should become the draft target.',
+      ],
+    });
+
+    await this.validateConfig(config);
+    await this.initializeClients(config);
+
+    const memory = memoryService.load(repoFullName);
+    const workspace = await ui.task({
+      title: `Preparing repository workspace for ${repoFullName}`,
+      doneMessage: 'Repository workspace prepared',
+      failedMessage: 'Repository workspace preparation failed',
+      tone: 'info',
+    }, async () => workspaceService.prepareRepositoryWorkspace(
+      repoFullName,
+      memory,
+      runChecks,
+      headless ? 'headless' : 'interactive',
+    ));
+
+    this.showWorkspaceSummary(workspace);
+
+    const suggestionsResult = await ui.task({
+      title: 'Analyzing repository contribution paths',
+      doneMessage: 'Repository suggestions generated',
+      failedMessage: 'Repository analysis failed',
+      tone: 'info',
+    }, async () => llmService.analyzeRepository(repoFullName, workspace, memory));
+    const suggestions = suggestionsResult.data;
+    if (suggestions.length === 0) {
+      ui.emptyState(
+        'OpenMeta Analyze',
+        'No repository suggestions generated',
+        'The model did not find a grounded contribution path from the current repository context.',
+      );
+      return;
+    }
+
+    this.showSuggestions(suggestions);
+    const selectedSuggestion = headless
+      ? this.selectTopSuggestion(suggestions)
+      : await this.promptForSuggestion(suggestions);
+    const syntheticIssue = this.buildSyntheticIssue(repoFullName, selectedSuggestion);
+
+    const patchDraftResult = await ui.task({
+      title: 'Generating patch strategy for selected suggestion',
+      doneMessage: 'Patch strategy generated',
+      failedMessage: 'Patch strategy generation failed',
+      tone: 'info',
+    }, async () => llmService.generatePatchDraft(syntheticIssue, workspace, memory));
+    const patchDraft = patchDraftResult.data;
+
+    const prDraftResult = await ui.task({
+      title: 'Generating PR narrative',
+      doneMessage: 'PR narrative generated',
+      failedMessage: 'PR narrative generation failed',
+      tone: 'info',
+    }, async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspace));
+    const prDraft = prDraftResult.data;
+
+    const artifacts = this.prepareArtifactPaths(repoFullName, selectedSuggestion.id);
+    const analysisMarkdown = contentService.formatRepositoryAnalysisMarkdown(
+      repoFullName,
+      workspace,
+      suggestions,
+      selectedSuggestion,
+    );
+    const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+
+    if (options.dryRun) {
+      ui.callout({
+        label: 'OpenMeta Analyze',
+        title: 'Dry-run artifact preview',
+        subtitle: 'No repository analysis files were written.',
+        lines: [
+          artifacts.analysisPath,
+          artifacts.patchDraftPath,
+          artifacts.prDraftPath,
+        ],
+        tone: 'info',
+      });
+    } else {
+      await ui.task({
+        title: 'Writing repository analysis artifacts',
+        doneMessage: 'Repository analysis artifacts written',
+        failedMessage: 'Repository analysis artifact write failed',
+        tone: 'info',
+      }, async () => {
+        this.writeLocalArtifacts({
+          artifacts,
+          analysisMarkdown,
+          patchDraftMarkdown,
+          prDraftMarkdown,
+        });
+      });
+    }
+
+    this.showResult({
+      repoFullName,
+      workspace,
+      selectedSuggestion,
+      patchDraft,
+      prDraft,
+      artifacts,
+    });
+  }
+
+  private async validateConfig(config: AppConfig): Promise<void> {
+    if (!config.github.pat || !config.github.username) {
+      throw new Error('GitHub configuration is incomplete. Please run "openmeta init" first.');
+    }
+
+    if (!config.llm.apiKey) {
+      throw new Error('LLM API configuration is incomplete. Please run "openmeta init" first.');
+    }
+  }
+
+  private async initializeClients(config: AppConfig): Promise<void> {
+    githubService.initialize(config.github.pat, config.github.username);
+    const ghValid = await ui.task({
+      title: 'Validating GitHub access',
+      doneMessage: 'GitHub access verified',
+      failedMessage: 'GitHub access failed',
+      tone: 'info',
+    }, async () => {
+      const valid = await githubService.validateCredentials();
+      if (!valid) {
+        throw new Error('GitHub validation failed');
+      }
+      return true;
+    });
+    if (!ghValid) {
+      throw new Error('GitHub credentials validation failed. Run "openmeta init" to refresh your token.');
+    }
+    llmService.initialize(
+      config.llm.apiKey,
+      config.llm.apiBaseUrl,
+      config.llm.modelName,
+      config.llm.apiHeaders,
+      config.llm.provider,
+      config.llm.reasoningEffort,
+      config.llm.stream === true,
+    );
+    const llmValid = await ui.task({
+      title: 'Validating LLM provider',
+      doneMessage: 'LLM provider verified',
+      failedMessage: 'LLM provider failed',
+      tone: 'info',
+    }, async () => {
+      const valid = await llmService.validateConnection();
+      if (!valid) {
+        const detail = llmService.getLastValidationError();
+        throw new Error(`LLM validation failed${detail ? `: ${detail}` : ''}`);
+      }
+      return true;
+    });
+    if (!llmValid) {
+      throw new Error('LLM API connection failed. Run "openmeta init" to update your provider settings.');
+    }
+  }
+
+  private showWorkspaceSummary(workspace: RepoWorkspaceContext): void {
+    ui.stats('Repository workspace', [
+      { label: 'Candidate files', value: String(workspace.candidateFiles.length), tone: 'success' },
+      { label: 'Detected checks', value: String(workspace.testCommands.length), tone: workspace.testCommands.length > 0 ? 'info' : 'muted' },
+      { label: 'Runnable checks', value: String(workspace.validationCommands.length), tone: workspace.validationCommands.length > 0 ? 'accent' : 'muted' },
+      { label: 'Dirty workspace', value: workspace.workspaceDirty ? 'YES' : 'NO', tone: workspace.workspaceDirty ? 'warning' : 'success' },
+    ]);
+    ui.keyValues('Repository context', [
+      { label: 'Path', value: workspace.workspacePath, tone: 'info' },
+      { label: 'Default branch', value: workspace.defaultBranch, tone: 'info' },
+      { label: 'Analysis branch', value: workspace.branchName || 'workspace already dirty', tone: 'info' },
+      { label: 'Candidate files', value: workspace.candidateFiles.slice(0, 8).join(', ') || 'n/a', tone: 'info' },
+    ]);
+  }
+
+  private showSuggestions(suggestions: RepositoryImprovementSuggestion[]): void {
+    ui.recordList('Repository suggestions', suggestions.slice(0, 5).map((suggestion) => ({
+      title: suggestion.title,
+      subtitle: suggestion.summary,
+      meta: [
+        `score ${suggestion.prPotentialScore}`,
+        `workload ${suggestion.estimatedWorkload}`,
+        `id ${suggestion.id}`,
+      ],
+      lines: [
+        `Files: ${suggestion.targetFiles.map((file) => file.path).join(', ')}`,
+        `Validation: ${suggestion.validationPlan.join('; ') || 'not specified'}`,
+      ],
+      tone: suggestion.prPotentialScore >= 80 ? 'success' : 'info',
+    })));
+  }
+
+  private selectTopSuggestion(suggestions: RepositoryImprovementSuggestion[]): RepositoryImprovementSuggestion {
+    const [selected] = [...suggestions].sort((left, right) => right.prPotentialScore - left.prPotentialScore);
+    if (!selected) {
+      throw new Error('No repository suggestions are available to select.');
+    }
+
+    return selected;
+  }
+
+  private async promptForSuggestion(
+    suggestions: RepositoryImprovementSuggestion[],
+  ): Promise<RepositoryImprovementSuggestion> {
+    return selectPrompt<RepositoryImprovementSuggestion>({
+      message: 'Select a repository suggestion to draft:',
+      pageSize: Math.min(10, suggestions.length),
+      choices: suggestions.slice(0, 5).map((suggestion) => ({
+        name: suggestion.title,
+        description: `score ${suggestion.prPotentialScore} | ${suggestion.summary.slice(0, 72)}`,
+        value: suggestion,
+      })),
+    });
+  }
+
+  private buildSyntheticIssue(
+    repoFullName: string,
+    suggestion: RepositoryImprovementSuggestion,
+  ): RankedIssue {
+    const now = new Date().toISOString();
+    const repoName = repoFullName.split('/').at(-1) || repoFullName;
+
+    return {
+      id: 0,
+      number: 0,
+      title: suggestion.title,
+      body: [
+        suggestion.summary,
+        '',
+        suggestion.rationale,
+        '',
+        'Target files:',
+        ...suggestion.targetFiles.map((file) => `- ${file.path}: ${file.reason}`),
+        '',
+        'Proposed changes:',
+        ...suggestion.proposedChanges.map((change) => `- ${change}`),
+        '',
+        'Validation plan:',
+        ...suggestion.validationPlan.map((step) => `- ${step}`),
+      ].join('\n'),
+      htmlUrl: `https://github.com/${repoFullName}`,
+      repoName,
+      repoFullName,
+      repoDescription: 'Repository analysis suggestion generated by OpenMeta.',
+      repoStars: 0,
+      labels: ['openmeta-analysis'],
+      createdAt: now,
+      updatedAt: now,
+      matchScore: suggestion.prPotentialScore,
+      analysis: {
+        coreDemand: suggestion.summary,
+        techRequirements: suggestion.targetFiles.map((file) => file.path),
+        solutionSuggestion: suggestion.proposedChanges.join(' '),
+        estimatedWorkload: suggestion.estimatedWorkload,
+      },
+      opportunity: {
+        score: suggestion.prPotentialScore,
+        overallScore: suggestion.prPotentialScore,
+        summary: suggestion.rationale,
+        breakdown: {
+          technicalFit: suggestion.prPotentialScore,
+          freshness: 70,
+          onboardingClarity: 70,
+          mergePotential: suggestion.prPotentialScore,
+          impact: suggestion.prPotentialScore,
+        },
+      },
+    };
+  }
+
+  private prepareArtifactPaths(repoFullName: string, suggestionId: string): AnalyzeArtifacts {
+    const dirName = `${repoFullName.replace(/\//g, '__')}__${suggestionId}`;
+    const artifactDir = ensureDirectory(join(getOpenMetaArtifactRoot(), getLocalDateStamp(), 'analysis', dirName));
+    return {
+      artifactDir,
+      analysisPath: join(artifactDir, 'repository-analysis.md'),
+      patchDraftPath: join(artifactDir, 'patch-draft.md'),
+      prDraftPath: join(artifactDir, 'pr-draft.md'),
+    };
+  }
+
+  private writeLocalArtifacts(input: {
+    artifacts: AnalyzeArtifacts;
+    analysisMarkdown: string;
+    patchDraftMarkdown: string;
+    prDraftMarkdown: string;
+  }): void {
+    mkdirSync(input.artifacts.artifactDir, { recursive: true });
+    writeFileSync(input.artifacts.analysisPath, input.analysisMarkdown, 'utf-8');
+    writeFileSync(input.artifacts.patchDraftPath, input.patchDraftMarkdown, 'utf-8');
+    writeFileSync(input.artifacts.prDraftPath, input.prDraftMarkdown, 'utf-8');
+  }
+
+  private showResult(result: AnalyzeResult): void {
+    logger.success(`Repository analysis artifacts written to ${result.artifacts.artifactDir}`);
+    ui.hero({
+      label: 'OpenMeta Analyze',
+      title: 'Repository analysis produced a contribution-ready draft',
+      subtitle: 'The selected improvement now has analysis notes, a patch strategy, and a PR narrative saved locally.',
+      lines: [
+        `Repository: ${result.repoFullName}`,
+        `Suggestion: ${result.selectedSuggestion.title}`,
+        `Artifacts: ${result.artifacts.artifactDir}`,
+      ],
+      tone: 'success',
+    });
+    ui.keyValues('Analysis result', [
+      { label: 'Workspace', value: result.workspace.workspacePath, tone: 'info' },
+      { label: 'Patch goal', value: result.patchDraft.goal, tone: 'info' },
+      { label: 'PR title', value: result.prDraft.title, tone: 'info' },
+      { label: 'Analysis artifact', value: result.artifacts.analysisPath, tone: 'info' },
+    ]);
+  }
+}
+
+export const analyzeOrchestrator = new AnalyzeOrchestrator();

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -1,4 +1,4 @@
-import { configService, prompt, ui } from '../infra/index.js';
+import { configService, parseLLMReasoningEffort, prompt, ui } from '../infra/index.js';
 import { schedulerService } from '../services/index.js';
 import type { AppConfig } from '../types/index.js';
 
@@ -62,6 +62,8 @@ export class ConfigOrchestrator {
       { label: 'Provider', value: config.llm.provider || '(not set)', tone: config.llm.provider ? 'info' : 'warning' },
       { label: 'Base URL', value: config.llm.apiBaseUrl || '(not set)', tone: config.llm.apiBaseUrl ? 'info' : 'warning' },
       { label: 'Model', value: config.llm.modelName || '(not set)', tone: config.llm.modelName ? 'info' : 'warning' },
+      { label: 'Reasoning effort', value: config.llm.reasoningEffort || 'none', tone: 'info' },
+      { label: 'Streaming', value: config.llm.stream ? 'yes' : 'no', tone: config.llm.stream ? 'info' : 'muted' },
       { label: 'Extra headers', value: Object.keys(config.llm.apiHeaders || {}).length > 0 ? JSON.stringify(config.llm.apiHeaders) : '(none)', tone: 'info' },
       { label: 'API key', value: ui.maskSecret(config.llm.apiKey), tone: config.llm.apiKey ? 'info' : 'warning' },
       { label: 'Saved profiles', value: String(Object.keys(config.llm.profiles || {}).length), tone: Object.keys(config.llm.profiles || {}).length > 0 ? 'info' : 'muted' },
@@ -97,7 +99,7 @@ export class ConfigOrchestrator {
   async set(key: string, value: string): Promise<void> {
     const config = await configService.get();
     const validPaths = ['userProfile.techStack', 'userProfile.proficiency', 'userProfile.focusAreas',
-                       'github.username', 'github.pat', 'github.targetRepoPath', 'llm.provider', 'llm.apiBaseUrl', 'llm.apiKey', 'llm.modelName',
+                       'github.username', 'github.pat', 'github.targetRepoPath', 'llm.provider', 'llm.apiBaseUrl', 'llm.apiKey', 'llm.modelName', 'llm.reasoningEffort', 'llm.stream',
                        'automation.enabled', 'automation.scheduleTime', 'automation.contentType',
                        'automation.minMatchScore', 'automation.skipIfAlreadyGeneratedToday',
                        'commitTemplate'];
@@ -144,6 +146,10 @@ export class ConfigOrchestrator {
       updated = await configService.update({ llm: { ...config.llm, apiKey: this.parseRequiredSecret(value, key) } });
     } else if (key === 'llm.modelName') {
       updated = await configService.update({ llm: { ...config.llm, modelName: value } });
+    } else if (key === 'llm.reasoningEffort') {
+      updated = await configService.update({ llm: { ...config.llm, reasoningEffort: parseLLMReasoningEffort(value) } });
+    } else if (key === 'llm.stream') {
+      updated = await configService.update({ llm: { ...config.llm, stream: this.parseBoolean(value, key) } });
     } else if (key === 'automation.enabled') {
       updated = await configService.update({
         automation: {
@@ -302,6 +308,10 @@ export class ConfigOrchestrator {
         return ui.maskSecret(config.llm.apiKey);
       case 'llm.modelName':
         return config.llm.modelName;
+      case 'llm.reasoningEffort':
+        return config.llm.reasoningEffort || 'none';
+      case 'llm.stream':
+        return config.llm.stream ? 'yes' : 'no';
       case 'automation.enabled':
         return config.automation.enabled ? 'yes' : 'no';
       case 'automation.scheduleTime':

--- a/src/orchestration/doctor.ts
+++ b/src/orchestration/doctor.ts
@@ -276,7 +276,7 @@ export class DoctorOrchestrator {
       label: 'LLM configuration',
       status: 'pass',
       summary: `${config.llm.provider} provider is configured.`,
-      detail: `${config.llm.modelName} at ${config.llm.apiBaseUrl}; key ${ui.maskSecret(config.llm.apiKey)}`,
+      detail: `${config.llm.modelName} at ${config.llm.apiBaseUrl}; reasoning ${config.llm.reasoningEffort || 'none'}; streaming ${config.llm.stream ? 'yes' : 'no'}; key ${ui.maskSecret(config.llm.apiKey)}`,
     };
   }
 

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -1,5 +1,6 @@
 export { dailyOrchestrator, DailyOrchestrator } from './daily.js';
 export { agentOrchestrator, AgentOrchestrator } from './agent.js';
+export { analyzeOrchestrator, AnalyzeOrchestrator } from './analyze.js';
 export { initOrchestrator, InitOrchestrator } from './init.js';
 export { configOrchestrator, ConfigOrchestrator } from './config.js';
 export { providerOrchestrator, ProviderOrchestrator } from './provider.js';

--- a/src/orchestration/init.ts
+++ b/src/orchestration/init.ts
@@ -9,8 +9,9 @@ import {
   findLLMProviderPreset,
   type SchedulerSyncResult,
 } from '../services/index.js';
-import { configService, prompt, selectPrompt, ui } from '../infra/index.js';
+import { configService, DEFAULT_LLM_REASONING_EFFORT, LLM_REASONING_EFFORTS, prompt, selectPrompt, ui } from '../infra/index.js';
 import type { ContentType } from '../types/content.types.js';
+import type { LLMReasoningEffort } from '../types/index.js';
 
 const TECH_STACK_CHOICES = [
   'TypeScript',
@@ -186,16 +187,20 @@ export class InitOrchestrator {
     let apiBaseUrl = config.llm.apiBaseUrl;
     let apiHeaders: Record<string, string> = config.llm.apiHeaders ?? {};
     let apiKey = config.llm.apiKey;
+    let reasoningEffort = config.llm.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT;
+    let stream = config.llm.stream === true;
 
     await stepOrSkip(
       'llm',
       !!(apiKey && apiBaseUrl && modelValue),
       'LLM provider is already configured.',
       () => {
-        llmService.initialize(apiKey, apiBaseUrl, modelValue, apiHeaders, providerValue);
+        llmService.initialize(apiKey, apiBaseUrl, modelValue, apiHeaders, providerValue, reasoningEffort, stream);
         ui.keyValues('LLM provider connected', [
           { label: 'Provider', value: selectedProvider?.name ?? providerValue, tone: 'success' },
           { label: 'Model', value: modelValue, tone: 'success' },
+          { label: 'Reasoning effort', value: reasoningEffort, tone: 'info' },
+          { label: 'Streaming', value: stream ? 'yes' : 'no', tone: stream ? 'info' : 'muted' },
           { label: 'Endpoint', value: apiBaseUrl, tone: 'info' },
           { label: 'Extra headers', value: Object.keys(apiHeaders).length > 0 ? JSON.stringify(apiHeaders) : '(none)', tone: 'info' },
           { label: 'API key', value: ui.maskSecret(apiKey), tone: 'success' },
@@ -231,9 +236,11 @@ export class InitOrchestrator {
               choices: selectedProvider.models.map((model) => ({ name: model.name, value: model.value })),
             });
 
+          reasoningEffort = await this.promptReasoningEffort(config.llm.reasoningEffort);
+          stream = await this.promptLlmStreaming(config.llm.stream);
           apiKey = await this.promptAPIKey();
 
-          llmService.initialize(apiKey, apiBaseUrl, modelValue, apiHeaders, selectedProvider.value as AppConfig['llm']['provider']);
+          llmService.initialize(apiKey, apiBaseUrl, modelValue, apiHeaders, selectedProvider.value as AppConfig['llm']['provider'], reasoningEffort, stream);
           llmValid = await this.validateLlmConnection();
 
           if (!llmValid) {
@@ -260,10 +267,12 @@ export class InitOrchestrator {
           }
         }
         completedSteps.add('llm');
-        await commit({ llm: { provider: providerValue as AppConfig['llm']['provider'], apiBaseUrl, apiKey, modelName: modelValue, apiHeaders } });
+        await commit({ llm: { provider: providerValue as AppConfig['llm']['provider'], apiBaseUrl, apiKey, modelName: modelValue, apiHeaders, reasoningEffort, stream } });
         ui.keyValues('LLM provider connected', [
           { label: 'Provider', value: selectedProvider!.name, tone: 'success' },
           { label: 'Model', value: modelValue, tone: 'success' },
+          { label: 'Reasoning effort', value: reasoningEffort, tone: 'info' },
+          { label: 'Streaming', value: stream ? 'yes' : 'no', tone: stream ? 'info' : 'muted' },
           { label: 'Endpoint', value: apiBaseUrl, tone: 'info' },
           { label: 'Extra headers', value: Object.keys(apiHeaders).length > 0 ? JSON.stringify(apiHeaders) : '(none)', tone: 'info' },
           { label: 'API key', value: ui.maskSecret(apiKey), tone: 'success' },
@@ -432,6 +441,8 @@ export class InitOrchestrator {
     ui.stats('Setup summary', [
       { label: 'GitHub', value: username, tone: 'success' },
       { label: 'Model', value: modelValue, hint: selectedProvider?.name, tone: 'success' },
+      { label: 'Reasoning', value: reasoningEffort, tone: 'info' },
+      { label: 'Streaming', value: stream ? 'YES' : 'NO', tone: stream ? 'info' : 'muted' },
       { label: 'Repo policy', value: targetRepoPath ? 'CUSTOM' : 'MANAGED', tone: 'accent' },
       { label: 'Automation', value: automationEnabled ? 'ENABLED' : 'MANUAL', tone: automationEnabled ? 'warning' : 'muted' },
     ]);
@@ -498,6 +509,30 @@ export class InitOrchestrator {
     ]);
 
     return modelName.trim();
+  }
+
+  private async promptReasoningEffort(defaultValue?: AppConfig['llm']['reasoningEffort']): Promise<LLMReasoningEffort> {
+    return selectPrompt<LLMReasoningEffort>({
+      message: 'Select reasoning effort:',
+      default: defaultValue || DEFAULT_LLM_REASONING_EFFORT,
+      choices: LLM_REASONING_EFFORTS.map((effort) => ({
+        name: effort,
+        value: effort,
+      })),
+    });
+  }
+
+  private async promptLlmStreaming(defaultValue?: boolean): Promise<boolean> {
+    const { stream } = await prompt<{ stream: boolean }>([
+      {
+        type: 'confirm',
+        name: 'stream',
+        message: 'Use streaming LLM responses?',
+        default: defaultValue === true,
+      },
+    ]);
+
+    return stream;
   }
 
   private async promptUsername(): Promise<string> {

--- a/src/orchestration/provider.ts
+++ b/src/orchestration/provider.ts
@@ -1,13 +1,15 @@
-import { configService, prompt, selectPrompt, ui } from '../infra/index.js';
+import { configService, DEFAULT_LLM_REASONING_EFFORT, LLM_REASONING_EFFORTS, parseLLMReasoningEffort, prompt, selectPrompt, ui } from '../infra/index.js';
 import { LLM_PROVIDER_PRESETS, findLLMProviderPreset } from '../services/index.js';
 import { llmService } from '../services/index.js';
-import type { AppConfig, LLMProvider, LLMProviderProfile } from '../types/index.js';
+import type { AppConfig, LLMProvider, LLMProviderProfile, LLMReasoningEffort } from '../types/index.js';
 
 interface ProviderAddOptions {
   provider?: string;
   baseUrl?: string;
   model?: string;
   apiKey?: string;
+  reasoningEffort?: string;
+  stream?: string;
   header?: string[];
   validate?: boolean;
 }
@@ -64,6 +66,23 @@ function requireValue(value: string | undefined, label: string): string {
   return trimmed;
 }
 
+function parseBooleanOption(value: string | undefined, label: string): boolean {
+  if (value === undefined) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  throw new Error(`${label} must be true or false.`);
+}
+
 export class ProviderOrchestrator {
   async list(): Promise<void> {
     const config = await configService.get();
@@ -100,6 +119,8 @@ export class ProviderOrchestrator {
         ],
         lines: [
           `API key: ${ui.maskSecret(profile.apiKey)}`,
+          `Reasoning effort: ${profile.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
+          `Streaming: ${profile.stream ? 'yes' : 'no'}`,
           `Extra headers: ${Object.keys(profile.apiHeaders || {}).length > 0 ? JSON.stringify(profile.apiHeaders) : '(none)'}`,
         ],
         tone: config.llm.activeProfile === name ? 'success' : 'info',
@@ -137,6 +158,10 @@ export class ProviderOrchestrator {
       modelName: requireValue(options.model, 'model'),
       apiKey: requireValue(options.apiKey, 'API key'),
       apiHeaders: parseHeaders(options.header?.filter(Boolean) ?? []),
+      reasoningEffort: options.reasoningEffort
+        ? parseLLMReasoningEffort(options.reasoningEffort)
+        : DEFAULT_LLM_REASONING_EFFORT,
+      stream: parseBooleanOption(options.stream, 'stream'),
     };
     const updated = await this.saveProfile(config, name, profile, config.llm.activeProfile);
 
@@ -148,6 +173,8 @@ export class ProviderOrchestrator {
         `Profile: ${name}`,
         `Provider: ${profile.provider}`,
         `Model: ${profile.modelName}`,
+        `Reasoning effort: ${profile.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
+        `Streaming: ${profile.stream ? 'yes' : 'no'}`,
         `Endpoint: ${profile.apiBaseUrl}`,
         `Active profile: ${updated.llm.activeProfile || '(none)'}`,
       ],
@@ -248,6 +275,9 @@ export class ProviderOrchestrator {
       },
     ]);
 
+    const reasoningEffort = await this.promptReasoningEffort(config.llm.reasoningEffort);
+    const stream = await this.promptLlmStreaming(config.llm.stream);
+
     const { extraHeaders } = await prompt<{ extraHeaders: string }>([
       {
         type: 'input',
@@ -292,6 +322,8 @@ export class ProviderOrchestrator {
       apiBaseUrl,
       modelName,
       apiKey: apiKey.trim(),
+      reasoningEffort,
+      stream,
       apiHeaders: {
         ...(preset.apiHeaders || {}),
         ...parseHeaderInput(extraHeaders),
@@ -313,6 +345,8 @@ export class ProviderOrchestrator {
         `Profile: ${name}`,
         `Provider: ${profile.provider}`,
         `Model: ${profile.modelName}`,
+        `Reasoning effort: ${profile.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
+        `Streaming: ${profile.stream ? 'yes' : 'no'}`,
         `Endpoint: ${profile.apiBaseUrl}`,
       ],
       tone: 'success',
@@ -332,6 +366,8 @@ export class ProviderOrchestrator {
         ...config.llm,
         ...profile,
         apiHeaders: profile.apiHeaders ?? config.llm.apiHeaders ?? {},
+        reasoningEffort: profile.reasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT,
+        stream: profile.stream === true,
         activeProfile: name,
         profiles: config.llm.profiles ?? {},
       },
@@ -355,6 +391,8 @@ export class ProviderOrchestrator {
         `Profile: ${name}`,
         `Provider: ${updated.llm.provider}`,
         `Model: ${updated.llm.modelName}`,
+        `Reasoning effort: ${updated.llm.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
+        `Streaming: ${updated.llm.stream ? 'yes' : 'no'}`,
         `Endpoint: ${updated.llm.apiBaseUrl}`,
         validationDetail,
       ],
@@ -433,6 +471,8 @@ export class ProviderOrchestrator {
       apiKey: config.llm.apiKey,
       modelName: config.llm.modelName,
       apiHeaders: config.llm.apiHeaders ?? {},
+      reasoningEffort: config.llm.reasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT,
+      stream: config.llm.stream === true,
     };
   }
 
@@ -451,6 +491,8 @@ export class ProviderOrchestrator {
           [name]: {
             ...profile,
             apiHeaders: profile.apiHeaders ?? {},
+            reasoningEffort: profile.reasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT,
+            stream: profile.stream === true,
           },
         },
       },
@@ -464,9 +506,35 @@ export class ProviderOrchestrator {
       profile.modelName,
       profile.apiHeaders,
       profile.provider,
+      profile.reasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT,
+      profile.stream === true,
     );
 
     return llmService.validateConnection();
+  }
+
+  private async promptReasoningEffort(defaultValue?: AppConfig['llm']['reasoningEffort']): Promise<LLMReasoningEffort> {
+    return selectPrompt<LLMReasoningEffort>({
+      message: 'Select reasoning effort:',
+      default: defaultValue || DEFAULT_LLM_REASONING_EFFORT,
+      choices: LLM_REASONING_EFFORTS.map((effort) => ({
+        name: effort,
+        value: effort,
+      })),
+    });
+  }
+
+  private async promptLlmStreaming(defaultValue?: boolean): Promise<boolean> {
+    const { stream } = await prompt<{ stream: boolean }>([
+      {
+        type: 'confirm',
+        name: 'stream',
+        message: 'Use streaming LLM responses?',
+        default: defaultValue === true,
+      },
+    ]);
+
+    return stream;
   }
 }
 

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -1,4 +1,4 @@
-import type { PatchDraft, PullRequestDraft } from '../contracts/index.js';
+import type { PatchDraft, PullRequestDraft, RepositoryImprovementSuggestion } from '../contracts/index.js';
 import type {
   ContentType,
   ContributionInboxItem,
@@ -133,6 +133,84 @@ export class ContentService {
       '',
       this.formatPullRequestDraftBody(draft),
     ].join('\n');
+  }
+
+  formatRepositoryAnalysisMarkdown(
+    repoFullName: string,
+    workspace: RepoWorkspaceContext,
+    suggestions: RepositoryImprovementSuggestion[],
+    selectedSuggestion?: RepositoryImprovementSuggestion,
+  ): string {
+    const lines = [
+      `# Repository Analysis - ${repoFullName}`,
+      '',
+      '## Workspace',
+      '',
+      `- Workspace Path: ${workspace.workspacePath}`,
+      `- Default Branch: ${workspace.defaultBranch}`,
+      `- Analysis Branch: ${workspace.branchName || 'not created'}`,
+      `- Workspace Dirty: ${workspace.workspaceDirty}`,
+      `- Top-Level Files: ${workspace.topLevelFiles.slice(0, 12).join(', ') || 'n/a'}`,
+      `- Candidate Files: ${workspace.candidateFiles.join(', ') || 'n/a'}`,
+      '',
+      '## Detected Validation',
+      '',
+      ...(workspace.testCommands.length > 0
+        ? workspace.testCommands.map((command) => `- \`${command.command}\` | ${command.reason} | ${command.source}`)
+        : ['- None detected']),
+      '',
+    ];
+
+    if (selectedSuggestion) {
+      lines.push(
+        '## Selected Suggestion',
+        '',
+        ...this.formatRepositorySuggestionMarkdown(selectedSuggestion),
+        '',
+      );
+    }
+
+    lines.push(
+      '## Suggestions',
+      '',
+      ...(suggestions.length > 0
+        ? suggestions.flatMap((suggestion) => [
+          `### ${suggestion.title}`,
+          '',
+          ...this.formatRepositorySuggestionMarkdown(suggestion),
+          '',
+        ])
+        : ['- No repository suggestions were generated.', '']),
+      `_Generated at ${new Date().toISOString()}_`,
+      '',
+    );
+
+    return lines.join('\n');
+  }
+
+  private formatRepositorySuggestionMarkdown(suggestion: RepositoryImprovementSuggestion): string[] {
+    return [
+      `ID: ${suggestion.id}`,
+      `PR Potential: ${suggestion.prPotentialScore}/100`,
+      `Estimated Workload: ${suggestion.estimatedWorkload}`,
+      '',
+      suggestion.summary,
+      '',
+      'Rationale:',
+      suggestion.rationale,
+      '',
+      'Target Files:',
+      ...suggestion.targetFiles.map((file) => `- \`${file.path}\` | ${file.reason}`),
+      '',
+      'Proposed Changes:',
+      ...suggestion.proposedChanges.map((change) => `- ${change}`),
+      '',
+      'Validation Plan:',
+      ...(suggestion.validationPlan.length > 0 ? suggestion.validationPlan.map((step) => `- ${step}`) : ['- Not specified']),
+      '',
+      'Risks:',
+      ...(suggestion.risks.length > 0 ? suggestion.risks.map((risk) => `- ${risk}`) : ['- None']),
+    ];
   }
 
   formatContributionDossier(

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -3,7 +3,7 @@ import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-meth
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { GitHubIssue } from '../types/index.js';
-import { ensureDirectory, getOpenMetaStateDir } from '../infra/index.js';
+import { ensureDirectory, getOpenMetaStateDir, parseGitHubRepoFullName } from '../infra/index.js';
 import { logger } from '../infra/logger.js';
 
 const FILTER_LABEL_GROUPS = [
@@ -54,6 +54,7 @@ interface IssueCachePayload {
 
 interface IssueDiscoveryOptions {
   refresh?: boolean;
+  repoFullName?: string;
   onStatus?: (message: string) => void;
 }
 
@@ -95,8 +96,10 @@ export class GitHubService {
       throw new Error('GitHub service not initialized');
     }
 
+    const repoFullName = options.repoFullName ? parseGitHubRepoFullName(options.repoFullName) : undefined;
+
     if (!options.refresh) {
-      const cachedIssues = this.loadCachedIssues();
+      const cachedIssues = this.loadCachedIssues(repoFullName);
       if (cachedIssues) {
         logger.info(`Using cached GitHub issues (${cachedIssues.length}) to avoid unnecessary Search API calls.`);
         return cachedIssues;
@@ -112,14 +115,14 @@ export class GitHubService {
     const failures: SearchFailure[] = [];
 
     try {
-      for (const labelGroup of FILTER_LABEL_GROUPS) {
+      if (repoFullName) {
         try {
-          const searchQuery = this.buildSearchQuery(labelGroup);
-          options.onStatus?.(this.buildSearchStatusMessage(labelGroup));
-          const items = await this.paginateSearchWithRetry(searchQuery, labelGroup, options.onStatus);
+          const searchQuery = this.buildRepositorySearchQuery(repoFullName);
+          options.onStatus?.(`Pulling open issue candidates for ${repoFullName}...`);
+          const items = await this.paginateSearchWithRetry(searchQuery, [repoFullName], options.onStatus);
 
           logger.debug(`Search query: ${searchQuery}`);
-          logger.debug(`Fetched ${items.length} total results for "${labelGroup.join(' / ')}"`);
+          logger.debug(`Fetched ${items.length} total results for "${repoFullName}"`);
 
           for (const item of items) {
             if (!this.shouldIncludeIssue(item)) {
@@ -138,9 +141,41 @@ export class GitHubService {
           }
         } catch (error) {
           const failure = this.describeSearchFailure(error);
-          failures.push({ labelGroup, ...failure });
-          logger.debug(`Issue search failed for labels "${labelGroup.join('" / "')}". ${failure.reason}`);
+          failures.push({ labelGroup: [repoFullName], ...failure });
+          logger.debug(`Issue search failed for repository "${repoFullName}". ${failure.reason}`);
           options.onStatus?.('GitHub search is being stubborn, but OpenMeta is still pulling together the best issue set it can.');
+        }
+      } else {
+        for (const labelGroup of FILTER_LABEL_GROUPS) {
+          try {
+            const searchQuery = this.buildSearchQuery(labelGroup);
+            options.onStatus?.(this.buildSearchStatusMessage(labelGroup));
+            const items = await this.paginateSearchWithRetry(searchQuery, labelGroup, options.onStatus);
+
+            logger.debug(`Search query: ${searchQuery}`);
+            logger.debug(`Fetched ${items.length} total results for "${labelGroup.join(' / ')}"`);
+
+            for (const item of items) {
+              if (!this.shouldIncludeIssue(item)) {
+                continue;
+              }
+
+              const repoId = this.parseRepositoryUrl(item.repository_url);
+              const issueKey = `${repoId.fullName}#${item.number}`;
+
+              if (seenIssueKeys.has(issueKey)) {
+                continue;
+              }
+
+              seenIssueKeys.add(issueKey);
+              candidateItems.push(item);
+            }
+          } catch (error) {
+            const failure = this.describeSearchFailure(error);
+            failures.push({ labelGroup, ...failure });
+            logger.debug(`Issue search failed for labels "${labelGroup.join('" / "')}". ${failure.reason}`);
+            options.onStatus?.('GitHub search is being stubborn, but OpenMeta is still pulling together the best issue set it can.');
+          }
         }
       }
 
@@ -172,8 +207,10 @@ export class GitHubService {
         });
       }
 
-      logger.success(`Fetched ${issues.length} trending issues from ${FILTER_LABEL_GROUPS.length} label searches`);
-      this.saveCachedIssues(issues);
+      logger.success(repoFullName
+        ? `Fetched ${issues.length} open issues from ${repoFullName}`
+        : `Fetched ${issues.length} trending issues from ${FILTER_LABEL_GROUPS.length} label searches`);
+      this.saveCachedIssues(issues, repoFullName);
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('GitHub issue discovery')) {
         throw error;
@@ -184,6 +221,47 @@ export class GitHubService {
     }
 
     return issues;
+  }
+
+  async fetchIssue(repoFullName: string, issueNumber: number): Promise<GitHubIssue> {
+    if (!this.octokit) {
+      throw new Error('GitHub service not initialized');
+    }
+
+    const normalizedRepo = parseGitHubRepoFullName(repoFullName);
+    const [owner, repo] = normalizedRepo.split('/');
+    if (!owner || !repo) {
+      throw new Error(`Invalid GitHub repository reference: ${repoFullName}`);
+    }
+
+    const response = await this.octokit.rest.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+    const item = response.data as SearchIssueItem;
+
+    if (!this.shouldIncludeIssue(item)) {
+      throw new Error(`${normalizedRepo}#${issueNumber} cannot be handled automatically because it is a pull request, locked, assigned, or carries an action-blocking label.`);
+    }
+
+    const repoId = this.parseRepositoryUrl(item.repository_url || `https://api.github.com/repos/${normalizedRepo}`);
+    const repoData = await this.fetchRepoMetadata(repoId, new Map());
+
+    return {
+      id: item.id,
+      number: item.number,
+      title: item.title,
+      body: item.body || '',
+      htmlUrl: item.html_url,
+      repoName: repoId.repo,
+      repoFullName: repoId.fullName,
+      repoDescription: repoData.description,
+      repoStars: repoData.stars,
+      labels: this.extractLabelNames(item),
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+    };
   }
 
   async validateTargetRepo(path: string): Promise<boolean> {
@@ -201,9 +279,14 @@ export class GitHubService {
     return this.username;
   }
 
-  private buildSearchQuery(labels: readonly string[]): string {
+  private buildSearchQuery(labels: readonly string[], repoFullName?: string): string {
     const joinedLabels = labels.map((label) => `label:"${label}"`).join(' OR ');
-    return `(${joinedLabels}) archived:false is:issue is:open no:assignee`;
+    const repoScope = repoFullName ? `repo:${repoFullName} ` : '';
+    return `${repoScope}(${joinedLabels}) archived:false is:issue is:open no:assignee`;
+  }
+
+  private buildRepositorySearchQuery(repoFullName: string): string {
+    return `repo:${repoFullName} archived:false is:issue is:open no:assignee`;
   }
 
   private shouldIncludeIssue(item: SearchIssueItem): boolean {
@@ -467,12 +550,15 @@ export class GitHubService {
     return `GitHub issue discovery failed for all label groups: ${failures.map((failure) => failure.labelGroup.join('/')).join(', ')}.`;
   }
 
-  private getCachePath(): string {
-    return join(ensureDirectory(join(getOpenMetaStateDir(), 'cache')), 'github-issues.json');
+  private getCachePath(repoFullName?: string): string {
+    const cacheFile = repoFullName
+      ? `github-issues-${repoFullName.replace(/\//g, '__')}.json`
+      : 'github-issues.json';
+    return join(ensureDirectory(join(getOpenMetaStateDir(), 'cache')), cacheFile);
   }
 
-  private loadCachedIssues(): GitHubIssue[] | null {
-    const cachePath = this.getCachePath();
+  private loadCachedIssues(repoFullName?: string): GitHubIssue[] | null {
+    const cachePath = this.getCachePath(repoFullName);
     if (!existsSync(cachePath)) {
       return null;
     }
@@ -495,14 +581,14 @@ export class GitHubService {
     }
   }
 
-  private saveCachedIssues(issues: GitHubIssue[]): void {
+  private saveCachedIssues(issues: GitHubIssue[], repoFullName?: string): void {
     try {
       const payload: IssueCachePayload = {
         fetchedAt: new Date().toISOString(),
         issues,
       };
 
-      writeFileSync(this.getCachePath(), JSON.stringify(payload, null, 2), 'utf-8');
+      writeFileSync(this.getCachePath(repoFullName), JSON.stringify(payload, null, 2), 'utf-8');
     } catch (error) {
       logger.debug('Unable to save GitHub issue cache', error);
     }

--- a/src/services/issue-ranking.ts
+++ b/src/services/issue-ranking.ts
@@ -36,9 +36,13 @@ const FOCUS_AREA_TERMS: Record<string, string[]> = {
 export class IssueRankingService {
   async loadRankedIssues(
     config: AppConfig,
-    options: { refresh?: boolean; localOnly?: boolean; onStatus?: (message: string) => void } = {},
+    options: { refresh?: boolean; repoFullName?: string; localOnly?: boolean; onStatus?: (message: string) => void } = {},
   ): Promise<RankedIssue[]> {
-    const issues = await githubService.fetchTrendingIssues({ refresh: options.refresh, onStatus: options.onStatus });
+    const issues = await githubService.fetchTrendingIssues({
+      refresh: options.refresh,
+      repoFullName: options.repoFullName,
+      onStatus: options.onStatus,
+    });
     const rankedCandidates = this.rankIssuesForProfile(issues, config.userProfile);
     if (options.localOnly) {
       return opportunityService.rankIssues(this.buildLocalIssueMatches(rankedCandidates, config.userProfile));
@@ -46,6 +50,19 @@ export class IssueRankingService {
 
     const matched = await this.scoreIssuesInBatches(config.userProfile, rankedCandidates);
     return opportunityService.rankIssues(matched);
+  }
+
+  async loadTargetIssue(
+    config: AppConfig,
+    target: { repoFullName: string; issueNumber: number },
+  ): Promise<RankedIssue[]> {
+    const issue = await githubService.fetchIssue(target.repoFullName, target.issueNumber);
+    const [matched] = await this.scoreIssuesInBatches(config.userProfile, [issue]);
+    if (!matched) {
+      return opportunityService.rankIssues(this.buildLocalIssueMatches([issue], config.userProfile));
+    }
+
+    return opportunityService.rankIssues([matched]);
   }
 
   buildLocalIssueMatches(

--- a/src/services/llm.providers.ts
+++ b/src/services/llm.providers.ts
@@ -16,6 +16,11 @@ export const LLM_PROVIDER_PRESETS: LLMProviderPreset[] = [
     value: 'openai',
     baseUrl: 'https://api.openai.com/v1',
     models: [
+      { name: 'GPT-5.5', value: 'gpt-5.5' },
+      { name: 'GPT-5.4', value: 'gpt-5.4' },
+      { name: 'GPT-5.4 mini', value: 'gpt-5.4-mini' },
+      { name: 'GPT-5.1', value: 'gpt-5.1' },
+      { name: 'GPT-5', value: 'gpt-5' },
       { name: 'GPT-4o-mini', value: 'gpt-4o-mini' },
       { name: 'GPT-4o', value: 'gpt-4o' },
       { name: 'GPT-4-turbo', value: 'gpt-4-turbo' },

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -4,10 +4,12 @@ import {
   ImplementationDraftEnvelopeSchema,
   IssueMatchListEnvelopeSchema,
   PatchDraftEnvelopeSchema,
+  RepositorySuggestionListEnvelopeSchema,
   type StructuredOutputResult,
   type PatchDraft,
   PullRequestDraftEnvelopeSchema,
   type PullRequestDraft,
+  type RepositoryImprovementSuggestion,
 } from '../contracts/index.js';
 import type {
   GitHubIssue,
@@ -41,6 +43,8 @@ import {
   PATCH_DRAFT_PROMPT,
   PATCH_DRAFT_REPAIR_PROMPT,
   PR_DRAFT_PROMPT,
+  REPOSITORY_ANALYSIS_PROMPT,
+  REPOSITORY_ANALYSIS_REPAIR_PROMPT,
   VALIDATION_REPAIR_PROMPT,
 } from '../infra/prompt-templates.js';
 
@@ -199,6 +203,38 @@ Repo Stars: ${i.repoStars}`
       prompt,
       parser: this.parsePatchDraft.bind(this),
       repairPrompt: PATCH_DRAFT_REPAIR_PROMPT,
+    });
+  }
+
+  async analyzeRepository(
+    repoFullName: string,
+    workspace: RepoWorkspaceContext,
+    memory: RepoMemory,
+  ): Promise<StructuredOutputResult<'repository_suggestion_list', RepositoryImprovementSuggestion[]>> {
+    const repoContext = [
+      `Repository: ${repoFullName}`,
+      `Workspace Path: ${workspace.workspacePath}`,
+      `Default Branch: ${workspace.defaultBranch}`,
+      `Workspace Dirty: ${workspace.workspaceDirty}`,
+      `Top-Level Files: ${workspace.topLevelFiles.join(', ') || 'none'}`,
+      `Candidate Files: ${workspace.candidateFiles.join(', ') || 'none'}`,
+      `Detected Test Commands: ${workspace.testCommands.map((item) => item.command).join(', ') || 'none'}`,
+      `Runnable Validation Commands: ${workspace.validationCommands.map((item) => item.command).join(', ') || 'none'}`,
+      `Validation Safety Notes: ${workspace.validationWarnings.join(' | ') || 'none'}`,
+      'Snippets:',
+      ...workspace.snippets.map((snippet) => `FILE: ${snippet.path}\n${snippet.content}`),
+    ].join('\n\n');
+
+    const prompt = fillPrompt(REPOSITORY_ANALYSIS_PROMPT, {
+      repoContext,
+      repoMemory: this.formatRepoMemory(memory),
+    });
+
+    return this.generateStructuredOutput({
+      prompt,
+      parser: this.parseRepositorySuggestions.bind(this),
+      repairPrompt: REPOSITORY_ANALYSIS_REPAIR_PROMPT,
+      temperature: 0.2,
     });
   }
 
@@ -462,6 +498,19 @@ Repo Stars: ${i.repoStars}`
     content: string,
   ): StructuredOutputResult<'pull_request_draft', PullRequestDraft> {
     return this.parseStructuredJson(content, PullRequestDraftEnvelopeSchema);
+  }
+
+  private parseRepositorySuggestions(
+    content: string,
+  ): StructuredOutputResult<'repository_suggestion_list', RepositoryImprovementSuggestion[]> {
+    const parsed = this.parseStructuredJson(content, RepositorySuggestionListEnvelopeSchema);
+
+    return {
+      version: parsed.version,
+      kind: parsed.kind,
+      status: parsed.status,
+      data: parsed.data.suggestions,
+    };
   }
 
   private parseStructuredJson<T>(content: string, schema: z.ZodType<T>): T {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -13,6 +13,7 @@ import type {
   GitHubIssue,
   ImplementationDraft,
   LLMProvider,
+  LLMReasoningEffort,
   MatchedIssue,
   RankedIssue,
   RepoFileSnippet,
@@ -47,6 +48,8 @@ export class LLMService {
   private client: OpenAI | null = null;
   private modelName: string = 'gpt-4o-mini';
   private provider: LLMProvider = 'openai';
+  private reasoningEffort: LLMReasoningEffort | undefined;
+  private stream = false;
   private lastValidationError: string | null = null;
 
   initialize(
@@ -55,6 +58,8 @@ export class LLMService {
     modelName?: string,
     apiHeaders?: Record<string, string>,
     provider?: LLMProvider,
+    reasoningEffort?: LLMReasoningEffort,
+    stream?: boolean,
   ): void {
     this.client = new OpenAI({
       apiKey,
@@ -67,6 +72,8 @@ export class LLMService {
     if (provider) {
       this.provider = provider;
     }
+    this.reasoningEffort = reasoningEffort;
+    this.stream = stream === true;
   }
 
   async validateConnection(): Promise<boolean> {
@@ -84,6 +91,7 @@ export class LLMService {
           model: this.modelName,
           messages: [{ role: 'user', content: LLM_VALIDATION_PROMPT }],
           ...LLM_VALIDATION_REQUEST,
+          ...this.getReasoningRequestParams(),
         }, {
           signal: controller.signal,
         });
@@ -282,14 +290,79 @@ Repo Stars: ${i.repoStars}`
           { role: 'user', content: prompt },
         ],
         temperature: options.temperature ?? 0.7,
+        ...(this.stream
+          ? {
+            stream: true,
+            stream_options: {
+              include_usage: true,
+            },
+          }
+          : {}),
+        ...this.getReasoningRequestParams(),
       });
 
-      const content = response.choices[0]?.message?.content || '';
-      return content;
+      return await this.extractChatContent(response);
     } catch (error) {
       logger.debug('LLM chat failed', error);
       throw new Error('The LLM request failed. Please verify your provider, model, and API key.');
     }
+  }
+
+  private async extractChatContent(response: unknown): Promise<string> {
+    if (this.isAsyncIterable(response)) {
+      let content = '';
+
+      for await (const chunk of response) {
+        content += this.extractStreamChunkContent(chunk);
+      }
+
+      return content;
+    }
+
+    return this.extractNonStreamingContent(response);
+  }
+
+  private isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+    return typeof value === 'object' &&
+      value !== null &&
+      Symbol.asyncIterator in value &&
+      typeof (value as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === 'function';
+  }
+
+  private extractStreamChunkContent(chunk: unknown): string {
+    if (typeof chunk !== 'object' || chunk === null || !('choices' in chunk) || !Array.isArray(chunk.choices)) {
+      return '';
+    }
+
+    const [choice] = chunk.choices;
+    if (typeof choice !== 'object' || choice === null || !('delta' in choice)) {
+      return '';
+    }
+
+    const delta = choice.delta;
+    if (typeof delta !== 'object' || delta === null || !('content' in delta)) {
+      return '';
+    }
+
+    return typeof delta.content === 'string' ? delta.content : '';
+  }
+
+  private extractNonStreamingContent(response: unknown): string {
+    if (typeof response !== 'object' || response === null || !('choices' in response) || !Array.isArray(response.choices)) {
+      return '';
+    }
+
+    const [choice] = response.choices;
+    if (typeof choice !== 'object' || choice === null || !('message' in choice)) {
+      return '';
+    }
+
+    const message = choice.message;
+    if (typeof message !== 'object' || message === null || !('content' in message)) {
+      return '';
+    }
+
+    return typeof message.content === 'string' ? message.content : '';
   }
 
   private async generateStructuredOutput<T>(input: {
@@ -350,6 +423,22 @@ Repo Stars: ${i.repoStars}`
           }];
         }),
     };
+  }
+
+  private getReasoningRequestParams(): { reasoning_effort?: LLMReasoningEffort } {
+    if (!this.reasoningEffort || !this.supportsReasoningEffort()) {
+      return {};
+    }
+
+    return { reasoning_effort: this.reasoningEffort };
+  }
+
+  private supportsReasoningEffort(): boolean {
+    const normalizedModel = this.modelName.toLowerCase();
+    return normalizedModel.startsWith('gpt-5') ||
+      normalizedModel.startsWith('o1') ||
+      normalizedModel.startsWith('o3') ||
+      normalizedModel.startsWith('o4');
   }
 
   private parseImplementationDraft(

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -91,6 +91,7 @@ export class LLMService {
           model: this.modelName,
           messages: [{ role: 'user', content: LLM_VALIDATION_PROMPT }],
           ...LLM_VALIDATION_REQUEST,
+          ...this.getStreamingRequestParams(),
           ...this.getReasoningRequestParams(),
         }, {
           signal: controller.signal,
@@ -98,7 +99,7 @@ export class LLMService {
 
         // 自定义兼容端点最容易把站点页面或其他 200 响应误判为可用，所以这里额外校验返回结构。
         if (this.provider === 'custom') {
-          this.assertCustomValidationResponse(response);
+          await this.assertCustomValidationResponse(response);
         }
       } finally {
         clearTimeout(timeout);
@@ -290,14 +291,7 @@ Repo Stars: ${i.repoStars}`
           { role: 'user', content: prompt },
         ],
         temperature: options.temperature ?? 0.7,
-        ...(this.stream
-          ? {
-            stream: true,
-            stream_options: {
-              include_usage: true,
-            },
-          }
-          : {}),
+        ...this.getStreamingRequestParams(),
         ...this.getReasoningRequestParams(),
       });
 
@@ -431,6 +425,19 @@ Repo Stars: ${i.repoStars}`
     }
 
     return { reasoning_effort: this.reasoningEffort };
+  }
+
+  private getStreamingRequestParams(): { stream?: true; stream_options?: { include_usage: true } } {
+    if (!this.stream) {
+      return {};
+    }
+
+    return {
+      stream: true,
+      stream_options: {
+        include_usage: true,
+      },
+    };
   }
 
   private supportsReasoningEffort(): boolean {
@@ -616,7 +623,15 @@ Repo Stars: ${i.repoStars}`
     return error instanceof Error && (error.name === 'AbortError' || error.message.toLowerCase().includes('aborted'));
   }
 
-  private assertCustomValidationResponse(response: unknown): void {
+  private async assertCustomValidationResponse(response: unknown): Promise<void> {
+    if (this.isAsyncIterable(response)) {
+      const content = await this.extractChatContent(response);
+      if (content.trim().length === 0) {
+        throw new Error('Custom provider validation response did not include a usable assistant reply.');
+      }
+      return;
+    }
+
     if (typeof response !== 'object' || response === null) {
       throw new Error('Custom provider validation response did not match the expected OpenAI-compatible format.');
     }

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -55,57 +55,54 @@ export class WorkspaceService {
     executionMode: ExecutionMode = 'interactive',
   ): Promise<RepoWorkspaceContext> {
     const workspacePath = this.getWorkspacePath(issue.repoFullName);
-    const repoUrl = `https://github.com/${issue.repoFullName}.git`;
-
-    if (!existsSync(workspacePath)) {
-      mkdirSync(dirname(workspacePath), { recursive: true });
-      await simpleGit().clone(repoUrl, workspacePath);
-    }
-
-    const git = simpleGit(workspacePath);
-    await git.fetch('origin');
-
-    const defaultBranch = await this.detectDefaultBranch(git);
-    const status = await git.status();
-    const workspaceDirty = status.files.length > 0;
-    const branchName = workspaceDirty ? undefined : await this.createWorkspaceBranchName(git, issue);
-
-    if (!workspaceDirty && branchName) {
-      await git.checkout(defaultBranch);
-      try {
-        await git.pull('origin', defaultBranch);
-      } catch (error) {
-        logger.debug('Unable to fast-forward workspace before branch creation', error);
-      }
-
-      await git.checkoutLocalBranch(branchName);
-    }
-
-    const topLevelFiles = readdirSync(workspacePath).slice(0, 50);
-    const discoveredFiles = this.discoverFiles(workspacePath);
-    const candidateFiles = this.rankCandidateFiles(issue, memory, discoveredFiles).slice(0, 8);
-    const snippets = candidateFiles.map((path) => ({
-      path,
-      content: this.readSnippet(join(workspacePath, path)),
-    }));
-    const testCommands = this.detectTestCommands(workspacePath);
-    const { commands: validationCommands, warnings: validationWarnings } =
-      this.selectValidationCommands(testCommands, executionMode);
-    const testResults = runChecks ? this.runTestCommands(workspacePath, validationCommands.slice(0, 3)) : [];
-
-    return {
+    const workspaceState = await this.prepareGitWorkspace(
+      issue.repoFullName,
       workspacePath,
-      workspaceDirty,
-      defaultBranch,
-      branchName,
-      topLevelFiles,
+      (git) => this.createWorkspaceBranchName(git, issue),
+    );
+    const candidateFiles = this.rankCandidateFiles(
+      issue,
+      memory,
+      this.discoverFiles(workspacePath),
+    ).slice(0, 8);
+
+    return this.buildWorkspaceContext({
+      workspacePath,
+      workspaceDirty: workspaceState.workspaceDirty,
+      defaultBranch: workspaceState.defaultBranch,
+      branchName: workspaceState.branchName,
       candidateFiles,
-      snippets,
-      testCommands,
-      validationCommands,
-      validationWarnings,
-      testResults,
-    };
+      runChecks,
+      executionMode,
+    });
+  }
+
+  async prepareRepositoryWorkspace(
+    repoFullName: string,
+    memory: RepoMemory,
+    runChecks: boolean,
+    executionMode: ExecutionMode = 'interactive',
+  ): Promise<RepoWorkspaceContext> {
+    const workspacePath = this.getWorkspacePath(repoFullName);
+    const workspaceState = await this.prepareGitWorkspace(
+      repoFullName,
+      workspacePath,
+      (git) => this.createRepositoryAnalysisBranchName(git, repoFullName),
+    );
+    const candidateFiles = this.rankRepositoryAnalysisFiles(
+      memory,
+      this.discoverFiles(workspacePath),
+    ).slice(0, 12);
+
+    return this.buildWorkspaceContext({
+      workspacePath,
+      candidateFiles,
+      workspaceDirty: workspaceState.workspaceDirty,
+      defaultBranch: workspaceState.defaultBranch,
+      branchName: workspaceState.branchName,
+      runChecks,
+      executionMode,
+    });
   }
 
   applyGeneratedChanges(
@@ -225,8 +222,94 @@ export class WorkspaceService {
     }
   }
 
+  private buildRepoUrl(repoFullName: string): string {
+    return `https://github.com/${repoFullName}.git`;
+  }
+
+  private async prepareGitWorkspace(
+    repoFullName: string,
+    workspacePath: string,
+    createBranchName: (git: SimpleGit) => Promise<string>,
+  ): Promise<{ defaultBranch: string; workspaceDirty: boolean; branchName?: string }> {
+    const repoUrl = this.buildRepoUrl(repoFullName);
+
+    if (!existsSync(workspacePath)) {
+      mkdirSync(dirname(workspacePath), { recursive: true });
+      await simpleGit().clone(repoUrl, workspacePath);
+    }
+
+    const git = simpleGit(workspacePath);
+    await git.fetch('origin');
+
+    const defaultBranch = await this.detectDefaultBranch(git);
+    const status = await git.status();
+    const workspaceDirty = status.files.length > 0;
+    const branchName = workspaceDirty ? undefined : await createBranchName(git);
+
+    if (!workspaceDirty && branchName) {
+      await git.checkout(defaultBranch);
+      try {
+        await git.pull('origin', defaultBranch);
+      } catch (error) {
+        logger.debug('Unable to fast-forward workspace before branch creation', error);
+      }
+
+      await git.checkoutLocalBranch(branchName);
+    }
+
+    return {
+      defaultBranch,
+      workspaceDirty,
+      branchName,
+    };
+  }
+
+  private buildWorkspaceContext(input: {
+    workspacePath: string;
+    workspaceDirty: boolean;
+    defaultBranch: string;
+    branchName?: string;
+    candidateFiles: string[];
+    runChecks: boolean;
+    executionMode: ExecutionMode;
+  }): RepoWorkspaceContext {
+    const topLevelFiles = readdirSync(input.workspacePath).slice(0, 50);
+    const snippets = input.candidateFiles.map((path) => ({
+      path,
+      content: this.readSnippet(join(input.workspacePath, path)),
+    }));
+    const testCommands = this.detectTestCommands(input.workspacePath);
+    const { commands: validationCommands, warnings: validationWarnings } =
+      this.selectValidationCommands(testCommands, input.executionMode);
+    const testResults = input.runChecks ? this.runTestCommands(input.workspacePath, validationCommands.slice(0, 3)) : [];
+
+    return {
+      workspacePath: input.workspacePath,
+      workspaceDirty: input.workspaceDirty,
+      defaultBranch: input.defaultBranch,
+      branchName: input.branchName,
+      topLevelFiles,
+      candidateFiles: input.candidateFiles,
+      snippets,
+      testCommands,
+      validationCommands,
+      validationWarnings,
+      testResults,
+    };
+  }
+
   private async createWorkspaceBranchName(git: SimpleGit, issue: RankedIssue): Promise<string> {
     const baseBranchName = `openmeta/${issue.number}-${slugify(issue.title) || 'issue'}`;
+    const localBranches = await git.branchLocal();
+    if (!localBranches.all.includes(baseBranchName)) {
+      return baseBranchName;
+    }
+
+    return `${baseBranchName}-${Date.now()}`;
+  }
+
+  private async createRepositoryAnalysisBranchName(git: SimpleGit, repoFullName: string): Promise<string> {
+    const baseBranchName = `openmeta/analyze-${slugify(repoFullName.replace(/\//g, '-')) || 'repo'}`;
     const localBranches = await git.branchLocal();
     if (!localBranches.all.includes(baseBranchName)) {
       return baseBranchName;
@@ -276,6 +359,64 @@ export class WorkspaceService {
 
     return [...files]
       .sort((left, right) => this.scorePath(right, keywords, memory, referencedPaths) - this.scorePath(left, keywords, memory, referencedPaths));
+  }
+
+  private rankRepositoryAnalysisFiles(memory: RepoMemory, files: string[]): string[] {
+    return [...files]
+      .sort((left, right) => this.scoreRepositoryAnalysisPath(right, memory) - this.scoreRepositoryAnalysisPath(left, memory));
+  }
+
+  private scoreRepositoryAnalysisPath(path: string, memory: RepoMemory): number {
+    let score = 0;
+    const lowerPath = path.toLowerCase();
+    const fileName = basename(lowerPath);
+    const pathSignal = (memory.pathSignals ?? []).find((signal) => signal.path === path);
+    const recentIssue = (memory.recentIssues ?? []).find((issue) => issue.changedFiles.includes(path));
+
+    if (memory.preferredPaths.some((candidate) => candidate === path)) {
+      score += 60;
+    }
+
+    if (pathSignal) {
+      score += pathSignal.candidateCount;
+      score += pathSignal.changedCount * 6;
+      score += pathSignal.successfulValidationCount * 10;
+      score += pathSignal.publishedCount * 14;
+    }
+
+    if (recentIssue) {
+      score += recentIssue.status === 'published' || recentIssue.status === 'pr_opened' ? 12 : 6;
+    }
+
+    if (fileName === 'readme.md') {
+      score += 62;
+    }
+
+    if (['package.json', 'pyproject.toml', 'cargo.toml', 'go.mod', 'makefile'].includes(fileName)) {
+      score += 68;
+    }
+
+    if (/(^|\/)(test|tests|__tests__)\/|\.test\.|\.spec\./.test(lowerPath)) {
+      score += 34;
+    }
+
+    if (/\.(ts|tsx|js|jsx|py|go|rs|java|kt)$/.test(fileName)) {
+      score += 28;
+    }
+
+    if (/\.(md|mdx)$/.test(fileName)) {
+      score += 12;
+    }
+
+    if (/\.(png|jpg|jpeg|gif|webp|ico|svg|lock|map)$/.test(fileName)) {
+      score -= 20;
+    }
+
+    if (lowerPath.includes('archive') || lowerPath.includes('vendor')) {
+      score -= 12;
+    }
+
+    return score;
   }
 
   private scorePath(path: string, keywords: string[], memory: RepoMemory, referencedPaths: string[]): number {

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -16,6 +16,7 @@ export interface GitHubConfig {
 }
 
 export type LLMProvider = 'openai' | 'minimax' | 'moonshot' | 'zhipu' | 'gemini' | 'claude' | 'custom';
+export type LLMReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface LLMProviderProfile {
   provider: LLMProvider;
@@ -23,6 +24,8 @@ export interface LLMProviderProfile {
   apiKey: string;
   modelName: string;
   apiHeaders: Record<string, string>;
+  reasoningEffort?: LLMReasoningEffort;
+  stream?: boolean;
 }
 
 export interface LLMConfig {
@@ -31,6 +34,8 @@ export interface LLMConfig {
   apiKey: string;
   modelName: string;
   apiHeaders?: Record<string, string>;
+  reasoningEffort?: LLMReasoningEffort;
+  stream?: boolean;
   activeProfile?: string;
   profiles?: Record<string, LLMProviderProfile>;
 }

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -114,6 +114,10 @@ interface AgentOrchestratorInternals {
     getRemotes(verbose: boolean): Promise<Array<{ name: string; refs: { fetch?: string; push?: string } }>>;
   }): Promise<string>;
   getGitHubRepositoryInfo(owner: string, repo: string): Promise<{ default_branch?: string }>;
+  detectLocalDefaultBranch(git: {
+    raw(args: string[]): Promise<string>;
+    branch(): Promise<{ all: string[]; current: string }>;
+  }): Promise<string>;
   prepareLocalRepository(git: {
     fetch(remote: string, branch: string): Promise<void>;
     checkout(args: string[] | string): Promise<void>;
@@ -855,6 +859,31 @@ describe('AgentOrchestrator support behavior', () => {
     }));
   });
 
+  test('detectLocalDefaultBranch prefers origin HEAD, common branch names, then the current branch', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
+
+    await expect(orchestrator.detectLocalDefaultBranch({
+      raw: async () => 'refs/remotes/origin/master\n',
+      branch: async () => {
+        throw new Error('branch should not be checked when origin HEAD exists');
+      },
+    })).resolves.toBe('master');
+
+    await expect(orchestrator.detectLocalDefaultBranch({
+      raw: async () => {
+        throw new Error('origin HEAD missing');
+      },
+      branch: async () => ({ all: ['openmeta-artifacts', 'main'], current: 'openmeta-artifacts' }),
+    })).resolves.toBe('main');
+
+    await expect(orchestrator.detectLocalDefaultBranch({
+      raw: async () => {
+        throw new Error('origin HEAD missing');
+      },
+      branch: async () => ({ all: ['feature'], current: 'feature' }),
+    })).resolves.toBe('feature');
+  });
+
   test('manages origin remotes, parses existing origin URLs, and fails clearly when origin is missing', async () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
     let addedRemote = '';
@@ -994,5 +1023,37 @@ describe('AgentOrchestrator support behavior', () => {
     expect(managedTarget.owner).toBe('octocat');
     expect(managedTarget.repo).toBe('openmeta-daily');
     expect(managedTarget.defaultBranch).toBe('main');
+  });
+
+  test('ensureTargetRepo falls back to the local default branch when configured target metadata is unavailable', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
+    const targetRepoPath = mkdtempSync(join(tmpdir(), 'openmeta-agent-target-repo-private-'));
+    tempDirs.push(targetRepoPath);
+
+    spyOn(simpleGitModule, 'simpleGit').mockImplementation(() => ({
+      getRemotes: async () => [{
+        name: 'origin',
+        refs: {
+          fetch: 'https://github.com/Zbl1007/openmeta.git',
+          push: 'https://github.com/Zbl1007/openmeta.git',
+        },
+      }],
+      raw: async () => 'refs/remotes/origin/master\n',
+      branch: async () => ({ all: ['master', 'openmeta-artifacts'], current: 'openmeta-artifacts' }),
+    } as never));
+    spyOn(orchestrator as object as { getGitHubRepositoryInfo: () => Promise<unknown> }, 'getGitHubRepositoryInfo').mockRejectedValue({ status: 404 });
+
+    await expect(orchestrator.ensureTargetRepo(createConfig({
+      github: {
+        pat: 'ghp_test_token',
+        username: 'zbl1007',
+        targetRepoPath,
+      },
+    }))).resolves.toEqual({
+      path: targetRepoPath,
+      owner: 'Zbl1007',
+      repo: 'openmeta',
+      defaultBranch: 'master',
+    });
   });
 });

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import * as infra from '../src/infra/index.js';
 import { AgentOrchestrator } from '../src/orchestration/agent.js';
+import { AnalyzeOrchestrator } from '../src/orchestration/analyze.js';
 import { contentService, inboxService, issueRankingService, llmService, memoryService, proofOfWorkService, workspaceService } from '../src/services/index.js';
 import type { AppConfig, ContributionAgentResult, RankedIssue } from '../src/types/index.js';
-import { createInboxItem, createMemory, createPatchDraft, createProofRecord, createPullRequestDraft, createRankedIssue, createWorkspace } from './helpers/factories.js';
+import { createInboxItem, createMemory, createPatchDraft, createProofRecord, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
 
 interface AgentRunInternals {
   run(options?: {
@@ -43,6 +44,25 @@ interface AgentRunInternals {
   writeLocalArtifacts(input: unknown): void;
   showResult(result: ContributionAgentResult): void;
   showStructuredReviewNotice(input: { title: string; subtitle: string; lines?: string[] }): void;
+}
+
+interface AnalyzeRunInternals {
+  run(options: {
+    repo?: string;
+    headless?: boolean;
+    runChecks?: boolean;
+    dryRun?: boolean;
+  }): Promise<void>;
+  initializeClients(config: AppConfig): Promise<void>;
+  promptForSuggestion<T>(suggestions: T[]): Promise<T>;
+  prepareArtifactPaths(repoFullName: string, suggestionId: string): {
+    artifactDir: string;
+    analysisPath: string;
+    patchDraftPath: string;
+    prDraftPath: string;
+  };
+  writeLocalArtifacts(input: unknown): void;
+  showResult(input: unknown): void;
 }
 
 function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
@@ -378,5 +398,100 @@ describe('AgentOrchestrator run flow', () => {
       reviewRequired: true,
     }));
     expect(showResultSpy).toHaveBeenCalled();
+  });
+});
+
+describe('AnalyzeOrchestrator run flow', () => {
+  test('analyzes a repository, selects the top suggestion in headless mode, and writes draft artifacts', async () => {
+    const orchestrator = new AnalyzeOrchestrator() as unknown as AnalyzeRunInternals;
+    const config = createConfig();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-demo',
+      branchName: 'openmeta/analyze-acme-demo',
+      candidateFiles: ['README.md', 'src/index.ts'],
+    });
+    const memory = createMemory({ repoFullName: 'acme/demo' });
+    const topSuggestion = createRepositorySuggestion({
+      id: 'config-validation',
+      title: 'Add config validation tests',
+      summary: 'Cover malformed provider config normalization.',
+      targetFiles: [{ path: 'src/infra/config.ts', reason: 'Normalization logic' }],
+      prPotentialScore: 93,
+    });
+    const lowerSuggestion = createRepositorySuggestion({
+      id: 'docs-install',
+      title: 'Document local install',
+      prPotentialScore: 75,
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const artifacts = {
+      artifactDir: '/tmp/openmeta/artifacts/analyze',
+      analysisPath: '/tmp/openmeta/artifacts/analyze/repository-analysis.md',
+      patchDraftPath: '/tmp/openmeta/artifacts/analyze/patch-draft.md',
+      prDraftPath: '/tmp/openmeta/artifacts/analyze/pr-draft.md',
+    };
+    const writeArtifactsSpy = spyOn(orchestrator as object as { writeLocalArtifacts: AnalyzeRunInternals['writeLocalArtifacts'] }, 'writeLocalArtifacts')
+      .mockImplementation(() => {});
+    const showResultSpy = spyOn(orchestrator as object as { showResult: AnalyzeRunInternals['showResult'] }, 'showResult')
+      .mockImplementation(() => {});
+    const promptForSuggestionSpy = spyOn(orchestrator as object as { promptForSuggestion: AnalyzeRunInternals['promptForSuggestion'] }, 'promptForSuggestion')
+      .mockResolvedValue(lowerSuggestion);
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as object as { initializeClients: AnalyzeRunInternals['initializeClients'] }, 'initializeClients').mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValue(memory);
+    spyOn(workspaceService, 'prepareRepositoryWorkspace').mockResolvedValue(workspace);
+    spyOn(llmService, 'analyzeRepository').mockResolvedValue({
+      version: '1',
+      kind: 'repository_suggestion_list',
+      status: 'success',
+      data: [lowerSuggestion, topSuggestion],
+    });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatRepositoryAnalysisMarkdown').mockReturnValue('# Repository Analysis');
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+    spyOn(orchestrator as object as { prepareArtifactPaths: AnalyzeRunInternals['prepareArtifactPaths'] }, 'prepareArtifactPaths')
+      .mockReturnValue(artifacts);
+
+    await orchestrator.run({ repo: 'https://github.com/acme/demo', headless: true });
+
+    expect(promptForSuggestionSpy).not.toHaveBeenCalled();
+    expect(workspaceService.prepareRepositoryWorkspace).toHaveBeenCalledWith('acme/demo', memory, false, 'headless');
+    expect(llmService.generatePatchDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoFullName: 'acme/demo',
+        number: 0,
+        title: 'Add config validation tests',
+        analysis: expect.objectContaining({
+          coreDemand: 'Cover malformed provider config normalization.',
+        }),
+      }),
+      workspace,
+      memory,
+    );
+    expect(writeArtifactsSpy).toHaveBeenCalledWith({
+      artifacts,
+      analysisMarkdown: '# Repository Analysis',
+      patchDraftMarkdown: '# Patch',
+      prDraftMarkdown: '# PR',
+    });
+    expect(showResultSpy).toHaveBeenCalledWith(expect.objectContaining({
+      repoFullName: 'acme/demo',
+      selectedSuggestion: topSuggestion,
+      artifacts,
+    }));
   });
 });

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -13,6 +13,8 @@ interface AgentRunInternals {
     runChecks?: boolean;
     draftOnly?: boolean;
     refresh?: boolean;
+    repo?: string;
+    issue?: string;
     dryRun?: boolean;
   }): Promise<void>;
   confirmManualHeadlessRun(config: AppConfig): Promise<void>;
@@ -223,6 +225,88 @@ describe('AgentOrchestrator run flow', () => {
       prDraft,
       pullRequestUrl: 'https://github.com/acme/demo/pull/42',
       changedFiles: ['src/app.ts'],
+    }));
+  });
+
+  test('runs against an explicitly targeted issue without discovery selection', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+    const config = createConfig();
+    const issue = createRankedIssue({
+      repoFullName: 'Wei-Shaw/sub2api',
+      repoName: 'sub2api',
+      number: 3014,
+    });
+    const memory = createMemory({ repoFullName: 'Wei-Shaw/sub2api' });
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-sub2api',
+      branchName: 'openmeta/3014-openai-compat',
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const artifacts = createArtifacts();
+    const showResultSpy = spyOn(orchestrator as object as { showResult: AgentRunInternals['showResult'] }, 'showResult').mockImplementation(() => {});
+    const loadTargetIssueSpy = spyOn(issueRankingService, 'loadTargetIssue').mockResolvedValue([issue]);
+    const loadRankedIssuesSpy = spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
+    const promptForIssueSpy = spyOn(orchestrator as object as { promptForIssue: AgentRunInternals['promptForIssue'] }, 'promptForIssue').mockResolvedValue(issue);
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as object as { initializeClients: AgentRunInternals['initializeClients'] }, 'initializeClients').mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValue(memory);
+    spyOn(workspaceService, 'prepareWorkspace').mockResolvedValue(workspace);
+    spyOn(memoryService, 'update').mockReturnValue(memory);
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(orchestrator as object as { generateConcretePatch: AgentRunInternals['generateConcretePatch'] }, 'generateConcretePatch').mockResolvedValue({
+      changedFiles: ['src/openai.ts'],
+      validationResults: [],
+      reviewRequired: false,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+    spyOn(contentService, 'formatContributionDossier').mockReturnValue('# Dossier');
+    spyOn(orchestrator as object as { submitContributionPullRequestIfPossible: AgentRunInternals['submitContributionPullRequestIfPossible'] }, 'submitContributionPullRequestIfPossible')
+      .mockResolvedValue({
+        branchName: 'openmeta/agent-3014',
+        url: 'https://github.com/Wei-Shaw/sub2api/pull/3015',
+        number: 3015,
+        changedFiles: ['src/openai.ts'],
+        validationResults: [],
+      });
+    spyOn(orchestrator as object as { prepareLocalArtifactPaths: AgentRunInternals['prepareLocalArtifactPaths'] }, 'prepareLocalArtifactPaths').mockReturnValue(artifacts);
+    spyOn(orchestrator as object as { writeLocalArtifacts: AgentRunInternals['writeLocalArtifacts'] }, 'writeLocalArtifacts').mockImplementation(() => {});
+    spyOn(orchestrator as object as { publishArtifactsIfNeeded: AgentRunInternals['publishArtifactsIfNeeded'] }, 'publishArtifactsIfNeeded').mockResolvedValue({
+      published: false,
+    });
+    spyOn(inboxService, 'saveItem').mockReturnValue([createInboxItem()]);
+    spyOn(inboxService, 'renderMarkdown').mockReturnValue('# Inbox');
+    spyOn(proofOfWorkService, 'load').mockReturnValue({ records: [] });
+    spyOn(proofOfWorkService, 'renderMarkdown').mockReturnValue('# Proof');
+    spyOn(proofOfWorkService, 'record').mockReturnValue([createProofRecord()]);
+    spyOn(memoryService, 'renderMarkdown').mockReturnValue('# Memory');
+    spyOn(memoryService, 'recordOutcome').mockReturnValue(memory);
+
+    await orchestrator.run({ issue: 'https://github.com/Wei-Shaw/sub2api/issues/3014' });
+
+    expect(loadTargetIssueSpy).toHaveBeenCalledWith(config, {
+      repoFullName: 'Wei-Shaw/sub2api',
+      issueNumber: 3014,
+    });
+    expect(loadRankedIssuesSpy).not.toHaveBeenCalled();
+    expect(promptForIssueSpy).not.toHaveBeenCalled();
+    expect(showResultSpy).toHaveBeenCalledWith(expect.objectContaining({
+      issue,
+      pullRequestUrl: 'https://github.com/Wei-Shaw/sub2api/pull/3015',
+      changedFiles: ['src/openai.ts'],
     }));
   });
 

--- a/test/analyze-command.test.ts
+++ b/test/analyze-command.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { Command } from 'commander';
+import { registerAnalyzeCommand } from '../src/commands/analyze.js';
+
+describe('registerAnalyzeCommand', () => {
+  test('registers analyze command with repository targeting options', () => {
+    const program = new Command();
+    registerAnalyzeCommand(program);
+
+    const analyzeCommand = program.commands.find((command) => command.name() === 'analyze');
+    const help = analyzeCommand?.helpInformation() ?? '';
+
+    expect(help).toContain('analyze');
+    expect(help).toContain('--repo <repository>');
+    expect(help).toContain('--headless');
+    expect(help).toContain('--run-checks');
+    expect(help).toContain('--dry-run');
+  });
+});

--- a/test/config-orchestrator.test.ts
+++ b/test/config-orchestrator.test.ts
@@ -46,4 +46,31 @@ describe('ConfigOrchestrator', () => {
     expect(loaded.github.pat).toBe('ghp_new_secret');
     expect(loaded.llm.apiKey).toBe('sk-new-secret');
   });
+
+  test('sets and validates LLM reasoning effort from dotted config keys', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('llm.reasoningEffort', 'high');
+
+    const loaded = await configService.get();
+    expect(loaded.llm.reasoningEffort).toBe('high');
+
+    await expect(orchestrator.set('llm.reasoningEffort', 'unsupported')).rejects.toThrow(
+      'llm.reasoningEffort must be',
+    );
+  });
+
+  test('sets and validates LLM streaming from dotted config keys', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('llm.stream', 'true');
+    expect((await configService.get()).llm.stream).toBe(true);
+
+    await orchestrator.set('llm.stream', 'false');
+    expect((await configService.get()).llm.stream).toBe(false);
+
+    await expect(orchestrator.set('llm.stream', 'maybe')).rejects.toThrow(
+      'llm.stream must be a boolean value.',
+    );
+  });
 });

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -8,6 +8,7 @@ import {
   createProofRecord,
   createPullRequestDraft,
   createRankedIssue,
+  createRepositorySuggestion,
   createWorkspace,
 } from './helpers/factories.js';
 
@@ -62,6 +63,41 @@ describe('contentService', () => {
     expect(markdown).toContain('## Summary');
     expect(markdown).toContain('## Changes');
     expect(markdown).toContain('## Validation');
+  });
+
+  test('formats repository analysis suggestions as markdown', () => {
+    const selectedSuggestion = createRepositorySuggestion({
+      id: 'config-validation',
+      title: 'Add config validation tests',
+      prPotentialScore: 91,
+      targetFiles: [
+        { path: 'src/infra/config.ts', reason: 'Config normalization logic' },
+        { path: 'test/config.test.ts', reason: 'Regression coverage' },
+      ],
+    });
+    const markdown = contentService.formatRepositoryAnalysisMarkdown(
+      'acme/demo',
+      createWorkspace({
+        workspacePath: '/tmp/openmeta-demo',
+        defaultBranch: 'main',
+        candidateFiles: ['README.md', 'src/infra/config.ts'],
+      }),
+      [
+        selectedSuggestion,
+        createRepositorySuggestion(),
+      ],
+      selectedSuggestion,
+    );
+
+    expect(markdown).toContain('# Repository Analysis - acme/demo');
+    expect(markdown).toContain('- Workspace Path: /tmp/openmeta-demo');
+    expect(markdown).toContain('- Candidate Files: README.md, src/infra/config.ts');
+    expect(markdown).toContain('## Selected Suggestion');
+    expect(markdown).toContain('Add config validation tests');
+    expect(markdown).toContain('PR Potential: 91/100');
+    expect(markdown).toContain('`src/infra/config.ts` | Config normalization logic');
+    expect(markdown).toContain('## Suggestions');
+    expect(markdown).toContain('### Document local install');
   });
 
   test('formats inbox and proof-of-work markdown summaries', () => {

--- a/test/github-repo.test.ts
+++ b/test/github-repo.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  parseGitHubIssueReference,
+  parseGitHubRepoFullName,
+  resolveGitHubIssueTarget,
+} from '../src/infra/index.js';
+
+describe('parseGitHubRepoFullName', () => {
+  test('accepts owner/name shorthand', () => {
+    expect(parseGitHubRepoFullName('vercel/next.js')).toBe('vercel/next.js');
+  });
+
+  test('normalizes HTTPS and SSH GitHub repository URLs', () => {
+    expect(parseGitHubRepoFullName('https://github.com/vercel/next.js')).toBe('vercel/next.js');
+    expect(parseGitHubRepoFullName('https://github.com/vercel/next.js.git')).toBe('vercel/next.js');
+    expect(parseGitHubRepoFullName('git@github.com:vercel/next.js.git')).toBe('vercel/next.js');
+  });
+
+  test('rejects non-GitHub repository addresses', () => {
+    expect(() => parseGitHubRepoFullName('https://gitlab.com/vercel/next.js')).toThrow(
+      'Repository must be a GitHub repository',
+    );
+  });
+});
+
+describe('parseGitHubIssueReference', () => {
+  test('accepts positive issue numbers', () => {
+    expect(parseGitHubIssueReference('3014')).toEqual({
+      issueNumber: 3014,
+    });
+  });
+
+  test('normalizes GitHub issue URLs', () => {
+    expect(parseGitHubIssueReference('https://github.com/Wei-Shaw/sub2api/issues/3014')).toEqual({
+      repoFullName: 'Wei-Shaw/sub2api',
+      issueNumber: 3014,
+    });
+  });
+
+  test('rejects pull request URLs and invalid numbers', () => {
+    expect(() => parseGitHubIssueReference('0')).toThrow('Issue must be a positive issue number');
+    expect(() => parseGitHubIssueReference('https://github.com/Wei-Shaw/sub2api/pull/3014')).toThrow(
+      'Issue must be a GitHub issue URL or positive issue number',
+    );
+  });
+});
+
+describe('resolveGitHubIssueTarget', () => {
+  test('uses --repo when the issue is provided as a number', () => {
+    expect(resolveGitHubIssueTarget('3014', 'https://github.com/Wei-Shaw/sub2api')).toEqual({
+      repoFullName: 'Wei-Shaw/sub2api',
+      issueNumber: 3014,
+    });
+  });
+
+  test('allows issue URLs without --repo', () => {
+    expect(resolveGitHubIssueTarget('https://github.com/Wei-Shaw/sub2api/issues/3014')).toEqual({
+      repoFullName: 'Wei-Shaw/sub2api',
+      issueNumber: 3014,
+    });
+  });
+
+  test('rejects repository mismatches between --repo and --issue URL', () => {
+    expect(() => resolveGitHubIssueTarget(
+      'https://github.com/Wei-Shaw/sub2api/issues/3014',
+      'vercel/next.js',
+    )).toThrow('does not match --repo');
+  });
+
+  test('requires --repo for numeric issue references', () => {
+    expect(() => resolveGitHubIssueTarget('3014')).toThrow('Issue number targets require --repo');
+  });
+});

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -9,12 +9,19 @@ import type { GitHubIssue } from '../src/types/index.js';
 interface GitHubServiceInternals {
   octokit: {
     rest: {
+      issues: {
+        get: (params: { owner: string; repo: string; issue_number: number }) => Promise<{ data: unknown }>;
+      };
+      repos: {
+        get: (params: { owner: string; repo: string }) => Promise<{ data: { description?: string | null; stargazers_count?: number | null } }>;
+      };
       search: {
-        issuesAndPullRequests: (params?: { page?: number }) => Promise<{ data: { total_count: number; items: unknown[] } }>;
+        issuesAndPullRequests: (params?: { q?: string; page?: number }) => Promise<{ data: { total_count: number; items: unknown[] } }>;
       };
     };
   } | null;
-  buildSearchQuery(labels: readonly string[]): string;
+  buildSearchQuery(labels: readonly string[], repoFullName?: string): string;
+  buildRepositorySearchQuery(repoFullName: string): string;
   shouldIncludeIssue(item: Record<string, unknown>): boolean;
   parseRepositoryUrl(repositoryUrl: string): { owner: string; repo: string; fullName: string };
   extractLabelNames(item: { labels: Array<string | { name?: string | null }> }): string[];
@@ -26,9 +33,9 @@ interface GitHubServiceInternals {
   }>): string;
   paginateSearchWithRetry(searchQuery: string): Promise<Array<{ id: number; number: number }>>;
   delay(ms: number): Promise<void>;
-  loadCachedIssues(): GitHubIssue[] | null;
-  saveCachedIssues(issues: GitHubIssue[]): void;
-  getCachePath(): string;
+  loadCachedIssues(repoFullName?: string): GitHubIssue[] | null;
+  saveCachedIssues(issues: GitHubIssue[], repoFullName?: string): void;
+  getCachePath(repoFullName?: string): string;
 }
 
 let tempRoot = '';
@@ -89,6 +96,18 @@ describe('GitHubService internals', () => {
     expect(query).toContain('no:assignee');
   });
 
+  test('builds repository-scoped GitHub search queries', () => {
+    const service = new GitHubService() as unknown as GitHubServiceInternals;
+    const query = service.buildRepositorySearchQuery('vercel/next.js');
+
+    expect(query).toContain('repo:vercel/next.js');
+    expect(query).not.toContain('label:');
+    expect(query).toContain('archived:false');
+    expect(query).toContain('is:issue');
+    expect(query).toContain('is:open');
+    expect(query).toContain('no:assignee');
+  });
+
   test('filters out pull requests, locked issues, and assigned issues', () => {
     const service = new GitHubService() as unknown as GitHubServiceInternals;
 
@@ -139,6 +158,117 @@ describe('GitHubService internals', () => {
     });
 
     expect(labels).toEqual(['good first issue', 'help wanted']);
+  });
+
+  test('fetches a single issue from a target repository', async () => {
+    const service = new GitHubService();
+    const internals = service as unknown as GitHubServiceInternals;
+    const observedIssueRequests: unknown[] = [];
+    const observedRepoRequests: unknown[] = [];
+
+    internals.octokit = {
+      rest: {
+        issues: {
+          get: async (params: { owner: string; repo: string; issue_number: number }) => {
+            observedIssueRequests.push(params);
+            return {
+              data: {
+                id: 3014,
+                number: 3014,
+                title: 'bug(openai): codex_cli_only 未拦截 /v1/chat/completions 兼容入口',
+                body: 'Steps to reproduce are listed here.',
+                html_url: 'https://github.com/Wei-Shaw/sub2api/issues/3014',
+                repository_url: 'https://api.github.com/repos/Wei-Shaw/sub2api',
+                labels: [],
+                created_at: '2026-06-03T00:00:00.000Z',
+                updated_at: '2026-06-03T01:00:00.000Z',
+                locked: false,
+                assignees: [],
+              },
+            };
+          },
+        },
+        repos: {
+          get: async (params: { owner: string; repo: string }) => {
+            observedRepoRequests.push(params);
+            return {
+              data: {
+                description: 'Sub converter API',
+                stargazers_count: 1234,
+              },
+            };
+          },
+        },
+        search: {
+          issuesAndPullRequests: async () => ({
+            data: {
+              total_count: 0,
+              items: [],
+            },
+          }),
+        },
+      },
+    } as unknown as GitHubServiceInternals['octokit'];
+
+    const issue = await service.fetchIssue('https://github.com/Wei-Shaw/sub2api', 3014);
+
+    expect(observedIssueRequests).toEqual([
+      {
+        owner: 'Wei-Shaw',
+        repo: 'sub2api',
+        issue_number: 3014,
+      },
+    ]);
+    expect(observedRepoRequests).toEqual([
+      {
+        owner: 'Wei-Shaw',
+        repo: 'sub2api',
+      },
+    ]);
+    expect(issue).toMatchObject({
+      number: 3014,
+      repoFullName: 'Wei-Shaw/sub2api',
+      repoName: 'sub2api',
+      repoDescription: 'Sub converter API',
+      repoStars: 1234,
+    });
+  });
+
+  test('rejects pull requests and blocked single issue targets', async () => {
+    const service = new GitHubService();
+    const internals = service as unknown as GitHubServiceInternals;
+
+    internals.octokit = {
+      rest: {
+        issues: {
+          get: async () => ({
+            data: {
+              id: 44,
+              number: 44,
+              title: 'Blocked target',
+              body: '',
+              html_url: 'https://github.com/acme/demo/issues/44',
+              repository_url: 'https://api.github.com/repos/acme/demo',
+              labels: [{ name: 'blocked' }],
+              created_at: '2026-06-03T00:00:00.000Z',
+              updated_at: '2026-06-03T01:00:00.000Z',
+              locked: false,
+              assignees: [],
+            },
+          }),
+        },
+        repos: {
+          get: async () => ({ data: { description: '', stargazers_count: 0 } }),
+        },
+        search: {
+          issuesAndPullRequests: async () => ({ data: { total_count: 0, items: [] } }),
+        },
+      },
+    } as unknown as GitHubServiceInternals['octokit'];
+
+    await expect(service.fetchIssue('acme/demo', 44)).rejects.toThrow(
+      'cannot be handled automatically',
+    );
   });
 
   test('classifies search failures by rate limit and validation errors', () => {
@@ -237,6 +367,36 @@ describe('GitHubService internals', () => {
     expect(cached).toHaveLength(1);
     expect(refreshed).toEqual([]);
     expect(searchCalls).toBe(2);
+  });
+
+  test('keeps global and repository-scoped issue discovery caches separate', async () => {
+    const service = new GitHubService();
+    const internals = service as unknown as GitHubServiceInternals;
+    const queries: string[] = [];
+
+    internals.saveCachedIssues([createIssue({ repoFullName: 'global/cache' })]);
+    internals.octokit = {
+      rest: {
+        search: {
+          issuesAndPullRequests: async (params?: { q?: string; page?: number }) => {
+            queries.push(params?.q || '');
+            return {
+              data: {
+                total_count: 0,
+                items: [],
+              },
+            };
+          },
+        },
+      },
+    } as unknown as GitHubServiceInternals['octokit'];
+
+    const repoIssues = await service.fetchTrendingIssues({ repoFullName: 'vercel/next.js' });
+
+    expect(repoIssues).toEqual([]);
+    expect(queries).toHaveLength(1);
+    expect(queries.every((query) => query.includes('repo:vercel/next.js'))).toBe(true);
+    expect(queries.every((query) => !query.includes('label:'))).toBe(true);
   });
 
   test('falls back to the conservative delay when retry-after is invalid', async () => {

--- a/test/helpers/factories.ts
+++ b/test/helpers/factories.ts
@@ -1,4 +1,4 @@
-import type { PatchDraft, PullRequestDraft } from '../../src/contracts/index.js';
+import type { PatchDraft, PullRequestDraft, RepositoryImprovementSuggestion } from '../../src/contracts/index.js';
 import type {
   ContributionInboxItem,
   GitHubIssue,
@@ -197,6 +197,37 @@ export function createPullRequestDraft(overrides: Partial<PullRequestDraft> = {}
     ],
     validation: ['bun test (pending)'],
     risks: ['Consumers may need to update snapshots that cover button rendering'],
+    ...overrides,
+  };
+}
+
+export function createRepositorySuggestion(
+  overrides: Partial<RepositoryImprovementSuggestion> = {},
+): RepositoryImprovementSuggestion {
+  return {
+    id: 'docs-install',
+    title: 'Document local install',
+    summary: 'Clarify how contributors can install and link the CLI locally.',
+    rationale: 'The README explains the product but does not give a reliable local setup path.',
+    targetFiles: [
+      {
+        path: 'README.md',
+        reason: 'Primary contributor onboarding surface',
+      },
+    ],
+    proposedChanges: [
+      'Add a local installation section',
+      'Document the expected validation command',
+    ],
+    validationPlan: [
+      'Run bun run build',
+      'Review README commands for accuracy',
+    ],
+    risks: [
+      'Install steps may change if packaging changes later',
+    ],
+    estimatedWorkload: 'small',
+    prPotentialScore: 84,
     ...overrides,
   };
 }

--- a/test/init-orchestrator.test.ts
+++ b/test/init-orchestrator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, spyOn, test } from 'bun:test';
+import * as infra from '../src/infra/index.js';
+import { InitOrchestrator } from '../src/orchestration/init.js';
+import type { LLMReasoningEffort } from '../src/types/index.js';
+
+interface InitOrchestratorInternals {
+  promptReasoningEffort(defaultValue?: LLMReasoningEffort): Promise<LLMReasoningEffort>;
+  promptLlmStreaming(defaultValue?: boolean): Promise<boolean>;
+}
+
+describe('InitOrchestrator LLM reasoning setup', () => {
+  test('defaults reasoning effort selection to none during init', async () => {
+    const orchestrator = new InitOrchestrator() as unknown as InitOrchestratorInternals;
+    const selectSpy = spyOn(infra, 'selectPrompt').mockResolvedValue('none');
+
+    try {
+      const selected = await orchestrator.promptReasoningEffort();
+
+      expect(selected).toBe('none');
+      expect(selectSpy).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Select reasoning effort:',
+        default: 'none',
+        choices: expect.arrayContaining([
+          expect.objectContaining({ name: 'none', value: 'none' }),
+          expect.objectContaining({ name: 'high', value: 'high' }),
+        ]),
+      }));
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  test('defaults streaming selection to false during init', async () => {
+    const orchestrator = new InitOrchestrator() as unknown as InitOrchestratorInternals;
+    const promptSpy = spyOn(infra, 'prompt').mockResolvedValue({ stream: false });
+
+    try {
+      const selected = await orchestrator.promptLlmStreaming();
+
+      expect(selected).toBe(false);
+      expect(promptSpy).toHaveBeenCalledWith([
+        expect.objectContaining({
+          type: 'confirm',
+          name: 'stream',
+          message: 'Use streaming LLM responses?',
+          default: false,
+        }),
+      ]);
+    } finally {
+      promptSpy.mockRestore();
+    }
+  });
+});

--- a/test/issue-ranking.test.ts
+++ b/test/issue-ranking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { issueRankingService, llmService } from '../src/services/index.js';
+import { githubService, issueRankingService, llmService } from '../src/services/index.js';
 import { createIssue, createMatchedIssue, createRankedIssue } from './helpers/factories.js';
 
 describe('IssueRankingService', () => {
@@ -121,5 +121,138 @@ describe('IssueRankingService', () => {
     expect(matches[0]?.analysis.techRequirements).toContain('React');
     expect(matches[0]?.analysis.estimatedWorkload).toBe('1-3 hours');
     expect(matches[0]?.analysis.solutionSuggestion).toContain('Local scout mode');
+  });
+
+  test('builds a ranked target issue without batch discovery', async () => {
+    const originalFetchIssue = githubService.fetchIssue;
+    const originalScoreIssues = llmService.scoreIssues;
+    const observedFetches: unknown[] = [];
+
+    try {
+      githubService.fetchIssue = async (repoFullName, issueNumber) => {
+        observedFetches.push({ repoFullName, issueNumber });
+        return createIssue({
+          repoFullName: 'Wei-Shaw/sub2api',
+          repoName: 'sub2api',
+          number: 3014,
+          title: 'bug(openai): codex_cli_only 未拦截 /v1/chat/completions 兼容入口',
+          body: 'The issue points to src/openai.ts and includes steps to reproduce.',
+          labels: [],
+        });
+      };
+      llmService.scoreIssues = async (_profile, issues) => ({
+        version: '1',
+        kind: 'issue_match_list',
+        status: 'success',
+        data: issues.map((issue) => createMatchedIssue({
+          ...issue,
+          matchScore: 77,
+          analysis: {
+            coreDemand: issue.title,
+            techRequirements: ['TypeScript', 'OpenAI API'],
+            solutionSuggestion: 'Inspect the compatibility route and add a guard.',
+            estimatedWorkload: '1-2 hours',
+          },
+        })),
+      });
+
+      const [ranked] = await issueRankingService.loadTargetIssue({
+        userProfile: {
+          techStack: ['TypeScript'],
+          proficiency: 'intermediate',
+          focusAreas: ['backend'],
+        },
+        github: {
+          pat: 'ghp-test',
+          username: 'octocat',
+          targetRepoPath: '',
+        },
+        llm: {
+          provider: 'openai',
+          apiBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          modelName: 'gpt-5.5',
+          reasoningEffort: 'none',
+        },
+        automation: {
+          enabled: false,
+          scheduleTime: '09:00',
+          timezone: 'UTC',
+          contentType: 'research_note',
+          scheduler: 'manual',
+          minMatchScore: 70,
+          skipIfAlreadyGeneratedToday: true,
+        },
+        commitTemplate: '{{content}}',
+      }, {
+        repoFullName: 'Wei-Shaw/sub2api',
+        issueNumber: 3014,
+      });
+
+      expect(observedFetches).toEqual([
+        {
+          repoFullName: 'Wei-Shaw/sub2api',
+          issueNumber: 3014,
+        },
+      ]);
+      expect(ranked?.repoFullName).toBe('Wei-Shaw/sub2api');
+      expect(ranked?.number).toBe(3014);
+      expect(ranked?.matchScore).toBe(77);
+      expect(ranked?.opportunity.overallScore).toBeGreaterThan(0);
+    } finally {
+      githubService.fetchIssue = originalFetchIssue;
+      llmService.scoreIssues = originalScoreIssues;
+    }
+  });
+
+  test('passes repository scope to GitHub issue discovery', async () => {
+    const originalFetchTrendingIssues = githubService.fetchTrendingIssues;
+    const observedOptions: unknown[] = [];
+
+    try {
+      githubService.fetchTrendingIssues = async (options) => {
+        observedOptions.push(options);
+        return [];
+      };
+
+      await issueRankingService.loadRankedIssues({
+        userProfile: {
+          techStack: ['TypeScript'],
+          proficiency: 'intermediate',
+          focusAreas: ['web-dev'],
+        },
+        github: {
+          pat: 'ghp-test',
+          username: 'octocat',
+          targetRepoPath: '',
+        },
+        llm: {
+          provider: 'openai',
+          apiBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          modelName: 'gpt-5.5',
+          reasoningEffort: 'none',
+        },
+        automation: {
+          enabled: false,
+          scheduleTime: '09:00',
+          timezone: 'UTC',
+          contentType: 'research_note',
+          scheduler: 'manual',
+          minMatchScore: 70,
+          skipIfAlreadyGeneratedToday: true,
+        },
+        commitTemplate: '{{content}}',
+      }, {
+        repoFullName: 'vercel/next.js',
+        localOnly: true,
+      });
+
+      expect(observedOptions[0]).toMatchObject({
+        repoFullName: 'vercel/next.js',
+      });
+    } finally {
+      githubService.fetchTrendingIssues = originalFetchTrendingIssues;
+    }
   });
 });

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -24,11 +24,14 @@ interface LLMServiceInternals {
   client: {
     chat: {
       completions: {
-        create: (payload: {
-          model: string;
-          messages: Array<{ role: string; content: string }>;
-          temperature: number;
-        }) => Promise<unknown>;
+          create: (payload: {
+            model: string;
+            messages: Array<{ role: string; content: string }>;
+            temperature: number;
+            reasoning_effort?: string;
+            stream?: boolean;
+            stream_options?: { include_usage?: boolean };
+          }) => unknown | Promise<unknown>;
       };
     };
   } | null;
@@ -252,6 +255,188 @@ describe('LLMService validation behavior', () => {
 
     const valid = await service.validateConnection();
     expect(valid).toBe(true);
+  });
+});
+
+describe('LLMService reasoning effort requests', () => {
+  test('streams chat completions and aggregates content chunks when enabled', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'openai',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+        stream?: boolean,
+      ): void;
+      generateDailyReport(issueAnalysis: string): Promise<string>;
+    };
+    const payloads: Array<Record<string, unknown>> = [];
+
+    async function* streamChunks() {
+      yield { choices: [{ delta: { content: 'hel' } }] };
+      yield { choices: [{ delta: { content: 'lo' } }] };
+      yield { choices: [], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } };
+    }
+
+    service.initialize('sk-test', 'https://api.openai.com/v1', 'gpt-5.5', {}, 'openai', 'xhigh', true);
+    service.client = {
+      chat: {
+        completions: {
+          create: (payload) => {
+            payloads.push(payload);
+            return streamChunks();
+          },
+        },
+      },
+    };
+
+    const content = await service.generateDailyReport('issue analysis');
+
+    expect(content).toBe('hello');
+    expect(payloads[0]).toMatchObject({
+      model: 'gpt-5.5',
+      reasoning_effort: 'xhigh',
+      stream: true,
+      stream_options: {
+        include_usage: true,
+      },
+    });
+  });
+
+  test('uses non-streaming chat completions by default', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'openai',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+        stream?: boolean,
+      ): void;
+      generateDailyReport(issueAnalysis: string): Promise<string>;
+    };
+    const payloads: Array<Record<string, unknown>> = [];
+
+    service.initialize('sk-test', 'https://api.openai.com/v1', 'gpt-5.5', {}, 'openai', 'xhigh');
+    service.client = {
+      chat: {
+        completions: {
+          create: async (payload) => {
+            payloads.push(payload);
+            return { choices: [{ message: { content: 'done' } }] };
+          },
+        },
+      },
+    };
+
+    const content = await service.generateDailyReport('issue analysis');
+
+    expect(content).toBe('done');
+    expect(payloads[0]).toMatchObject({
+      model: 'gpt-5.5',
+      reasoning_effort: 'xhigh',
+    });
+    expect(payloads[0]).not.toHaveProperty('stream');
+    expect(payloads[0]).not.toHaveProperty('stream_options');
+  });
+
+  test('passes configured reasoning effort to chat completions', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'openai',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+      ): void;
+      generateDailyReport(issueAnalysis: string): Promise<string>;
+    };
+    const payloads: unknown[] = [];
+
+    service.initialize('sk-test', 'https://api.openai.com/v1', 'gpt-5.5', {}, 'openai', 'high');
+    service.client = {
+      chat: {
+        completions: {
+          create: async (payload) => {
+            payloads.push(payload);
+            return { choices: [{ message: { content: 'done' } }] };
+          },
+        },
+      },
+    };
+
+    await service.generateDailyReport('issue analysis');
+
+    expect(payloads[0]).toMatchObject({
+      model: 'gpt-5.5',
+      reasoning_effort: 'high',
+    });
+  });
+
+  test('omits reasoning effort for non-reasoning chat models', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'openai',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+      ): void;
+      generateDailyReport(issueAnalysis: string): Promise<string>;
+    };
+    const payloads: Array<Record<string, unknown>> = [];
+
+    service.initialize('sk-test', 'https://api.openai.com/v1', 'gpt-4o-mini', {}, 'openai', 'none');
+    service.client = {
+      chat: {
+        completions: {
+          create: async (payload) => {
+            payloads.push(payload);
+            return { choices: [{ message: { content: 'done' } }] };
+          },
+        },
+      },
+    };
+
+    await service.generateDailyReport('issue analysis');
+
+    expect(payloads[0]).not.toHaveProperty('reasoning_effort');
+  });
+
+  test('omits default reasoning effort for custom legacy models', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'custom',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+      ): void;
+      generateDailyReport(issueAnalysis: string): Promise<string>;
+    };
+    const payloads: Array<Record<string, unknown>> = [];
+
+    service.initialize('sk-test', 'https://example.com/v1', 'legacy-model', {}, 'custom', 'none');
+    service.client = {
+      chat: {
+        completions: {
+          create: async (payload) => {
+            payloads.push(payload);
+            return { choices: [{ message: { content: 'done' } }] };
+          },
+        },
+      },
+    };
+
+    await service.generateDailyReport('issue analysis');
+
+    expect(payloads[0]).not.toHaveProperty('reasoning_effort');
   });
 });
 

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -21,6 +21,18 @@ interface LLMServiceInternals {
       validationNotes: string[];
     };
   }>;
+  analyzeRepository(
+    repoFullName: string,
+    workspace: ReturnType<typeof createWorkspace>,
+    memory: ReturnType<typeof createMemory>,
+  ): Promise<{
+    status: StructuredOutputStatus;
+    data: Array<{
+      id: string;
+      title: string;
+      prPotentialScore: number;
+    }>;
+  }>;
   client: {
     chat: {
       completions: {
@@ -60,12 +72,191 @@ interface LLMServiceInternals {
       risks: string[];
     };
   };
+  parseRepositorySuggestions(content: string): {
+    status: StructuredOutputStatus;
+    data: Array<{
+      id: string;
+      title: string;
+      summary: string;
+      rationale: string;
+      targetFiles: Array<{ path: string; reason: string }>;
+      proposedChanges: string[];
+      validationPlan: string[];
+      risks: string[];
+      estimatedWorkload: 'small' | 'medium' | 'large';
+      prPotentialScore: number;
+    }>;
+  };
   parseLLMResponse(content: string, originalIssues: ReturnType<typeof createIssue>[]): {
     status: StructuredOutputStatus;
     data: MatchedIssue[];
   };
   formatRepoMemory(memory: ReturnType<typeof createMemory>): string;
 }
+
+describe('LLMService repository suggestion parsing', () => {
+  test('parses structured repository suggestions and keeps the highest scoring duplicate', () => {
+    const service = new LLMService() as unknown as LLMServiceInternals;
+    const suggestions = service.parseRepositorySuggestions(`
+      {
+        "version": "1",
+        "kind": "repository_suggestion_list",
+        "status": "success",
+        "data": {
+          "suggestions": [
+            {
+              "id": "docs-install",
+              "title": "Document the local install path",
+              "summary": "Make setup instructions easier to follow.",
+              "rationale": "The README mentions installation but not local linking.",
+              "targetFiles": [
+                {
+                  "path": "README.md",
+                  "reason": "Primary onboarding documentation"
+                }
+              ],
+              "proposedChanges": ["Add a local install section"],
+              "validationPlan": ["Run the documented command in a clean shell"],
+              "risks": ["Docs may drift if package scripts change"],
+              "estimatedWorkload": "small",
+              "prPotentialScore": 72
+            },
+            {
+              "id": "config-validation",
+              "title": "Add config validation tests",
+              "summary": "Cover malformed provider config normalization.",
+              "rationale": "Config compatibility is a high-impact safety path.",
+              "targetFiles": [
+                {
+                  "path": "src/infra/config.ts",
+                  "reason": "Normalization logic"
+                },
+                {
+                  "path": "test/config.test.ts",
+                  "reason": "Regression coverage"
+                }
+              ],
+              "proposedChanges": ["Add tests for invalid stream and reasoning values"],
+              "validationPlan": ["bun test test/config.test.ts"],
+              "risks": [],
+              "estimatedWorkload": "medium",
+              "prPotentialScore": 91
+            },
+            {
+              "id": "docs-install",
+              "title": "Document the local install path",
+              "summary": "Duplicate lower-scoring suggestion.",
+              "rationale": "Same suggestion should be deduped.",
+              "targetFiles": [
+                {
+                  "path": "README.md",
+                  "reason": "Primary onboarding documentation"
+                }
+              ],
+              "proposedChanges": ["Add a smaller docs note"],
+              "validationPlan": ["Read the docs"],
+              "risks": [],
+              "estimatedWorkload": "small",
+              "prPotentialScore": 61
+            }
+          ]
+        }
+      }
+    `);
+
+    expect(suggestions.status).toBe('success');
+    expect(suggestions.data).toHaveLength(2);
+    expect(suggestions.data[0]?.id).toBe('config-validation');
+    expect(suggestions.data[0]?.targetFiles.map((file) => file.path)).toEqual([
+      'src/infra/config.ts',
+      'test/config.test.ts',
+    ]);
+    expect(suggestions.data[1]?.id).toBe('docs-install');
+    expect(suggestions.data[1]?.summary).toBe('Make setup instructions easier to follow.');
+  });
+
+  test('generates repository analysis requests from workspace context', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'openai',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+        stream?: boolean,
+      ): void;
+    };
+    const payloads: Array<{
+      messages: Array<{ role: string; content: string }>;
+      stream?: boolean;
+      reasoning_effort?: string;
+    }> = [];
+
+    service.initialize('sk-test', 'https://api.openai.com/v1', 'gpt-5.5', {}, 'openai', 'high', true);
+    service.client = {
+      chat: {
+        completions: {
+          create: async (payload) => {
+            payloads.push(payload);
+            return {
+              choices: [{
+                message: {
+                  content: JSON.stringify({
+                    version: '1',
+                    kind: 'repository_suggestion_list',
+                    status: 'success',
+                    data: {
+                      suggestions: [
+                        {
+                          id: 'docs-install',
+                          title: 'Document local install',
+                          summary: 'Clarify setup docs.',
+                          rationale: 'README setup is incomplete.',
+                          targetFiles: [{ path: 'README.md', reason: 'Setup docs' }],
+                          proposedChanges: ['Add local install instructions'],
+                          validationPlan: ['Review README commands'],
+                          risks: [],
+                          estimatedWorkload: 'small',
+                          prPotentialScore: 82,
+                        },
+                      ],
+                    },
+                  }),
+                },
+              }],
+            };
+          },
+        },
+      },
+    };
+
+    const result = await service.analyzeRepository(
+      'acme/demo',
+      createWorkspace({
+        topLevelFiles: ['README.md', 'package.json', 'src'],
+        candidateFiles: ['README.md', 'src/index.ts'],
+        snippets: [
+          { path: 'README.md', content: '# Demo\n\nInstall instructions are missing.\n' },
+          { path: 'src/index.ts', content: 'export const demo = true;\n' },
+        ],
+        testCommands: [{ command: 'bun test', reason: 'Detected package.json test script (bun)', source: 'repo-script' }],
+        validationCommands: [{ command: 'bun test', reason: 'Detected package.json test script (bun)', source: 'repo-script' }],
+      }),
+      createMemory(),
+    );
+
+    expect(result.data[0]?.title).toBe('Document local install');
+    expect(payloads[0]).toMatchObject({
+      stream: true,
+      reasoning_effort: 'high',
+    });
+    expect(payloads[0]?.messages[1]?.content).toContain('Repository: acme/demo');
+    expect(payloads[0]?.messages[1]?.content).toContain('Candidate Files: README.md, src/index.ts');
+    expect(payloads[0]?.messages[1]?.content).toContain('FILE: README.md');
+    expect(payloads[0]?.messages[1]?.content).toContain('Detected Test Commands: bun test');
+  });
+});
 
 describe('LLMService implementation draft parsing', () => {
   test('parses raw JSON responses into file change drafts', () => {

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -256,6 +256,50 @@ describe('LLMService validation behavior', () => {
     const valid = await service.validateConnection();
     expect(valid).toBe(true);
   });
+
+  test('uses streaming validation requests when streaming is enabled', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'custom',
+        reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh',
+        stream?: boolean,
+      ): void;
+    };
+    const payloads: Array<Record<string, unknown>> = [];
+
+    async function* validationChunks() {
+      yield { choices: [{ delta: { content: 'O' } }] };
+      yield { choices: [{ delta: { content: 'K' } }] };
+    }
+
+    service.initialize('sk-test', 'https://example.com/v1', 'gpt-5.5', {}, 'custom', 'xhigh', true);
+    service.client = {
+      chat: {
+        completions: {
+          create: (payload) => {
+            payloads.push(payload);
+            return validationChunks();
+          },
+        },
+      },
+    };
+
+    const valid = await service.validateConnection();
+
+    expect(valid).toBe(true);
+    expect(payloads[0]).toMatchObject({
+      model: 'gpt-5.5',
+      stream: true,
+      stream_options: {
+        include_usage: true,
+      },
+      reasoning_effort: 'xhigh',
+    });
+  });
 });
 
 describe('LLMService reasoning effort requests', () => {

--- a/test/provider-orchestrator.test.ts
+++ b/test/provider-orchestrator.test.ts
@@ -42,6 +42,8 @@ describe('ProviderOrchestrator', () => {
         apiBaseUrl: 'https://example.com/v1',
         modelName: 'example-model',
         apiKey: 'sk-profile-secret',
+        reasoningEffort: 'high',
+        stream: true,
       },
     });
 
@@ -57,6 +59,8 @@ describe('ProviderOrchestrator', () => {
       modelName: 'example-model',
       apiKey: 'sk-profile-secret',
       apiHeaders: {},
+      reasoningEffort: 'high',
+      stream: true,
     });
     expect(loaded.llm.activeProfile).toBe('example');
   });
@@ -69,6 +73,8 @@ describe('ProviderOrchestrator', () => {
       baseUrl: 'https://api2.henng.cn/v1',
       model: 'gpt-5.4',
       apiKey: 'sk-henng-secret',
+      reasoningEffort: 'low',
+      stream: 'true',
       header: ['X-Test=yes'],
     });
     await orchestrator.use('henng-gpt54');
@@ -78,6 +84,8 @@ describe('ProviderOrchestrator', () => {
     expect(loaded.llm.apiBaseUrl).toBe('https://api2.henng.cn/v1');
     expect(loaded.llm.modelName).toBe('gpt-5.4');
     expect(loaded.llm.apiKey).toBe('sk-henng-secret');
+    expect(loaded.llm.reasoningEffort).toBe('low');
+    expect(loaded.llm.stream).toBe(true);
     expect(loaded.llm.apiHeaders).toEqual({ 'X-Test': 'yes' });
     expect(loaded.llm.activeProfile).toBe('henng-gpt54');
   });

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { simpleGit } from 'simple-git';
 import { workspaceService } from '../src/services/workspace.js';
-import { createRankedIssue } from './helpers/factories.js';
+import { createMemory, createRankedIssue } from './helpers/factories.js';
 
 const tempDirs: string[] = [];
 
@@ -118,6 +118,73 @@ describe('workspaceService.applyGeneratedChanges', () => {
 });
 
 describe('workspaceService.detectTestCommands', () => {
+  test('prepares repository workspace without a real issue target', async () => {
+    const tempRoot = makeWorkspace();
+    const openMetaHome = join(tempRoot, 'openmeta-home');
+    const remotePath = join(tempRoot, 'remote.git');
+    const seedPath = join(tempRoot, 'seed');
+    process.env['OPENMETA_HOME'] = openMetaHome;
+
+    mkdirSync(seedPath, { recursive: true });
+    const seedGit = simpleGit(seedPath);
+    await seedGit.init(['--initial-branch=main']);
+    await seedGit.addConfig('user.name', 'OpenMeta Test');
+    await seedGit.addConfig('user.email', 'openmeta@example.com');
+    mkdirSync(join(seedPath, 'src'), { recursive: true });
+    writeFileSync(join(seedPath, 'README.md'), '# Demo\n\nMissing setup notes.\n', 'utf-8');
+    writeFileSync(join(seedPath, 'package.json'), JSON.stringify({
+      scripts: {
+        test: 'bun test',
+      },
+    }), 'utf-8');
+    writeFileSync(join(seedPath, 'src', 'index.ts'), 'export const demo = true;\n', 'utf-8');
+    await seedGit.add('.');
+    await seedGit.commit('chore: seed repo');
+    await simpleGit().clone(seedPath, remotePath, ['--bare']);
+
+    const service = workspaceService as unknown as {
+      buildRepoUrl(repoFullName: string): string;
+      prepareRepositoryWorkspace(
+        repoFullName: string,
+        memory: ReturnType<typeof createMemory>,
+        runChecks: boolean,
+        executionMode?: 'interactive' | 'headless',
+      ): Promise<{
+        workspacePath: string;
+        defaultBranch: string;
+        branchName?: string;
+        topLevelFiles: string[];
+        candidateFiles: string[];
+        snippets: Array<{ path: string; content: string }>;
+        testCommands: Array<{ command: string }>;
+      }>;
+    };
+    const originalBuildRepoUrl = service.buildRepoUrl;
+    service.buildRepoUrl = () => remotePath;
+
+    try {
+      const workspace = await service.prepareRepositoryWorkspace(
+        'acme/demo',
+        createMemory({
+          repoFullName: 'acme/demo',
+          preferredPaths: ['src/index.ts'],
+        }),
+        false,
+      );
+
+      expect(workspace.defaultBranch).toBe('main');
+      expect(workspace.branchName).toMatch(/^openmeta\/analyze-acme-demo/);
+      expect(workspace.topLevelFiles).toContain('README.md');
+      expect(workspace.candidateFiles).toContain('README.md');
+      expect(workspace.candidateFiles).toContain('src/index.ts');
+      expect(workspace.snippets.some((snippet) => snippet.path === 'README.md')).toBe(true);
+      expect(workspace.testCommands.map((command) => command.command)).toContain('bun run test');
+    } finally {
+      service.buildRepoUrl = originalBuildRepoUrl;
+      delete process.env['OPENMETA_HOME'];
+    }
+  });
+
   test('prefers bun for package scripts when a bun lockfile is present', () => {
     const workspacePath = makeWorkspace();
     writeFileSync(join(workspacePath, 'package.json'), JSON.stringify({
@@ -261,5 +328,30 @@ describe('workspaceService.detectTestCommands', () => {
     }, ['src/utils/labels.ts', 'src/components/IconButton.tsx']);
 
     expect(rankedFiles[0]).toBe('src/components/IconButton.tsx');
+  });
+
+  test('prioritizes repository analysis paths with docs, config, source, tests, and memory signals', () => {
+    const rankedFiles = (workspaceService as unknown as {
+      rankRepositoryAnalysisFiles: (
+        memory: ReturnType<typeof createMemory>,
+        files: string[],
+      ) => string[];
+    }).rankRepositoryAnalysisFiles(createMemory({
+      preferredPaths: ['src/components/IconButton.tsx'],
+    }), [
+      'docs/internal/archive.txt',
+      'README.md',
+      'package.json',
+      'src/components/IconButton.tsx',
+      'test/icon-button.test.ts',
+      'assets/logo.png',
+    ]);
+
+    expect(rankedFiles.slice(0, 4)).toEqual([
+      'src/components/IconButton.tsx',
+      'README.md',
+      'package.json',
+      'test/icon-button.test.ts',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Add `--repo <repository>` for `agent` and `scout`, accepting either `owner/name` or GitHub repository URLs.
- Add `--issue <issue>` for `agent`, supporting numeric issue targets with `--repo` and full GitHub issue URLs.
- Improve repo-scoped discovery so explicit repositories search open unassigned issues instead of only help-wanted labels.
- Add configurable LLM reasoning effort with `none` as the default, including `xhigh` for GPT-5-compatible routes.
- Add configurable LLM streaming via `llm.stream`, defaulting to `false`, with provider profile and init support.

## Configuration
- `openmeta config set llm.reasoningEffort <none|minimal|low|medium|high|xhigh>`
- `openmeta config set llm.stream true|false`
- `openmeta provider add ... --reasoning-effort xhigh --stream true`

## Test Plan
- `bun test`
- `bun run typecheck`
- `bun run build`
