### PR TITLE
fix(scoring): address code review findings for customizable scoring weights

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -18,6 +18,11 @@ export function registerConfigCommand(program: Command): void {
     .action((key: string, value: string) => runCommand('OpenMeta Config', () => configOrchestrator.set(key, value)));
 
   config
+    .command('scoring')
+    .description('Configure scoring weights interactively with presets or custom values')
+    .action(() => runCommand('OpenMeta Scoring', () => configOrchestrator.scoring()));
+
+  config
     .command('reset')
     .description('Reset configuration to defaults')
     .action(() => runCommand('OpenMeta Config', () => configOrchestrator.reset()));

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -58,6 +58,20 @@ function createDefaultConfig(): AppConfig {
       minMatchScore: 70,
       skipIfAlreadyGeneratedToday: true,
     },
+    scoring: {
+      weights: {
+        freshness: 0.25,
+        onboardingClarity: 0.25,
+        mergePotential: 0.30,
+        impact: 0.20,
+        riskPenalty: 0.35,
+      },
+      overallWeights: {
+        technicalMatch: 0.45,
+        opportunityScore: 0.55,
+      },
+      preset: 'balanced',
+    },
     commitTemplate: 'feat(daily): {{title}}\n\n{{content}}',
   };
 }
@@ -199,6 +213,18 @@ export class ConfigService {
       automation: {
         ...defaults.automation,
         ...config.automation,
+      },
+      scoring: {
+        ...defaults.scoring,
+        ...config.scoring,
+        weights: {
+          ...defaults.scoring.weights,
+          ...config.scoring?.weights,
+        },
+        overallWeights: {
+          ...defaults.scoring.overallWeights,
+          ...config.scoring?.overallWeights,
+        },
       },
     };
   }

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -1,6 +1,6 @@
-import { configService, parseLLMReasoningEffort, prompt, ui } from '../infra/index.js';
-import { schedulerService } from '../services/index.js';
-import type { AppConfig } from '../types/index.js';
+import { configService, parseLLMReasoningEffort, prompt, selectPrompt, ui } from '../infra/index.js';
+import { schedulerService, SCORING_PRESETS, getPreset, normalizeWeights, normalizeOverallWeights } from '../services/index.js';
+import type { AppConfig, ScoringWeights, OverallWeights } from '../types/index.js';
 
 export class ConfigOrchestrator {
   async view(): Promise<void> {
@@ -86,6 +86,19 @@ export class ConfigOrchestrator {
       tone: 'muted',
     });
 
+    const sw = config.scoring.weights;
+    const ow = config.scoring.overallWeights;
+    ui.keyValues('Scoring weights', [
+      { label: 'Active preset', value: config.scoring.preset || 'custom', tone: config.scoring.preset ? 'success' : 'muted' },
+      { label: 'Freshness', value: `${(sw.freshness * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Onboarding Clarity', value: `${(sw.onboardingClarity * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Merge Potential', value: `${(sw.mergePotential * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Impact', value: `${(sw.impact * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Risk Penalty', value: `${(sw.riskPenalty * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Technical Match', value: `${(ow.technicalMatch * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Opportunity Score', value: `${(ow.opportunityScore * 100).toFixed(0)}%`, tone: 'info' },
+    ]);
+
     if (missingRequired > 0) {
       ui.callout({
         label: 'OpenMeta Config',
@@ -102,6 +115,10 @@ export class ConfigOrchestrator {
                        'github.username', 'github.pat', 'github.targetRepoPath', 'llm.provider', 'llm.apiBaseUrl', 'llm.apiKey', 'llm.modelName', 'llm.reasoningEffort', 'llm.stream',
                        'automation.enabled', 'automation.scheduleTime', 'automation.contentType',
                        'automation.minMatchScore', 'automation.skipIfAlreadyGeneratedToday',
+                       'scoring.weights.freshness', 'scoring.weights.onboardingClarity',
+                       'scoring.weights.mergePotential', 'scoring.weights.impact', 'scoring.weights.riskPenalty',
+                       'scoring.overallWeights.technicalMatch', 'scoring.overallWeights.opportunityScore',
+                       'scoring.preset',
                        'commitTemplate'];
 
     if (!validPaths.includes(key)) {
@@ -195,6 +212,34 @@ export class ConfigOrchestrator {
           skipIfAlreadyGeneratedToday: this.parseBoolean(value, key),
         },
       });
+    } else if (key.startsWith('scoring.weights.')) {
+      const weightKey = key.replace('scoring.weights.', '') as keyof ScoringWeights;
+      const numValue = Number.parseFloat(value);
+      if (Number.isNaN(numValue) || numValue < 0 || numValue > 1) {
+        throw new Error(`${key} must be a number between 0 and 1.`);
+      }
+      const newWeights = normalizeWeights({ ...config.scoring.weights, [weightKey]: numValue });
+      updated = await configService.update({
+        scoring: { ...config.scoring, weights: newWeights, preset: 'custom' },
+      });
+    } else if (key.startsWith('scoring.overallWeights.')) {
+      const weightKey = key.replace('scoring.overallWeights.', '') as keyof OverallWeights;
+      const numValue = Number.parseFloat(value);
+      if (Number.isNaN(numValue) || numValue < 0 || numValue > 1) {
+        throw new Error(`${key} must be a number between 0 and 1.`);
+      }
+      const newWeights = normalizeOverallWeights({ ...config.scoring.overallWeights, [weightKey]: numValue });
+      updated = await configService.update({
+        scoring: { ...config.scoring, overallWeights: newWeights, preset: 'custom' },
+      });
+    } else if (key === 'scoring.preset') {
+      const preset = getPreset(value);
+      if (!preset) {
+        throw new Error(`Unknown scoring preset "${value}". Available: ${SCORING_PRESETS.map(p => p.name).join(', ')}`);
+      }
+      updated = await configService.update({
+        scoring: { weights: preset.weights, overallWeights: preset.overallWeights, preset: preset.name },
+      });
     } else if (key === 'commitTemplate') {
       updated = await configService.update({ commitTemplate: value });
     } else {
@@ -222,6 +267,132 @@ export class ConfigOrchestrator {
       ],
       tone: resultTone,
     });
+  }
+
+  async scoring(): Promise<void> {
+    const config = await configService.get();
+
+    ui.hero({
+      label: 'OpenMeta Scoring',
+      title: 'Tune the scoring weights to match your contribution style',
+      subtitle: 'Choose a preset or customize individual weights. Higher weight = more influence on the final ranking.',
+      tone: 'accent',
+    });
+
+    const presetChoices = [
+      ...SCORING_PRESETS.map((p) => ({
+        name: `${p.label} — ${p.description}`,
+        value: p.name,
+      })),
+      { name: 'Custom — Adjust weights manually', value: 'custom' },
+    ];
+
+    const selectedPreset = await selectPrompt<string>({
+      message: 'Select a scoring preset',
+      choices: presetChoices,
+      default: config.scoring.preset || 'balanced',
+    });
+
+    let newWeights: ScoringWeights;
+    let newOverallWeights: OverallWeights;
+
+    if (selectedPreset !== 'custom') {
+      const preset = getPreset(selectedPreset)!;
+      newWeights = preset.weights;
+      newOverallWeights = preset.overallWeights;
+    } else {
+      ui.section('Custom weights', 'Enter a value between 0 and 100 for each dimension. They will be normalized automatically.');
+
+      const current = config.scoring.weights;
+      const entries: Array<{ key: keyof ScoringWeights; label: string; default: number }> = [
+        { key: 'freshness', label: 'Freshness (newer issues rank higher)', default: Math.round(current.freshness * 100) },
+        { key: 'onboardingClarity', label: 'Onboarding Clarity (clear descriptions, good-first-issue)', default: Math.round(current.onboardingClarity * 100) },
+        { key: 'mergePotential', label: 'Merge Potential (likely to be accepted)', default: Math.round(current.mergePotential * 100) },
+        { key: 'impact', label: 'Impact (repo stars and visibility)', default: Math.round(current.impact * 100) },
+        { key: 'riskPenalty', label: 'Risk Penalty (reduce score for risky issues)', default: Math.round(current.riskPenalty * 100) },
+      ];
+
+      const rawWeights: Record<string, number> = {};
+      for (const entry of entries) {
+        const result = await prompt<{ value: string }>([{
+          type: 'input',
+          name: 'value',
+          message: `${entry.label} (0-100)`,
+          default: String(entry.default),
+        }]);
+        const num = Number.parseInt(result.value, 10);
+        if (Number.isNaN(num) || num < 0 || num > 100) {
+          throw new Error('Weight must be an integer between 0 and 100.');
+        }
+        rawWeights[entry.key] = num / 100;
+      }
+
+      newWeights = normalizeWeights(rawWeights as unknown as ScoringWeights);
+
+      const owCurrent = config.scoring.overallWeights;
+      ui.section('Overall weights', 'Adjust the balance between technical match and opportunity score.');
+
+      const owEntries: Array<{ key: keyof OverallWeights; label: string; default: number }> = [
+        { key: 'technicalMatch', label: 'Technical Match (your stack vs issue)', default: Math.round(owCurrent.technicalMatch * 100) },
+        { key: 'opportunityScore', label: 'Opportunity Score (freshness, impact, clarity)', default: Math.round(owCurrent.opportunityScore * 100) },
+      ];
+
+      const rawOverall: Record<string, number> = {};
+      for (const entry of owEntries) {
+        const result = await prompt<{ value: string }>([{
+          type: 'input',
+          name: 'value',
+          message: `${entry.label} (0-100)`,
+          default: String(entry.default),
+        }]);
+        const num = Number.parseInt(result.value, 10);
+        if (Number.isNaN(num) || num < 0 || num > 100) {
+          throw new Error('Weight must be an integer between 0 and 100.');
+        }
+        rawOverall[entry.key] = num / 100;
+      }
+
+      newOverallWeights = normalizeOverallWeights(rawOverall as unknown as OverallWeights);
+    }
+
+    ui.keyValues('Preview — Scoring weights', [
+      { label: 'Preset', value: selectedPreset === 'custom' ? 'custom' : selectedPreset, tone: 'success' },
+      { label: 'Freshness', value: `${(newWeights.freshness * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Onboarding Clarity', value: `${(newWeights.onboardingClarity * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Merge Potential', value: `${(newWeights.mergePotential * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Impact', value: `${(newWeights.impact * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Risk Penalty', value: `${(newWeights.riskPenalty * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Technical Match', value: `${(newOverallWeights.technicalMatch * 100).toFixed(0)}%`, tone: 'info' },
+      { label: 'Opportunity Score', value: `${(newOverallWeights.opportunityScore * 100).toFixed(0)}%`, tone: 'info' },
+    ]);
+
+    const { confirm } = await prompt<{ confirm: boolean }>([{
+      type: 'confirm',
+      name: 'confirm',
+      message: 'Save these scoring weights?',
+      default: true,
+    }]);
+
+    if (confirm) {
+      const presetName = selectedPreset === 'custom' ? 'custom' : selectedPreset;
+      await configService.update({
+        scoring: { weights: newWeights, overallWeights: newOverallWeights, preset: presetName },
+      });
+      ui.banner({
+        label: 'OpenMeta Scoring',
+        title: 'Scoring weights updated',
+        subtitle: `Preset: ${presetName}. The new weights will be used in the next scout/agent run.`,
+        lines: [`Config: ${configService.getConfigPath()}`],
+        tone: 'success',
+      });
+    } else {
+      ui.callout({
+        label: 'OpenMeta Scoring',
+        title: 'Changes discarded',
+        subtitle: 'Scoring weights remain unchanged.',
+        tone: 'info',
+      });
+    }
   }
 
   async reset(): Promise<void> {
@@ -322,9 +493,14 @@ export class ConfigOrchestrator {
         return String(config.automation.minMatchScore);
       case 'automation.skipIfAlreadyGeneratedToday':
         return config.automation.skipIfAlreadyGeneratedToday ? 'yes' : 'no';
+      case 'scoring.preset':
+        return config.scoring.preset;
       case 'commitTemplate':
         return config.commitTemplate;
       default:
+        if (key.startsWith('scoring.')) {
+          return '(updated)';
+        }
         return '(updated)';
     }
   }

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -298,8 +298,8 @@ export class ConfigOrchestrator {
 
     if (selectedPreset !== 'custom') {
       const preset = getPreset(selectedPreset)!;
-      newWeights = preset.weights;
-      newOverallWeights = preset.overallWeights;
+      newWeights = { ...preset.weights };
+      newOverallWeights = { ...preset.overallWeights };
     } else {
       ui.section('Custom weights', 'Enter a value between 0 and 100 for each dimension. They will be normalized automatically.');
 
@@ -320,9 +320,9 @@ export class ConfigOrchestrator {
           message: `${entry.label} (0-100)`,
           default: String(entry.default),
         }]);
-        const num = Number.parseInt(result.value, 10);
+        const num = Number.parseFloat(result.value);
         if (Number.isNaN(num) || num < 0 || num > 100) {
-          throw new Error('Weight must be an integer between 0 and 100.');
+          throw new Error('Weight must be a number between 0 and 100.');
         }
         rawWeights[entry.key] = num / 100;
       }
@@ -345,9 +345,9 @@ export class ConfigOrchestrator {
           message: `${entry.label} (0-100)`,
           default: String(entry.default),
         }]);
-        const num = Number.parseInt(result.value, 10);
+        const num = Number.parseFloat(result.value);
         if (Number.isNaN(num) || num < 0 || num > 100) {
-          throw new Error('Weight must be an integer between 0 and 100.');
+          throw new Error('Weight must be a number between 0 and 100.');
         }
         rawOverall[entry.key] = num / 100;
       }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,4 +12,5 @@ export { proofOfWorkService, ProofOfWorkService } from './proof-of-work.js';
 export { workspaceService, WorkspaceService } from './workspace.js';
 export { runHistoryService, RunHistoryService } from './run-history.js';
 export { LLM_PROVIDER_PRESETS, findLLMProviderPreset, type LLMProviderPreset } from './llm.providers.js';
+export { SCORING_PRESETS, DEFAULT_SCORING, getPreset, normalizeWeights, normalizeOverallWeights } from './scoring-presets.js';
 export type { SchedulerSyncResult } from './scheduler.js';

--- a/src/services/issue-ranking.ts
+++ b/src/services/issue-ranking.ts
@@ -46,11 +46,11 @@ export class IssueRankingService {
     });
     const rankedCandidates = this.rankIssuesForProfile(issues, config.userProfile);
     if (options.localOnly) {
-      return opportunityService.rankIssues(this.buildLocalIssueMatches(rankedCandidates, config.userProfile));
+      return opportunityService.rankIssues(this.buildLocalIssueMatches(rankedCandidates, config.userProfile), config.scoring);
     }
 
     const matched = await this.scoreIssuesInBatches(config.userProfile, rankedCandidates);
-    return opportunityService.rankIssues(matched);
+    return opportunityService.rankIssues(matched, config.scoring);
   }
 
   async loadTargetIssue(
@@ -60,10 +60,10 @@ export class IssueRankingService {
     const issue = await githubService.fetchIssue(target.repoFullName, target.issueNumber);
     const [matched] = await this.scoreIssuesInBatches(config.userProfile, [issue]);
     if (!matched) {
-      return opportunityService.rankIssues(this.buildLocalIssueMatches([issue], config.userProfile));
+      return opportunityService.rankIssues(this.buildLocalIssueMatches([issue], config.userProfile), config.scoring);
     }
 
-    return opportunityService.rankIssues([matched]);
+    return opportunityService.rankIssues([matched], config.scoring);
   }
 
   buildLocalIssueMatches(

--- a/src/services/opportunity.ts
+++ b/src/services/opportunity.ts
@@ -1,4 +1,5 @@
-import type { MatchedIssue, OpportunityAnalysis, RankedIssue } from '../types/index.js';
+import type { MatchedIssue, OpportunityAnalysis, RankedIssue, ScoringConfig } from '../types/index.js';
+import { DEFAULT_SCORING } from './scoring-presets.js';
 
 const ACTION_RISK_LABELS = new Set([
   'blocked',
@@ -145,7 +146,11 @@ function computeRiskPenalty(issue: MatchedIssue): number {
 }
 
 export class OpportunityService {
-  rankIssues(issues: MatchedIssue[]): RankedIssue[] {
+  rankIssues(issues: MatchedIssue[], scoringConfig?: ScoringConfig): RankedIssue[] {
+    const config = scoringConfig ?? DEFAULT_SCORING;
+    const w = config.weights;
+    const ow = config.overallWeights;
+
     return issues
       .map((issue) => {
         const freshness = computeFreshnessScore(issue.updatedAt);
@@ -154,13 +159,13 @@ export class OpportunityService {
         const mergePotential = computeMergePotential(issue, freshness, riskPenalty);
         const impact = computeImpactScore(issue);
         const opportunityScore = clampScore(
-          freshness * 0.25 +
-          onboardingClarity * 0.25 +
-          mergePotential * 0.30 +
-          impact * 0.20 -
-          riskPenalty * 0.35,
+          freshness * w.freshness +
+          onboardingClarity * w.onboardingClarity +
+          mergePotential * w.mergePotential +
+          impact * w.impact -
+          riskPenalty * w.riskPenalty,
         );
-        const overallScore = clampScore(issue.matchScore * 0.45 + opportunityScore * 0.55);
+        const overallScore = clampScore(issue.matchScore * ow.technicalMatch + opportunityScore * ow.opportunityScore);
 
         const opportunity: OpportunityAnalysis = {
           score: opportunityScore,

--- a/src/services/scoring-presets.ts
+++ b/src/services/scoring-presets.ts
@@ -1,0 +1,74 @@
+import type { ScoringPreset, ScoringWeights, OverallWeights, ScoringConfig } from '../types/index.js';
+
+export const SCORING_PRESETS: ScoringPreset[] = [
+  {
+    name: 'balanced',
+    label: 'Balanced',
+    description: 'Default balanced scoring across all dimensions',
+    weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+    overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+  },
+  {
+    name: 'impact-first',
+    label: 'Impact First',
+    description: 'Prioritize high-star repos for resume/portfolio visibility',
+    weights: { freshness: 0.15, onboardingClarity: 0.15, mergePotential: 0.20, impact: 0.40, riskPenalty: 0.20 },
+    overallWeights: { technicalMatch: 0.40, opportunityScore: 0.60 },
+  },
+  {
+    name: 'quick-wins',
+    label: 'Quick Wins',
+    description: 'Prioritize fresh issues with clear descriptions for fast turnaround',
+    weights: { freshness: 0.35, onboardingClarity: 0.35, mergePotential: 0.20, impact: 0.05, riskPenalty: 0.15 },
+    overallWeights: { technicalMatch: 0.55, opportunityScore: 0.45 },
+  },
+  {
+    name: 'rising-stars',
+    label: 'Rising Stars',
+    description: 'Discover responsive 1k-5k star projects that are actively growing',
+    weights: { freshness: 0.25, onboardingClarity: 0.30, mergePotential: 0.25, impact: 0.05, riskPenalty: 0.20 },
+    overallWeights: { technicalMatch: 0.50, opportunityScore: 0.50 },
+  },
+  {
+    name: 'learning',
+    label: 'Learning',
+    description: 'Prioritize small, well-documented projects for learning',
+    weights: { freshness: 0.20, onboardingClarity: 0.40, mergePotential: 0.25, impact: 0.05, riskPenalty: 0.10 },
+    overallWeights: { technicalMatch: 0.55, opportunityScore: 0.45 },
+  },
+];
+
+export const DEFAULT_SCORING: ScoringConfig = {
+  weights: SCORING_PRESETS[0]!.weights,
+  overallWeights: SCORING_PRESETS[0]!.overallWeights,
+  preset: 'balanced',
+};
+
+export function getPreset(name: string): ScoringPreset | undefined {
+  return SCORING_PRESETS.find((p) => p.name === name);
+}
+
+export function normalizeWeights(weights: ScoringWeights): ScoringWeights {
+  const sum = weights.freshness + weights.onboardingClarity + weights.mergePotential + weights.impact;
+  if (sum === 0) {
+    return { ...DEFAULT_SCORING.weights };
+  }
+  return {
+    freshness: +(weights.freshness / sum).toFixed(3),
+    onboardingClarity: +(weights.onboardingClarity / sum).toFixed(3),
+    mergePotential: +(weights.mergePotential / sum).toFixed(3),
+    impact: +(weights.impact / sum).toFixed(3),
+    riskPenalty: weights.riskPenalty,
+  };
+}
+
+export function normalizeOverallWeights(weights: OverallWeights): OverallWeights {
+  const sum = weights.technicalMatch + weights.opportunityScore;
+  if (sum === 0) {
+    return { ...DEFAULT_SCORING.overallWeights };
+  }
+  return {
+    technicalMatch: +(weights.technicalMatch / sum).toFixed(3),
+    opportunityScore: +(weights.opportunityScore / sum).toFixed(3),
+  };
+}

--- a/src/services/scoring-presets.ts
+++ b/src/services/scoring-presets.ts
@@ -39,8 +39,8 @@ export const SCORING_PRESETS: ScoringPreset[] = [
 ];
 
 export const DEFAULT_SCORING: ScoringConfig = {
-  weights: SCORING_PRESETS[0]!.weights,
-  overallWeights: SCORING_PRESETS[0]!.overallWeights,
+  weights: { ...SCORING_PRESETS[0]!.weights },
+  overallWeights: { ...SCORING_PRESETS[0]!.overallWeights },
   preset: 'balanced',
 };
 

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -50,10 +50,38 @@ export interface AutomationConfig {
   skipIfAlreadyGeneratedToday: boolean;
 }
 
+export interface ScoringWeights {
+  freshness: number;
+  onboardingClarity: number;
+  mergePotential: number;
+  impact: number;
+  riskPenalty: number;
+}
+
+export interface OverallWeights {
+  technicalMatch: number;
+  opportunityScore: number;
+}
+
+export interface ScoringPreset {
+  name: string;
+  label: string;
+  description: string;
+  weights: ScoringWeights;
+  overallWeights: OverallWeights;
+}
+
+export interface ScoringConfig {
+  weights: ScoringWeights;
+  overallWeights: OverallWeights;
+  preset: string;
+}
+
 export interface AppConfig {
   userProfile: UserProfile;
   github: GitHubConfig;
   llm: LLMConfig;
   automation: AutomationConfig;
+  scoring: ScoringConfig;
   commitTemplate: string;
 }

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -161,7 +161,12 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       minMatchScore: 75,
       skipIfAlreadyGeneratedToday: false,
     },
-    commitTemplate: 'feat: {{title}}',
+    scoring: {
+      weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+      overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+      preset: 'balanced',
+    },
+    commitTemplate: 'feat: {title}',
     ...overrides,
   };
 }

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -166,7 +166,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
       preset: 'balanced',
     },
-    commitTemplate: 'feat: {title}',
+    commitTemplate: 'feat: {{title}}',
     ...overrides,
   };
 }

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -92,7 +92,12 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       minMatchScore: 75,
       skipIfAlreadyGeneratedToday: false,
     },
-    commitTemplate: 'feat: {{title}}',
+    scoring: {
+      weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+      overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+      preset: 'balanced',
+    },
+    commitTemplate: 'feat: {title}',
     ...overrides,
   };
 }

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -97,7 +97,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
       preset: 'balanced',
     },
-    commitTemplate: 'feat: {title}',
+    commitTemplate: 'feat: {{title}}',
     ...overrides,
   };
 }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -34,7 +34,12 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       minMatchScore: 70,
       skipIfAlreadyGeneratedToday: true,
     },
-    commitTemplate: 'feat(daily): {{title}}\n\n{{content}}',
+    scoring: {
+      weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+      overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+      preset: 'balanced',
+    },
+    commitTemplate: 'feat(daily): {title}\n\n{content}',
   };
 
   return {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -39,7 +39,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
       preset: 'balanced',
     },
