### PR TITLE
fix(agent): use post-fetch star filter and improve result diversity

### DIFF
--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -195,13 +195,16 @@ export class AgentOrchestrator {
       ? 'Using the explicitly targeted issue as the contribution target.'
       : 'Review the top ranked issues and choose the next contribution target.');
     if (!issueTarget) {
-      this.renderOpportunityList('Top ranked opportunities', rankedIssues.slice(0, 5));
+      const displayIssues = issueRankingService.diversifyScoutIssues(rankedIssues, 5);
+      this.renderOpportunityList('Top ranked opportunities', displayIssues);
     }
     const selectedIssue = issueTarget
       ? rankedIssues[0]
       : headless
         ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
-        : await this.promptForIssue(rankedIssues);
+        : await this.promptForIssue(
+          issueRankingService.diversifyScoutIssues(rankedIssues, 5),
+        );
 
     if (!selectedIssue) {
       ui.emptyState(

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -26,7 +26,7 @@ const MAX_PAGINATION_RETRIES = 3;
 const MAX_SEARCH_PAGES = 4;
 const SEARCH_PAGE_PACING_DELAY_MS = 3_000;
 const RATE_LIMIT_RETRY_FALLBACK_DELAY_MS = 10_000;
-const MAX_ISSUES_PER_REPO = 5;
+const MAX_ISSUES_PER_REPO = 3;
 const MIN_REPO_STARS = 50;
 
 type SearchIssueItem =
@@ -212,6 +212,12 @@ export class GitHubService {
         const repoId = this.parseRepositoryUrl(item.repository_url);
         const repoData = await this.fetchRepoMetadata(repoId, repoCache);
 
+        // Post-fetch quality gate: GitHub issue search does not support the
+        // `stars:` qualifier, so we filter by repo stars after resolving metadata.
+        if (repoData.stars < MIN_REPO_STARS) {
+          continue;
+        }
+
         issues.push({
           id: item.id,
           number: item.number,
@@ -303,7 +309,7 @@ export class GitHubService {
   private buildSearchQuery(labels: readonly string[], repoFullName?: string): string {
     const joinedLabels = labels.map((label) => `label:"${label}"`).join(' OR ');
     const repoScope = repoFullName ? `repo:${repoFullName} ` : '';
-    return `${repoScope}(${joinedLabels}) archived:false is:issue is:open no:assignee stars:>${MIN_REPO_STARS}`;
+    return `${repoScope}(${joinedLabels}) archived:false is:issue is:open no:assignee`;
   }
 
   private buildRepositorySearchQuery(repoFullName: string): string {
@@ -323,7 +329,7 @@ export class GitHubService {
     if (!joinedTech) {
       return '';
     }
-    return `(${joinedLabels}) (${joinedTech}) archived:false is:issue is:open no:assignee stars:>${Math.max(1, MIN_REPO_STARS - 5)}`;
+    return `(${joinedLabels}) (${joinedTech}) archived:false is:issue is:open no:assignee`;
   }
 
   private shouldIncludeIssue(item: SearchIssueItem): boolean {

--- a/src/services/issue-ranking.ts
+++ b/src/services/issue-ranking.ts
@@ -111,14 +111,26 @@ export class IssueRankingService {
     issues: GitHubIssue[],
     userProfile: AppConfig['userProfile'],
   ): GitHubIssue[] {
-    return [...issues].sort((left, right) => {
-      const scoreDelta = this.scoreIssueForProfile(right, userProfile) - this.scoreIssueForProfile(left, userProfile);
-      if (scoreDelta !== 0) {
-        return scoreDelta;
-      }
+    const repoOrder = new Map<string, number>();
 
-      return new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime();
-    });
+    return [...issues]
+      .map((issue) => {
+        const repoIdx = repoOrder.get(issue.repoFullName) ?? 0;
+        repoOrder.set(issue.repoFullName, repoIdx + 1);
+        const sameRepoPenalty = repoIdx >= 2 ? 20 : repoIdx >= 1 ? 10 : 0;
+        return {
+          issue,
+          score: Math.max(0, this.scoreIssueForProfile(issue, userProfile) - sameRepoPenalty),
+        };
+      })
+      .sort((left, right) => {
+        const scoreDelta = right.score - left.score;
+        if (scoreDelta !== 0) {
+          return scoreDelta;
+        }
+        return new Date(right.issue.updatedAt).getTime() - new Date(left.issue.updatedAt).getTime();
+      })
+      .map((entry) => entry.issue);
   }
 
   selectIssueForAutomation(issues: RankedIssue[], minOverallScore: number): RankedIssue | undefined {
@@ -235,12 +247,14 @@ export class IssueRankingService {
       score -= 6;
     }
 
-    // Penalize issues with no updates in > 90 days
+    // Penalize stale issues — a >1yr old issue is almost certainly unmaintained
     const ageDays = (Date.now() - new Date(issue.updatedAt).getTime()) / (1000 * 60 * 60 * 24);
-    if (ageDays > 180) {
-      score -= 14;
+    if (ageDays > 365) {
+      score -= 35;
+    } else if (ageDays > 180) {
+      score -= 25;
     } else if (ageDays > 90) {
-      score -= 6;
+      score -= 12;
     }
 
     // Bonus for well-structured bug reports


### PR DESCRIPTION
## Summary

Follow-up to #48. Three fixes discovered during testing.

## Changes

### 1. Fix broken star filter

GitHub's issue search API **silently ignores** the `stars:` qualifier (it's repository-search-only). The previous implementation added `stars:>50` to the query but it had no effect — 1-star and 4-star repos were still appearing. Fixed by removing the non-functional query parameter and adding a post-fetch filter after repo metadata resolution.

### 2. Tighten quality thresholds

| Change | Before | After |
|--------|--------|-------|
| Per-repo issue cap | 5 | 3 |
| Staleness: 90+ days | -6 | -12 |
| Staleness: 180+ days | -14 | -25 |
| Staleness: 365+ days | (none) | -35 |
| Same-repo 2nd issue | (none) | -10 |
| Same-repo 3rd+ issue | (none) | -20 |

### 3. Agent select stage uses `diversifyScoutIssues`

The `openmeta scout` command already deduplicates by repository. This applies the same logic to `openmeta agent`, ensuring the selection menu shows at most one issue per repository.

## Testing

- `bun run typecheck` passes
- `bun test` passes (188 tests, 0 failures)
- Manual `--refresh` run verified: no low-star repos, no multi-year stale issues, single-repo dominance eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)