### PR TITLE
feat: 四项优化 — 直接指定issue、断点恢复、搜索去重、多方案选择

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -12,8 +12,9 @@ export function registerAgentCommand(program: Command): void {
     .option('--draft-only', 'Generate dossier and PR draft artifacts without applying file edits or opening a PR')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--dry-run', 'Preview artifacts without writing to git')
+    .option('--issue <ref>', 'Skip scout and work directly on a specific issue (e.g. owner/repo#123)')
     .addOption(new Option('--scheduler-run', 'Internal flag for scheduled automation').hideHelp())
-    .action((options: { headless?: boolean; force?: boolean; runChecks?: boolean; draftOnly?: boolean; refresh?: boolean; dryRun?: boolean; schedulerRun?: boolean }) => runCommand(
+    .action((options: { headless?: boolean; force?: boolean; runChecks?: boolean; draftOnly?: boolean; refresh?: boolean; dryRun?: boolean; schedulerRun?: boolean; issue?: string }) => runCommand(
       'OpenMeta Agent',
       () => agentOrchestrator.run({
         headless: options.headless,
@@ -23,6 +24,7 @@ export function registerAgentCommand(program: Command): void {
         refresh: options.refresh,
         dryRun: options.dryRun,
         schedulerRun: options.schedulerRun,
+        issue: options.issue,
       }),
     ));
 }

--- a/src/contracts/agent-contracts.ts
+++ b/src/contracts/agent-contracts.ts
@@ -90,7 +90,19 @@ export const PullRequestDraftSchema = z.object({
 });
 
 export const IssueMatchListEnvelopeSchema = createStructuredOutputEnvelopeSchema('issue_match_list', IssueMatchListSchema);
+export const PatchApproachSchema = z.object({
+  name: nonEmptyTrimmedString,
+  description: nonEmptyTrimmedString,
+  tradeoffs: z.array(nonEmptyTrimmedString).default([]),
+  patchDraft: PatchDraftSchema,
+});
+
+export const MultiApproachPatchSchema = z.object({
+  approaches: z.array(PatchApproachSchema).min(2).max(4),
+});
+
 export const PatchDraftEnvelopeSchema = createStructuredOutputEnvelopeSchema('patch_draft', PatchDraftSchema);
+export const MultiApproachPatchEnvelopeSchema = createStructuredOutputEnvelopeSchema('multi_approach_patch', MultiApproachPatchSchema);
 export const ImplementationDraftEnvelopeSchema = createStructuredOutputEnvelopeSchema('implementation_draft', ImplementationDraftSchema);
 export const PullRequestDraftEnvelopeSchema = createStructuredOutputEnvelopeSchema('pull_request_draft', PullRequestDraftSchema);
 
@@ -110,6 +122,9 @@ export interface StructuredOutputResult<TKind extends string, TData> {
   data: TData;
 }
 export type IssueMatchListEnvelope = z.infer<typeof IssueMatchListEnvelopeSchema>;
+export type PatchApproach = z.infer<typeof PatchApproachSchema>;
+export type MultiApproachPatch = z.infer<typeof MultiApproachPatchSchema>;
 export type PatchDraftEnvelope = z.infer<typeof PatchDraftEnvelopeSchema>;
+export type MultiApproachPatchEnvelope = z.infer<typeof MultiApproachPatchEnvelopeSchema>;
 export type ImplementationDraftEnvelope = z.infer<typeof ImplementationDraftEnvelopeSchema>;
 export type PullRequestDraftEnvelope = z.infer<typeof PullRequestDraftEnvelopeSchema>;

--- a/src/infra/prompt-templates.ts
+++ b/src/infra/prompt-templates.ts
@@ -131,44 +131,51 @@ Repo Memory:
 {{repoMemory}}
 `;
 
-export const PATCH_DRAFT_REPAIR_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.
+export const MULTI_APPROACH_PATCH_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.
 
-The previous patch draft response was not parseable or did not match the required schema. Reformat it into strict JSON.
+Generate 2-3 distinct approaches to fix this issue. For each approach, provide a complete patch draft. The approaches should differ meaningfully — for example, minimal vs thorough, or different architectural choices.
 
-Required schema:
+Requirements:
+1. Return one valid JSON object only. No markdown. No commentary.
+2. Generate exactly 2-3 approaches with clear trade-offs.
+3. The first approach should be the recommended one.
+4. Each approach must be a complete, actionable patch draft.
+
+Output schema:
 {
   "version": "1",
-  "kind": "patch_draft",
-  "status": "success" | "needs_review",
+  "kind": "multi_approach_patch",
+  "status": "success",
   "data": {
-    "goal": "what the patch should achieve",
-    "targetFiles": [
+    "approaches": [
       {
-        "path": "relative/path/to/file",
-        "reason": "why this file matters"
+        "name": "short distinctive label",
+        "description": "one sentence explaining this approach",
+        "tradeoffs": ["pro: ...", "con: ..."],
+        "patchDraft": {
+          "goal": "what this approach should achieve",
+          "targetFiles": [
+            { "path": "relative/path/to/file", "reason": "why this file matters" }
+          ],
+          "proposedChanges": [
+            { "title": "short step title", "details": "specific implementation details", "files": ["relative/path/to/file"] }
+          ],
+          "risks": ["concrete risk"],
+          "validationNotes": ["concrete validation note"]
+        }
       }
-    ],
-    "proposedChanges": [
-      {
-        "title": "short step title",
-        "details": "specific implementation details",
-        "files": ["relative/path/to/file"]
-      }
-    ],
-    "risks": ["concrete risk"],
-    "validationNotes": ["concrete validation note"]
+    ]
   }
 }
 
-Rules:
-1. Return only one valid JSON object. No commentary.
-2. Preserve the original intended patch plan when possible.
-3. Keep target files repository-relative and concrete.
-4. If the previous response is unusable, return:
-{"version":"1","kind":"patch_draft","status":"needs_review","data":{"goal":"Insufficient context for a safe patch draft.","targetFiles":[{"path":"README.md","reason":"Placeholder target when the prior response is unusable."}],"proposedChanges":[{"title":"Needs review","details":"The previous patch draft could not be safely reconstructed.","files":["README.md"]}],"risks":["The prior model response was unusable."],"validationNotes":["Review the issue and repository context before generating a new patch draft."]}}
+Issue:
+{{issueContext}}
 
-Previous response:
-{{invalidResponse}}
+Repo Context:
+{{repoContext}}
+
+Repo Memory:
+{{repoMemory}}
 `;
 
 export const CODE_CHANGE_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -1,9 +1,9 @@
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import { Octokit } from '@octokit/rest';
 import { simpleGit, type SimpleGit } from 'simple-git';
-import type { PatchDraft, PullRequestDraft } from '../contracts/index.js';
+import type { PatchDraft, PullRequestDraft, StructuredOutputStatus } from '../contracts/index.js';
 import type {
   AppConfig,
   ContributionAgentResult,
@@ -32,6 +32,7 @@ import {
   issueRankingService,
   llmService,
   memoryService,
+  opportunityService,
   proofOfWorkService,
   workspaceService,
 } from '../services/index.js';
@@ -44,6 +45,8 @@ export interface AgentRunOptions {
   draftOnly?: boolean;
   refresh?: boolean;
   dryRun?: boolean;
+  /** 跳过搜索，直接处理指定 issue，格式 owner/repo#123 */
+  issue?: string;
 }
 
 export interface ScoutRunOptions {
@@ -75,6 +78,15 @@ interface ConcretePatchResult {
 
 type AgentStageId = 'scout' | 'select' | 'prepare' | 'draft' | 'validate' | 'pr' | 'publish';
 const ARTIFACT_PUBLISH_BRANCH = 'openmeta-artifacts';
+
+interface AgentCheckpoint {
+  rankedIssues: RankedIssue[];
+  selectedIssue?: RankedIssue;
+  completedStages: AgentStageId[];
+  savedAt: string;
+}
+
+const CHECKPOINT_FILE = 'agent-checkpoint.json';
 
 const AGENT_STAGES: Array<{ id: AgentStageId; label: string; description: string }> = [
   {
@@ -146,44 +158,93 @@ export class AgentOrchestrator {
       await this.confirmManualHeadlessRun(config);
     }
 
-    this.renderAgentStage('scout', completedStages, 'Verifying provider access and loading ranked opportunities.');
     await this.initializeClients(config);
 
-    const rankedIssues = await ui.task({
-      title: 'Ranking contribution opportunities',
-      doneMessage: 'Opportunity ranking complete',
-      failedMessage: 'Opportunity ranking failed',
-      tone: 'info',
-    }, async (task) => issueRankingService.loadRankedIssues(config, {
-      refresh,
-      onStatus: (message) => task.setMessage(message),
-    }));
-    if (rankedIssues.length === 0) {
-      ui.emptyState(
-        'OpenMeta Agent',
-        'No viable issues found',
-        'No issues met the current technical match threshold. Broaden your profile or try again later.',
-      );
-      return;
-    }
-    completedStages.add('scout');
+    let rankedIssues: RankedIssue[];
+    let selectedIssue: RankedIssue | undefined;
 
-    this.renderAgentStage('select', completedStages, 'Review the top ranked issues and choose the next contribution target.');
-    this.renderOpportunityList('Top ranked opportunities', rankedIssues.slice(0, 5));
-    const selectedIssue = headless
-      ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
-      : await this.promptForIssue(rankedIssues);
+    // ── 直接指定 issue：跳过搜索 ──
+    if (options.issue) {
+      rankedIssues = [];
+      try {
+        selectedIssue = await this.resolveDirectIssue(options.issue, config);
+        logger.info(`Skipping scout — working directly on ${options.issue}`);
+      } catch (err) {
+        logger.error(`Failed to resolve issue "${options.issue}": ${err instanceof Error ? err.message : String(err)}`);
+        return;
+      }
+      completedStages.add('scout');
+      completedStages.add('select');
+      this.showSelectedOpportunity(selectedIssue, headless);
+    } else {
+      // ── 断点恢复 ──
+      const checkpoint = this.loadCheckpoint();
+      if (checkpoint && !headless && !refresh) {
+        const resumeChoice = await selectPrompt({
+          message: `Found a checkpoint from ${checkpoint.savedAt}. Resume from where you left off?`,
+          choices: [
+            { name: 'Resume (skip scout)', value: 'resume' as const },
+            { name: 'Start fresh', value: 'fresh' as const },
+          ],
+        });
+        if (resumeChoice === 'resume') {
+          rankedIssues = checkpoint.rankedIssues;
+          for (const stage of checkpoint.completedStages) {
+            completedStages.add(stage);
+          }
+          logger.info(`Resuming from checkpoint — ${completedStages.size} stage(s) already completed`);
 
-    if (!selectedIssue) {
-      ui.emptyState(
-        'OpenMeta Agent',
-        'No issue met the automation threshold',
-        `Top opportunities were below ${config.automation.minMatchScore}/100. Lower the threshold or widen your profile.`,
-      );
-      return;
+          if (checkpoint.selectedIssue) {
+            selectedIssue = checkpoint.selectedIssue;
+            this.showSelectedOpportunity(selectedIssue, headless);
+          }
+        }
+      }
+
+      // ── Scout: 搜索 issue ──
+      if (!rankedIssues!) {
+        this.renderAgentStage('scout', completedStages, 'Verifying provider access and loading ranked opportunities.');
+        rankedIssues = await ui.task({
+          title: 'Ranking contribution opportunities',
+          doneMessage: 'Opportunity ranking complete',
+          failedMessage: 'Opportunity ranking failed',
+          tone: 'info',
+        }, async () => issueRankingService.loadRankedIssues(config, { refresh }));
+        if (rankedIssues.length === 0) {
+          ui.emptyState(
+            'OpenMeta Agent',
+            'No viable issues found',
+            'No issues met the current technical match threshold. Broaden your profile or try again later.',
+          );
+          return;
+        }
+        completedStages.add('scout');
+        // 保存 checkpoint：搜索和评分是最耗时的
+        this.saveCheckpoint({ rankedIssues, completedStages: [...completedStages] });
+      }
+
+      // ── Select: 选择目标 issue ──
+      if (!selectedIssue) {
+        this.renderAgentStage('select', completedStages, 'Review the top ranked issues and choose the next contribution target.');
+        this.renderOpportunityList('Top ranked opportunities', rankedIssues.slice(0, 5));
+        selectedIssue = headless
+          ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+          : await this.promptForIssue(rankedIssues);
+
+        if (!selectedIssue) {
+          ui.emptyState(
+            'OpenMeta Agent',
+            'No issue met the automation threshold',
+            `Top opportunities were below ${config.automation.minMatchScore}/100. Lower the threshold or widen your profile.`,
+          );
+          return;
+        }
+        completedStages.add('select');
+        this.showSelectedOpportunity(selectedIssue, headless);
+        // 更新 checkpoint
+        this.saveCheckpoint({ rankedIssues, selectedIssue, completedStages: [...completedStages] });
+      }
     }
-    completedStages.add('select');
-    this.showSelectedOpportunity(selectedIssue, headless);
 
     this.renderAgentStage('prepare', completedStages, `Cloning and inspecting ${selectedIssue.repoFullName}.`);
     const memoryBeforeRun = memoryService.load(selectedIssue.repoFullName);
@@ -202,15 +263,63 @@ export class AgentOrchestrator {
     completedStages.add('prepare');
     this.showWorkspaceSummary(workspace, memory);
 
-    this.renderAgentStage('draft', completedStages, 'Drafting patch strategy and turning it into concrete file changes.');
-    const patchDraftResult = await ui.task({
-      title: 'Generating patch strategy',
-      doneMessage: 'Patch strategy generated',
-      failedMessage: 'Patch strategy generation failed',
-      tone: 'info',
-    }, async () => llmService.generatePatchDraft(selectedIssue, workspace, memory));
-    const patchDraft = patchDraftResult.data;
-    if (patchDraftResult.status !== 'success') {
+    // ── Draft: 多方案生成并让用户选择 ──
+    let patchDraft: PatchDraft;
+    let patchDraftStatus: StructuredOutputStatus = 'success';
+
+    if (!headless) {
+      this.renderAgentStage('draft', completedStages, 'Generating multiple fix approaches and letting you choose.');
+      const multiResult = await ui.task({
+        title: 'Generating fix approaches',
+        doneMessage: 'Approaches generated',
+        failedMessage: 'Approach generation failed',
+        tone: 'info',
+      }, async () => llmService.generateMultiApproachPatch(selectedIssue, workspace, memory));
+
+      if (multiResult.status === 'success' && multiResult.data.approaches.length >= 2) {
+        // 让用户选方案
+        const approaches = multiResult.data.approaches;
+        const choice = await selectPrompt({
+          message: `Found ${approaches.length} approaches. Which one do you prefer?`,
+          choices: approaches.map((a, i) => ({
+            name: `${i === 0 ? '⭐ ' : ''}${a.name} — ${a.description}`,
+            value: a,
+          })),
+        });
+        patchDraft = choice.patchDraft;
+        logger.info(`User selected approach: ${choice.name}`);
+      } else {
+        // 多方案失败，回退到单方案
+        logger.warn('Multi-approach generation yielded insufficient approaches. Falling back to single approach.');
+        const fallback = await ui.task({
+          title: 'Generating single patch strategy',
+          doneMessage: 'Patch strategy generated',
+          failedMessage: 'Patch strategy generation failed',
+          tone: 'info',
+        }, async () => llmService.generatePatchDraft(selectedIssue, workspace, memory));
+        patchDraft = fallback.data;
+        patchDraftStatus = fallback.status;
+      }
+    } else {
+      // Headless: 直接用单方案（第一个方案，即推荐方案）
+      this.renderAgentStage('draft', completedStages, 'Drafting patch strategy and turning it into concrete file changes.');
+      const result = await ui.task({
+        title: 'Generating patch strategy',
+        doneMessage: 'Patch strategy generated',
+        failedMessage: 'Patch strategy generation failed',
+        tone: 'info',
+      }, async () => llmService.generateMultiApproachPatch(selectedIssue, workspace, memory));
+      if (result.status === 'success' && result.data.approaches.length > 0) {
+        const firstApproach = result.data.approaches[0]!;
+        patchDraft = firstApproach.patchDraft;
+      } else {
+        const fallback = await llmService.generatePatchDraft(selectedIssue, workspace, memory);
+        patchDraft = fallback.data;
+        patchDraftStatus = fallback.status;
+      }
+    }
+
+    if (patchDraftStatus !== 'success') {
       this.showStructuredReviewNotice({
         title: 'Patch strategy requires review',
         subtitle: 'OpenMeta marked the generated patch plan as review-required, so this run will preserve artifacts but skip concrete code edits.',
@@ -220,7 +329,7 @@ export class AgentOrchestrator {
       });
     }
     const implementationWorkspace = this.buildImplementationWorkspace(workspace, patchDraft);
-    const implementation = patchDraftResult.status === 'success'
+    const implementation = patchDraftStatus === 'success'
       ? await this.generateConcretePatch(selectedIssue, implementationWorkspace, patchDraft, runChecks, draftOnly)
       : {
         changedFiles: [],
@@ -259,7 +368,7 @@ export class AgentOrchestrator {
 
     const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
       config,
-      allowRealPr: patchDraftResult.status === 'success' && prDraftResult.status === 'success',
+      allowRealPr: patchDraftStatus === 'success' && prDraftResult.status === 'success',
       headless,
       issue: selectedIssue,
       prDraft,
@@ -350,7 +459,7 @@ export class AgentOrchestrator {
     });
 
     const reviewRequired =
-      patchDraftResult.status !== 'success'
+      patchDraftStatus !== 'success'
       || implementation.reviewRequired
       || prDraftResult.status !== 'success';
     const finalProofRecord = {
@@ -378,6 +487,7 @@ export class AgentOrchestrator {
       proofMarkdown: finalProofMarkdown,
     });
     completedStages.add('publish');
+    this.clearCheckpoint();
 
     this.showResult({
       issue: selectedIssue,
@@ -420,11 +530,7 @@ export class AgentOrchestrator {
       doneMessage: 'Contribution opportunities scored',
       failedMessage: 'Contribution opportunity scoring failed',
       tone: 'info',
-    }, async (task) => issueRankingService.loadRankedIssues(config, {
-      refresh,
-      localOnly,
-      onStatus: (message) => task.setMessage(message),
-    }));
+    }, async () => issueRankingService.loadRankedIssues(config, { refresh, localOnly }));
     if (rankedIssues.length === 0) {
       ui.emptyState('OpenMeta Scout', 'No issues found', 'No issues met the current scoring thresholds.');
       return;
@@ -1768,6 +1874,72 @@ export class AgentOrchestrator {
     if (!status.tracking) {
       await git.commit('chore: initialize repository', { '--allow-empty': null });
       await git.raw(['push', '--set-upstream', 'origin', defaultBranch]);
+    }
+  }
+
+  // ── 直接指定 issue ──
+  private async resolveDirectIssue(ref: string, config: AppConfig): Promise<RankedIssue> {
+    const match = ref.match(/^([\w.-]+)\/([\w.-]+)#(\d+)$/);
+    if (!match || !match[1] || !match[2] || !match[3]) {
+      throw new Error(`Invalid issue reference "${ref}". Expected format: owner/repo#number`);
+    }
+    const owner = match[1];
+    const repo = match[2];
+    const issueNum = match[3];
+    const issueNumber = parseInt(issueNum, 10);
+
+    const githubIssue = await githubService.fetchIssueByRef(owner, repo, issueNumber);
+    const ranked = opportunityService.rankIssues(
+      await issueRankingService.scoreIssuesInBatches(config.userProfile, [githubIssue])
+    );
+    const result = ranked[0];
+    if (!result) {
+      throw new Error(`Failed to rank issue "${ref}". The LLM scoring may have returned no results.`);
+    }
+    return result;
+  }
+
+  // ── Checkpoint 断点恢复 ──
+  private getCheckpointPath(): string {
+    return join(ensureDirectory(join(homedir(), '.openmeta', 'state')), CHECKPOINT_FILE);
+  }
+
+  private loadCheckpoint(): AgentCheckpoint | null {
+    try {
+      const path = this.getCheckpointPath();
+      if (!existsSync(path)) return null;
+      const data = JSON.parse(readFileSync(path, 'utf-8'));
+      // 1 小时过期
+      if (Date.now() - new Date(data.savedAt).getTime() > 60 * 60 * 1000) {
+        try { unlinkSync(path); } catch { /* ok */ }
+        return null;
+      }
+      return data as AgentCheckpoint;
+    } catch {
+      return null;
+    }
+  }
+
+  private saveCheckpoint(data: { rankedIssues: RankedIssue[]; selectedIssue?: RankedIssue; completedStages: AgentStageId[] }): void {
+    try {
+      const checkpoint: AgentCheckpoint = {
+        ...data,
+        savedAt: new Date().toISOString(),
+      };
+      writeFileSync(this.getCheckpointPath(), JSON.stringify(checkpoint, null, 2), 'utf-8');
+    } catch {
+      // 非致命，静默跳过
+    }
+  }
+
+  private clearCheckpoint(): void {
+    try {
+      const path = this.getCheckpointPath();
+      if (existsSync(path)) {
+        unlinkSync(path);
+      }
+    } catch {
+      // ok
     }
   }
 }

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -23,9 +23,9 @@ const ACTION_BLOCKING_LABELS = [
 const SEARCH_RESULTS_PER_PAGE = 30;
 const SEARCH_CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_PAGINATION_RETRIES = 3;
-const MAX_SEARCH_PAGES = 4;
-const SEARCH_PAGE_PACING_DELAY_MS = 3_000;
-const RATE_LIMIT_RETRY_FALLBACK_DELAY_MS = 10_000;
+const MAX_SEARCH_PAGES = 6;
+const PAGE_DELAY_MS = 2500;
+const RATE_LIMIT_RETRY_BASE_DELAY_MS = 1000;
 
 type SearchIssueItem =
   RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'][number];
@@ -54,7 +54,6 @@ interface IssueCachePayload {
 
 interface IssueDiscoveryOptions {
   refresh?: boolean;
-  onStatus?: (message: string) => void;
 }
 
 export class GitHubService {
@@ -62,15 +61,7 @@ export class GitHubService {
   private username: string = '';
 
   initialize(pat: string, username: string): void {
-    this.octokit = new Octokit({
-      auth: pat,
-      log: {
-        debug: () => {},
-        info: () => {},
-        warn: (message, ...args) => logger.debug(`GitHub client: ${String(message)}`, ...args),
-        error: (message, ...args) => logger.debug(`GitHub client: ${String(message)}`, ...args),
-      },
-    });
+    this.octokit = new Octokit({ auth: pat });
     this.username = username;
   }
 
@@ -110,13 +101,13 @@ export class GitHubService {
     const candidateItems: SearchIssueItem[] = [];
     const repoCache = new Map<string, RepoMetadata>();
     const failures: SearchFailure[] = [];
+    let totalBeforeDedup = 0;
 
     try {
       for (const labelGroup of FILTER_LABEL_GROUPS) {
         try {
           const searchQuery = this.buildSearchQuery(labelGroup);
-          options.onStatus?.(this.buildSearchStatusMessage(labelGroup));
-          const items = await this.paginateSearchWithRetry(searchQuery, labelGroup, options.onStatus);
+          const items = await this.paginateSearchWithRetry(searchQuery);
 
           logger.debug(`Search query: ${searchQuery}`);
           logger.debug(`Fetched ${items.length} total results for "${labelGroup.join(' / ')}"`);
@@ -126,6 +117,7 @@ export class GitHubService {
               continue;
             }
 
+            totalBeforeDedup++;
             const repoId = this.parseRepositoryUrl(item.repository_url);
             const issueKey = `${repoId.fullName}#${item.number}`;
 
@@ -139,13 +131,17 @@ export class GitHubService {
         } catch (error) {
           const failure = this.describeSearchFailure(error);
           failures.push({ labelGroup, ...failure });
-          logger.debug(`Issue search failed for labels "${labelGroup.join('" / "')}". ${failure.reason}`);
-          options.onStatus?.('GitHub search is being stubborn, but OpenMeta is still pulling together the best issue set it can.');
+          logger.warn(`Issue search failed for labels "${labelGroup.join('" / "')}". ${failure.reason}`);
         }
       }
 
       if (candidateItems.length === 0 && failures.length > 0) {
         throw new Error(this.buildDiscoveryFailureMessage(failures));
+      }
+
+      const duplicatesDeduped = totalBeforeDedup - candidateItems.length;
+      if (duplicatesDeduped > 0) {
+        logger.info(`Dedup: filtered ${duplicatesDeduped} duplicate issues (same issue appeared in multiple label groups)`);
       }
 
       candidateItems.sort((left, right) =>
@@ -199,6 +195,40 @@ export class GitHubService {
 
   getUsername(): string {
     return this.username;
+  }
+
+  async fetchIssueByRef(owner: string, repo: string, issueNumber: number): Promise<GitHubIssue> {
+    if (!this.octokit) {
+      throw new Error('GitHub service not initialized');
+    }
+
+    const { data: item } = await this.octokit.rest.issues.get({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+
+    const repoData = await this.fetchRepoMetadata(
+      { owner, repo, fullName: `${owner}/${repo}` },
+      new Map(),
+    );
+
+    return {
+      id: item.id,
+      number: item.number,
+      title: item.title,
+      body: item.body || '',
+      htmlUrl: item.html_url,
+      repoName: repo,
+      repoFullName: `${owner}/${repo}`,
+      repoDescription: repoData.description,
+      repoStars: repoData.stars,
+      labels: (item.labels && Array.isArray(item.labels)
+        ? (item.labels as Array<{ name?: string }>).map((l) => l.name ?? '').filter(Boolean)
+        : []),
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+    };
   }
 
   private buildSearchQuery(labels: readonly string[]): string {
@@ -351,11 +381,7 @@ export class GitHubService {
     };
   }
 
-  private async paginateSearchWithRetry(
-    searchQuery: string,
-    labelGroup: readonly string[],
-    onStatus?: (message: string) => void,
-  ): Promise<SearchIssueItem[]> {
+  private async paginateSearchWithRetry(searchQuery: string): Promise<SearchIssueItem[]> {
     if (!this.octokit) {
       throw new Error('GitHub service not initialized');
     }
@@ -367,40 +393,33 @@ export class GitHubService {
 
     while (attempt < MAX_PAGINATION_RETRIES) {
       try {
-        while (pagesFetched < MAX_SEARCH_PAGES) {
-          if (pagesFetched > 0) {
-            onStatus?.('Still pulling issue candidates...');
-            await this.delay(SEARCH_PAGE_PACING_DELAY_MS);
-          }
-
-          const response = await this.octokit.rest.search.issuesAndPullRequests({
+        for await (const response of this.octokit.paginate.iterator(
+          this.octokit.rest.search.issuesAndPullRequests,
+          {
             q: searchQuery,
             sort: 'updated',
             order: 'desc',
             per_page: SEARCH_RESULTS_PER_PAGE,
             page: currentPage,
-          });
-          const pageItems: SearchIssueItem[] = Array.isArray(response.data.items)
-            ? (response.data.items as SearchIssueItem[])
+          },
+        )) {
+          const pageItems: SearchIssueItem[] = Array.isArray((response as any).data)
+            ? (response as any).data
             : [];
-          const totalCount = typeof response.data.total_count === 'number' ? response.data.total_count : 0;
 
           items.push(...pageItems);
           pagesFetched++;
-          const hasMorePages = pageItems.length > 0 && totalCount > pagesFetched * SEARCH_RESULTS_PER_PAGE;
+          currentPage++;
+
+          // 翻页之间暂停一下，避免触发 GitHub 二次限速
+          if (pagesFetched > 1) {
+            await this.delay(PAGE_DELAY_MS);
+          }
 
           if (pagesFetched >= MAX_SEARCH_PAGES) {
             logger.debug(`Reached page limit (${MAX_SEARCH_PAGES}). Stopping pagination.`);
-            onStatus?.(`Captured the strongest issue candidates for ${labelGroup.join(' / ')}.`);
             return items;
           }
-
-          if (!hasMorePages) {
-            onStatus?.(`Finished pulling issue candidates for ${labelGroup.join(' / ')}.`);
-            return items;
-          }
-
-          currentPage++;
         }
         return items;
       } catch (error) {
@@ -413,8 +432,8 @@ export class GitHubService {
             const resetHeader = err.headers?.['x-ratelimit-reset'];
             const retryAfterHeader = err.headers?.['retry-after'];
 
-            // Short fallback when GitHub omits retry headers; still grows per attempt.
-            let delayMs = RATE_LIMIT_RETRY_FALLBACK_DELAY_MS + RATE_LIMIT_RETRY_FALLBACK_DELAY_MS * (attempt - 1);
+            // Default conservative fallback if no headers are provided (60s + slight exponential backoff)
+            let delayMs = 60_000 + RATE_LIMIT_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
 
             const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : Number.NaN;
             if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
@@ -430,14 +449,12 @@ export class GitHubService {
               }
             }
 
-            logger.debug(`Rate limited during pagination (attempt ${attempt}/${MAX_PAGINATION_RETRIES}). Retrying in ${Math.round(delayMs / 1000)}s...`);
-            onStatus?.('GitHub is throttling search requests. Holding briefly and trying again...');
+            logger.warn(`Rate limited during pagination (attempt ${attempt}/${MAX_PAGINATION_RETRIES}). Retrying in ${Math.round(delayMs / 1000)}s...`);
             await this.delay(delayMs);
             continue;
           } else if (items.length > 0) {
             // MAX_PAGINATION_RETRIES exhausted, but we have some data. Graceful return.
-            logger.debug(`Pagination retries exhausted. Yielding ${items.length} items collected so far.`);
-            onStatus?.('GitHub kept throttling search requests, so OpenMeta is continuing with the strongest issues already collected.');
+            logger.warn(`Pagination retries exhausted. Yielding ${items.length} items collected so far.`);
             return items;
           }
         }
@@ -447,10 +464,6 @@ export class GitHubService {
     }
 
     throw new Error(`Pagination exhausted after ${MAX_PAGINATION_RETRIES} attempts`);
-  }
-
-  private buildSearchStatusMessage(labelGroup: readonly string[]): string {
-    return `Pulling issue candidates for ${labelGroup.join(' / ')}...`;
   }
 
   private delay(ms: number): Promise<void> {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -3,8 +3,10 @@ import { z } from 'zod';
 import {
   ImplementationDraftEnvelopeSchema,
   IssueMatchListEnvelopeSchema,
+  MultiApproachPatchEnvelopeSchema,
   PatchDraftEnvelopeSchema,
   type StructuredOutputResult,
+  type MultiApproachPatch,
   type PatchDraft,
   PullRequestDraftEnvelopeSchema,
   type PullRequestDraft,
@@ -38,7 +40,7 @@ import {
   DAILY_REPORT_GENERATE_PROMPT,
   DAILY_DIARY_GENERATE_PROMPT,
   PATCH_DRAFT_PROMPT,
-  PATCH_DRAFT_REPAIR_PROMPT,
+  MULTI_APPROACH_PATCH_PROMPT,
   PR_DRAFT_PROMPT,
   VALIDATION_REPAIR_PROMPT,
 } from '../infra/prompt-templates.js';
@@ -189,7 +191,34 @@ Repo Stars: ${i.repoStars}`
     return this.generateStructuredOutput({
       prompt,
       parser: this.parsePatchDraft.bind(this),
-      repairPrompt: PATCH_DRAFT_REPAIR_PROMPT,
+    });
+  }
+
+  async generateMultiApproachPatch(
+    issue: RankedIssue,
+    workspace: RepoWorkspaceContext,
+    memory: RepoMemory,
+  ): Promise<StructuredOutputResult<'multi_approach_patch', MultiApproachPatch>> {
+    const repoContext = [
+      `Workspace Path: ${workspace.workspacePath}`,
+      `Default Branch: ${workspace.defaultBranch}`,
+      `Candidate Files: ${workspace.candidateFiles.join(', ') || 'none'}`,
+      `Detected Test Commands: ${workspace.testCommands.map((item) => item.command).join(', ') || 'none'}`,
+      'Snippets:',
+      ...workspace.snippets.map((snippet) => `FILE: ${snippet.path}\n${snippet.content}`),
+    ].join('\n\n');
+
+    const repoMemory = this.formatRepoMemory(memory);
+
+    const prompt = fillPrompt(MULTI_APPROACH_PATCH_PROMPT, {
+      issueContext: this.formatRankedIssue(issue),
+      repoContext,
+      repoMemory,
+    });
+
+    return this.generateStructuredOutput({
+      prompt,
+      parser: this.parseMultiApproachPatch.bind(this),
     });
   }
 
@@ -360,6 +389,12 @@ Repo Stars: ${i.repoStars}`
 
   private parsePatchDraft(content: string): StructuredOutputResult<'patch_draft', PatchDraft> {
     return this.parseStructuredJson(content, PatchDraftEnvelopeSchema);
+  }
+
+  private parseMultiApproachPatch(
+    content: string,
+  ): StructuredOutputResult<'multi_approach_patch', MultiApproachPatch> {
+    return this.parseStructuredJson(content, MultiApproachPatchEnvelopeSchema);
   }
 
   private parsePullRequestDraft(


### PR DESCRIPTION
## 改动概览

### 1. --issue 直接指定 issue（跳过搜索）
```bash
openmeta agent --issue mohitkumhar/business-ai-agent#86
```
跳过 scout + select，直接进入 workspace 准备阶段。

### 2. 断点恢复（Checkpoint）
搜索和 LLM 评分完成后自动保存 checkpoint。失败重启时提示 Resume，跳过已完成的搜索。1 小时后自动过期，成功完成自动清理。

### 3. 搜索去重 + API 限速优化
- 跨标签组去重（good-first-issue + help-wanted 重复 issue 自动过滤）
- 翻页间隔 2.5s 避免触发 GitHub 二次限速
- 翻页上限从 8 降到 6

### 4. 多方案选择
非 headless 模式下，LLM 生成 2-3 个修复方案供用户选择，每个方案带优劣分析。

## 改动文件

| 文件 | 改动 |
|------|------|
| src/commands/agent.ts | --issue CLI 参数 |
| src/orchestration/agent.ts | checkpoint 恢复、--issue 支持、多方案选择 |
| src/services/github.ts | fetchIssueByRef、翻页延迟、去重日志 |
| src/services/llm.ts | generateMultiApproachPatch 方法 |
| src/contracts/agent-contracts.ts | MultiApproachPatch/PatchApproach schema |
| src/infra/prompt-templates.ts | MULTI_APPROACH_PATCH_PROMPT |

## 测试
109 pass, 1 fail（1 个超时是已有的 github.test.ts 超时，与本次无关）