-    commitTemplate: 'feat(daily): {title}\n\n{content}',
+    commitTemplate: 'feat(daily): {{title}}\n\n{{content}}',
   };
 
   return {

--- a/test/issue-ranking.test.ts
+++ b/test/issue-ranking.test.ts
@@ -183,6 +183,11 @@ describe('IssueRankingService', () => {
           minMatchScore: 70,
           skipIfAlreadyGeneratedToday: true,
         },
+      scoring: {
+        weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+        overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+        preset: 'balanced',
+      },
         commitTemplate: '{{content}}',
       }, {
         repoFullName: 'Wei-Shaw/sub2api',
@@ -242,6 +247,11 @@ describe('IssueRankingService', () => {
           minMatchScore: 70,
           skipIfAlreadyGeneratedToday: true,
         },
+      scoring: {
+        weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+        overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+        preset: 'balanced',
+      },
         commitTemplate: '{{content}}',
       }, {
         repoFullName: 'vercel/next.js',

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -64,7 +64,12 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       minMatchScore: 70,
       skipIfAlreadyGeneratedToday: true,
     },
-    commitTemplate: 'feat(daily): {{title}}\n\n{{content}}',
+    scoring: {
+      weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.30, impact: 0.20, riskPenalty: 0.35 },
+      overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
+      preset: 'balanced',
+    },
+    commitTemplate: 'feat(daily): {title}\n\n{content}',
     ...overrides,
   };
 }

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -69,7 +69,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
       preset: 'balanced',
     },
-    commitTemplate: 'feat(daily): {title}\n\n{content}',
+    commitTemplate: 'feat(daily): {{title}}\n\n{{content}}',
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes 3 bugs found during code review of the customizable scoring weights feature (#47):

### 1. commitTemplate 花括号格式错误
Test fixtures incorrectly changed `{{title}}` to `{title}` (single braces), which breaks the template replacement in `content.ts` that uses `.replace("{{title}}", ...)`.

**Fixed in:** `test/agent-orchestrator.test.ts`, `test/agent-run.test.ts`, `test/doctor.test.ts`, `test/scheduler.test.ts`

### 2. DEFAULT_SCORING 共享可变引用
`DEFAULT_SCORING.weights` was a direct reference to `SCORING_PRESETS[0].weights` (same object in memory). Any mutation through one reference would silently corrupt the "balanced" preset for the rest of the process lifetime.

**Fixed in:** `src/services/scoring-presets.ts`, `src/orchestration/config.ts`

### 3. parseInt 静默截断小数输入
The interactive scoring prompt used `Number.parseInt` which silently truncated decimal input (e.g., "50.5" → 50). Changed to `Number.parseFloat` to support fractional weight values.

**Fixed in:** `src/orchestration/config.ts`

## Testing
- All 188 tests pass ✅
- Build succeeds ✅
- Manually verified `openmeta config scoring` works correctly

Closes #47