### PR TITLE
[codex] add repository presets for contribution targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ openmeta agent
 
 # 3. 只看机会排名
 openmeta scout --limit 10
+openmeta scout --local --limit 10
 
 # 4. 查看贡献沉淀
 openmeta inbox
@@ -299,6 +300,7 @@ openmeta machine analyze --repo owner/name --dry-run
 | `openmeta scout --limit <count>` | 查看高价值贡献机会排名 |
 | `openmeta scout --refresh` | 强制刷新 GitHub issue discovery 缓存 |
 | `openmeta scout --repo <repository>` | 从一个 GitHub 仓库 URL 或 `owner/name` 中筛选贡献机会 |
+| `openmeta scout --local` | 使用本地启发式评分，不调用 LLM，适合模型服务暂时不可用时先筛机会 |
 | `openmeta inbox` | 查看已起草的贡献机会收件箱 |
 | `openmeta pow` | 查看贡献工作量证明记录 |
 | `openmeta runs` | 查看最近命令运行记录、耗时和失败原因 |
@@ -572,6 +574,7 @@ openmeta agent
 
 # 3. Only scout and rank opportunities
 openmeta scout --limit 10
+openmeta scout --local --limit 10
 
 # 4. Inspect durable contribution assets
 openmeta inbox
@@ -641,6 +644,7 @@ openmeta machine analyze --repo owner/name --dry-run
 | `openmeta scout --limit <count>` | Show ranked contribution opportunities |
 | `openmeta scout --refresh` | Force-refresh the GitHub issue discovery cache |
 | `openmeta scout --repo <repository>` | Rank opportunities from one upstream GitHub repository URL or `owner/name` |
+| `openmeta scout --local` | Use local heuristic scoring without calling the LLM provider |
 | `openmeta inbox` | Show drafted contribution opportunities |
 | `openmeta pow` | Show proof-of-work history |
 | `openmeta runs` | Show recent command runs, durations, and failure reasons |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   registerInitCommand,
   registerMachineCommand,
   registerPowCommand,
+  registerPresetCommand,
   registerProviderCommand,
   registerRunsCommand,
   registerScoutCommand,
@@ -40,6 +41,7 @@ async function main(): Promise<void> {
   registerPowCommand(program);
   registerConfigCommand(program);
   registerProviderCommand(program);
+  registerPresetCommand(program);
   registerAutomationCommand(program);
   registerDoctorCommand(program);
   registerRunsCommand(program);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -13,6 +13,8 @@ export function registerAgentCommand(program: Command): void {
     .option('--local-artifacts-only', 'Write local artifacts without publishing, committing, or pushing them')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
+    .option('--preset <name>', 'Use one saved repository preset as the exploration scope')
+    .option('--all-repos', 'Ignore the active repository preset and search the broader issue stream')
     .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
     .option('--dry-run', 'Preview artifacts without writing to git')
@@ -26,6 +28,8 @@ export function registerAgentCommand(program: Command): void {
         localArtifactsOnly?: boolean;
         refresh?: boolean;
         repo?: string;
+        preset?: string;
+        allRepos?: boolean;
         repoPath?: string;
         issue?: string;
         dryRun?: boolean;
@@ -40,6 +44,8 @@ export function registerAgentCommand(program: Command): void {
             localArtifactsOnly: options.localArtifactsOnly,
             refresh: options.refresh,
             repo: options.repo,
+            preset: options.preset,
+            allRepos: options.allRepos,
             repoPath: options.repoPath,
             issue: options.issue,
             dryRun: options.dryRun,

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -6,16 +6,25 @@ export function registerAnalyzeCommand(program: Command): void {
   program
     .command('analyze')
     .description('Analyze a repository and draft contribution suggestions without relying on existing issues')
-    .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name to analyze')
+    .option('--repo <repository>', 'GitHub repository URL or owner/name to analyze')
+    .option('--preset <name>', 'Use one saved repository preset as the analysis scope')
     .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--headless', 'Select the highest-scoring suggestion without prompting')
     .option('--run-checks', 'Execute detected baseline validation commands during workspace preparation')
     .option('--dry-run', 'Preview artifact paths without writing local analysis files')
     .action(
-      (options: { repo?: string; repoPath?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) =>
+      (options: {
+        repo?: string;
+        preset?: string;
+        repoPath?: string;
+        headless?: boolean;
+        runChecks?: boolean;
+        dryRun?: boolean;
+      }) =>
         runCommand('OpenMeta Analyze', () =>
           analyzeOrchestrator.run({
             repo: options.repo,
+            preset: options.preset,
             repoPath: options.repoPath,
             headless: options.headless,
             runChecks: options.runChecks,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 export { registerAgentCommand } from './agent.js';
 export { registerAnalyzeCommand } from './analyze.js';
+export { registerPresetCommand } from './preset.js';
 export { registerAutomationCommand } from './automation.js';
 export { registerConfigCommand } from './config.js';
 export { registerDailyCommand } from './daily.js';

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -1,0 +1,36 @@
+import { Command } from 'commander';
+import { presetOrchestrator } from '../orchestration/index.js';
+import { runCommand } from './run-command.js';
+
+export function registerPresetCommand(program: Command): void {
+  const preset = program
+    .command('preset')
+    .description('Manage reusable repository target presets');
+
+  preset
+    .command('list')
+    .alias('ls')
+    .description('List saved repository presets')
+    .action(() => runCommand('OpenMeta Preset', () => presetOrchestrator.list()));
+
+  preset
+    .command('add <name>')
+    .description('Add a repository preset from command-line values')
+    .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name; repeat for multiple repos', (value, previous: string[] = []) => [...previous, value], [])
+    .option('--activate', 'Mark this preset as the active default target set')
+    .action((name: string, options: { repo: string[]; activate?: boolean }) => runCommand(
+      'OpenMeta Preset',
+      () => presetOrchestrator.add(name, options),
+    ));
+
+  preset
+    .command('use <name>')
+    .description('Switch the active repository preset')
+    .action((name: string) => runCommand('OpenMeta Preset', () => presetOrchestrator.use(name)));
+
+  preset
+    .command('remove <name>')
+    .alias('rm')
+    .description('Remove a saved repository preset')
+    .action((name: string) => runCommand('OpenMeta Preset', () => presetOrchestrator.remove(name)));
+}

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -9,12 +9,22 @@ export function registerScoutCommand(program: Command): void {
     .option('--limit <count>', 'Number of opportunities to show', '10')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
-    .action((options: { limit?: string; refresh?: boolean; repo?: string }) =>
+    .option('--preset <name>', 'Use one saved repository preset as the discovery scope')
+    .option('--all-repos', 'Ignore the active repository preset and search the broader issue stream')
+    .action((options: {
+      limit?: string;
+      refresh?: boolean;
+      repo?: string;
+      preset?: string;
+      allRepos?: boolean;
+    }) =>
       runCommand('OpenMeta Scout', () =>
         agentOrchestrator.scout({
           limit: Number.parseInt(options.limit || '10', 10) || 10,
           refresh: options.refresh,
           repo: options.repo,
+          preset: options.preset,
+          allRepos: options.allRepos,
         }),
       ),
     );

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -38,6 +38,10 @@ function createDefaultConfig(): AppConfig {
       username: '',
       targetRepoPath: '',
     },
+    repositoryTargeting: {
+      activePreset: '',
+      presets: {},
+    },
     llm: {
       provider: 'openai',
       apiBaseUrl: 'https://api.openai.com/v1',
@@ -131,6 +135,7 @@ export class ConfigService {
       ...partial,
       userProfile: { ...current.userProfile, ...partial.userProfile },
       github: { ...current.github, ...partial.github },
+      repositoryTargeting: { ...current.repositoryTargeting, ...partial.repositoryTargeting },
       llm: { ...current.llm, ...partial.llm },
       automation: { ...current.automation, ...partial.automation },
     };
@@ -198,6 +203,12 @@ export class ConfigService {
       github: {
         ...defaults.github,
         ...config.github,
+      },
+      repositoryTargeting: {
+        ...defaults.repositoryTargeting,
+        ...config.repositoryTargeting,
+        activePreset: config.repositoryTargeting?.activePreset?.trim() || '',
+        presets: this.normalizeRepositoryPresets(config.repositoryTargeting?.presets),
       },
       llm: {
         ...defaults.llm,
@@ -280,6 +291,19 @@ export class ConfigService {
         },
       ]),
     );
+  }
+
+  private normalizeRepositoryPresets(
+    presets: AppConfig['repositoryTargeting']['presets'] = {},
+  ): AppConfig['repositoryTargeting']['presets'] {
+    return Object.fromEntries(Object.entries(presets).map(([name, preset]) => [
+      name,
+      {
+        repos: Array.isArray(preset?.repos)
+          ? preset.repos.map((repo) => String(repo).trim()).filter(Boolean)
+          : [],
+      },
+    ]));
   }
 }
 

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import { type SimpleGit, simpleGit } from 'simple-git';
-import type { PatchDraft, PullRequestDraft } from '../contracts/index.js';
+import type { PatchDraft, PullRequestDraft, RepositoryImprovementSuggestion } from '../contracts/index.js';
 import {
   configService,
   ensureDirectory,
@@ -27,6 +27,7 @@ import {
   llmService,
   memoryService,
   proofOfWorkService,
+  repositoryTargetingService,
   workspaceService,
 } from '../services/index.js';
 import type {
@@ -34,6 +35,7 @@ import type {
   ContributionAgentResult,
   RankedIssue,
   RepoFileSnippet,
+  RepoMemory,
   RepoWorkspaceContext,
   TestResult,
 } from '../types/index.js';
@@ -47,6 +49,8 @@ export interface AgentRunOptions {
   localArtifactsOnly?: boolean;
   refresh?: boolean;
   repo?: string;
+  preset?: string;
+  allRepos?: boolean;
   repoPath?: string;
   issue?: string;
   dryRun?: boolean;
@@ -56,6 +60,8 @@ export interface ScoutRunOptions {
   limit?: number;
   refresh?: boolean;
   repo?: string;
+  preset?: string;
+  allRepos?: boolean;
 }
 
 export interface MachineScoutResult {
@@ -120,6 +126,13 @@ interface ConcretePatchResult {
   changedFiles: string[];
   validationResults: TestResult[];
   reviewRequired: boolean;
+}
+
+interface PresetAnalyzeCandidate {
+  repoFullName: string;
+  workspace: RepoWorkspaceContext;
+  memory: RepoMemory;
+  suggestion: RepositoryImprovementSuggestion;
 }
 
 type AgentStageId = 'scout' | 'select' | 'prepare' | 'draft' | 'validate' | 'pr' | 'publish';
@@ -201,8 +214,14 @@ export class AgentOrchestrator {
     const dryRun = Boolean(options.dryRun);
     const repoPath = options.repoPath?.trim() || undefined;
     const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
-    const repoFullName =
-      issueTarget?.repoFullName ?? (options.repo ? parseGitHubRepoFullName(options.repo) : undefined);
+    const scope = issueTarget
+      ? undefined
+      : repositoryTargetingService.resolveScope(config, {
+          repo: options.repo,
+          preset: options.preset,
+          allRepos: options.allRepos,
+        });
+    const repoFullName = issueTarget?.repoFullName ?? scope?.repo;
 
     await this.validateConfig(config);
 
@@ -243,11 +262,16 @@ export class AgentOrchestrator {
             },
           },
           async (task) =>
-            issueRankingService.loadRankedIssues(config, {
-              refresh,
-              repoFullName,
-              onStatus: (message) => task.setMessage(message),
-            }),
+            scope?.mode === 'preset'
+              ? this.loadPresetRankedIssues(config, scope.repos, {
+                  refresh,
+                  onStatus: (message) => task.setMessage(message),
+                })
+              : issueRankingService.loadRankedIssues(config, {
+                  refresh,
+                  repoFullName,
+                  onStatus: (message) => task.setMessage(message),
+                }),
         );
 
     if (rankedIssues.length === 0) {
@@ -258,13 +282,260 @@ export class AgentOrchestrator {
       );
     }
 
+    const presetIssueFlowAllowed = !issueTarget &&
+      scope?.mode === 'preset' &&
+      (rankedIssues[0]?.opportunity.overallScore || 0) >= config.automation.minMatchScore;
+    const presetQualifiedIssue = presetIssueFlowAllowed
+      ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+      : undefined;
     const selectedIssue = issueTarget
       ? rankedIssues[0]
-      : headless
-        ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
-        : await this.promptForIssue(issueRankingService.diversifyScoutIssues(rankedIssues, 5));
+      : scope?.mode === 'preset'
+        ? presetQualifiedIssue
+        : headless
+          ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+          : await this.promptForIssue(issueRankingService.diversifyScoutIssues(rankedIssues, 5));
 
     if (!selectedIssue) {
+      if (!issueTarget && scope?.mode === 'preset') {
+        const selectedCandidate = await this.selectPresetAnalysisCandidate(scope.repos, {
+          headless,
+          runChecks,
+        });
+        const syntheticIssue = this.buildSyntheticIssueFromSuggestion(
+          selectedCandidate.repoFullName,
+          selectedCandidate.suggestion,
+        );
+        const memory = selectedCandidate.memory;
+        const patchDraftResult = await ui.task(
+          {
+            title: 'Generating patch strategy',
+            doneMessage: 'Patch strategy generated',
+            failedMessage: 'Patch strategy generation failed',
+            tone: 'info',
+            step: { index: 5, total: totalSteps },
+            heartbeat: {
+              message: 'Still drafting patch strategy',
+            },
+          },
+          async () => llmService.generatePatchDraft(syntheticIssue, selectedCandidate.workspace, memory),
+        );
+        const patchDraft = patchDraftResult.data;
+        const implementationWorkspace = this.buildImplementationWorkspace(selectedCandidate.workspace, patchDraft);
+        const implementation =
+          patchDraftResult.status === 'success'
+            ? await this.generateConcretePatch(
+                syntheticIssue,
+                implementationWorkspace,
+                patchDraft,
+                runChecks,
+                draftOnly,
+              )
+            : {
+                changedFiles: [],
+                validationResults: implementationWorkspace.testResults,
+                reviewRequired: true,
+              };
+        const workspaceForArtifacts: RepoWorkspaceContext = {
+          ...implementationWorkspace,
+          testResults: implementation.validationResults,
+        };
+        const prDraftResult = await ui.task(
+          {
+            title: 'Generating PR narrative',
+            doneMessage: 'PR narrative generated',
+            failedMessage: 'PR narrative generation failed',
+            tone: 'info',
+            step: { index: 6, total: totalSteps },
+            heartbeat: {
+              message: 'Still drafting PR narrative',
+            },
+          },
+          async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspaceForArtifacts),
+        );
+        const prDraft = prDraftResult.data;
+        const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
+        const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+        const contributionPullRequest = await ui.task(
+          {
+            title: 'Evaluating draft PR creation',
+            doneMessage: 'Draft PR evaluation complete',
+            failedMessage: 'Draft PR evaluation failed',
+            tone: 'info',
+            step: { index: 7, total: totalSteps },
+          },
+          async () =>
+            this.submitContributionPullRequestIfPossible({
+              config,
+              allowRealPr: patchDraftResult.status === 'success' && prDraftResult.status === 'success',
+              headless,
+              issue: syntheticIssue,
+              prDraft,
+              workspace: workspaceForArtifacts,
+              changedFiles: implementation.changedFiles,
+              validationResults: implementation.validationResults,
+            }),
+        );
+        const artifacts = this.prepareLocalArtifactPaths(syntheticIssue);
+        const reviewRequired =
+          patchDraftResult.status !== 'success' || implementation.reviewRequired || prDraftResult.status !== 'success';
+        const skipReasons = [
+          ...(draftOnly ? ['draft_only'] : []),
+          ...(localArtifactsOnly ? ['publish_skipped_local_artifacts_only'] : []),
+          ...(patchDraftResult.status !== 'success' ? ['patch_draft_requires_review'] : []),
+          ...(implementation.reviewRequired ? ['implementation_requires_review'] : []),
+          ...(prDraftResult.status !== 'success' ? ['pr_draft_requires_review'] : []),
+          ...(contributionPullRequest.url
+            ? []
+            : implementation.changedFiles.length > 0
+              ? ['pr_not_created']
+              : ['no_changes_applied']),
+        ];
+
+        if (!dryRun) {
+          const inboxItem = {
+            id: `${syntheticIssue.repoFullName}#${syntheticIssue.number}`,
+            repoFullName: syntheticIssue.repoFullName,
+            issueNumber: syntheticIssue.number,
+            issueTitle: syntheticIssue.title,
+            summary: syntheticIssue.opportunity.summary,
+            overallScore: syntheticIssue.opportunity.overallScore,
+            opportunityScore: syntheticIssue.opportunity.score,
+            status: 'ready' as const,
+            artifactDir: artifacts.artifactDir,
+            generatedAt: new Date().toISOString(),
+          };
+          const inboxItems = inboxService.saveItem(inboxItem);
+          const proofRecord = {
+            id: `${syntheticIssue.repoFullName}#${syntheticIssue.number}@${Date.now()}`,
+            repoFullName: syntheticIssue.repoFullName,
+            issueNumber: syntheticIssue.number,
+            issueTitle: syntheticIssue.title,
+            overallScore: syntheticIssue.opportunity.overallScore,
+            opportunityScore: syntheticIssue.opportunity.score,
+            branchName: workspaceForArtifacts.branchName,
+            artifactDir: artifacts.artifactDir,
+            generatedAt: new Date().toISOString(),
+            published: false,
+            pullRequestUrl: contributionPullRequest.url,
+            pullRequestNumber: contributionPullRequest.number,
+          };
+          const dossier = contentService.formatContributionDossier(
+            syntheticIssue,
+            workspaceForArtifacts,
+            memory,
+            patchDraft,
+            prDraft,
+          );
+          const proofMarkdown = proofOfWorkService.renderMarkdown(
+            [proofRecord, ...proofOfWorkService.load().records].slice(0, 100),
+          );
+
+          this.writeLocalArtifacts({
+            artifacts,
+            dossier,
+            patchDraftMarkdown,
+            prDraftMarkdown,
+            memoryMarkdown: memoryService.renderMarkdown(memory),
+            inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+            proofMarkdown,
+          });
+
+          const publishResult = localArtifactsOnly
+            ? { published: false }
+            : await ui.task(
+                {
+                  title: dryRun ? 'Previewing artifact publication' : 'Publishing contribution artifacts',
+                  doneMessage: dryRun ? 'Artifact publication preview complete' : 'Contribution artifacts published',
+                  failedMessage: dryRun
+                    ? 'Artifact publication preview failed'
+                    : 'Contribution artifact publication failed',
+                  tone: 'info',
+                  step: { index: 8, total: totalSteps },
+                },
+                async () =>
+                  this.publishArtifactsIfNeeded({
+                    config,
+                    headless,
+                    dryRun: options.dryRun,
+                    issue: syntheticIssue,
+                    patchDraftMarkdown,
+                    prDraftMarkdown,
+                    dossier,
+                    memoryMarkdown: memoryService.renderMarkdown(memory),
+                    inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+                    proofMarkdown,
+                    changedFiles: implementation.changedFiles,
+                    validationResults: implementation.validationResults,
+                    pullRequestUrl: contributionPullRequest.url,
+                  }),
+              );
+
+          const finalProofRecord = {
+            ...proofRecord,
+            published: publishResult.published,
+          };
+          const finalMemory = memoryService.recordOutcome({
+            issue: syntheticIssue,
+            workspace: workspaceForArtifacts,
+            changedFiles: implementation.changedFiles,
+            validationResults: implementation.validationResults,
+            published: publishResult.published,
+            pullRequestUrl: contributionPullRequest.url,
+            reviewRequired,
+          });
+          proofOfWorkService.record(finalProofRecord);
+          const finalProofMarkdown = proofOfWorkService.renderMarkdown(proofOfWorkService.load().records);
+          this.writeLocalArtifacts({
+            artifacts,
+            dossier,
+            patchDraftMarkdown,
+            prDraftMarkdown,
+            memoryMarkdown: memoryService.renderMarkdown(finalMemory),
+            inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+            proofMarkdown: finalProofMarkdown,
+          });
+        }
+
+        return {
+          issue: syntheticIssue,
+          workspace: workspaceForArtifacts,
+          patchDraft,
+          prDraft,
+          artifacts,
+          changedFiles: implementation.changedFiles,
+          validationResults: implementation.validationResults,
+          reviewRequired,
+          published: false,
+          prCreated: Boolean(contributionPullRequest.url),
+          repoMutated: implementation.changedFiles.length > 0,
+          artifactsWritten: !dryRun,
+          executionOutcome: this.resolveMachineExecutionOutcome({
+            draftOnly,
+            localArtifactsOnly,
+            changedFiles: implementation.changedFiles,
+            prCreated: Boolean(contributionPullRequest.url),
+            reviewRequired,
+          }),
+          executionPolicy: {
+            headless,
+            draftOnly,
+            localArtifactsOnly,
+            runChecks,
+            dryRun,
+            refresh,
+          },
+          skipReasons: [...new Set(skipReasons)],
+          nextActions: dryRun
+            ? ['inspect_artifact_paths']
+            : contributionPullRequest.url
+              ? ['review_pull_request']
+              : ['inspect_artifact_paths'],
+          pullRequestUrl: contributionPullRequest.url,
+          pullRequestNumber: contributionPullRequest.number,
+        };
+      }
+
       throw new Error(
         issueTarget
           ? 'OpenMeta could not select the specified target issue after scoring.'
@@ -532,8 +803,14 @@ export class AgentOrchestrator {
     const refresh = Boolean(options.refresh);
     const repoPath = options.repoPath?.trim() || undefined;
     const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
-    const repoFullName =
-      issueTarget?.repoFullName ?? (options.repo ? parseGitHubRepoFullName(options.repo) : undefined);
+    const scope = issueTarget
+      ? undefined
+      : repositoryTargetingService.resolveScope(config, {
+          repo: options.repo,
+          preset: options.preset,
+          allRepos: options.allRepos,
+        });
+    const repoFullName = issueTarget?.repoFullName ?? scope?.repo;
     const completedStages = new Set<AgentStageId>();
 
     ui.hero({
@@ -561,7 +838,9 @@ export class AgentOrchestrator {
             : 'Issue discovery may reuse the short local search cache.',
         issueTarget
           ? 'Issue discovery and interactive selection are skipped for this run.'
-          : repoFullName
+          : scope?.mode === 'preset'
+            ? `Issue discovery is limited to preset ${scope.presetName} (${scope.repos.length} repositories).`
+            : repoFullName
             ? `Issue discovery is limited to ${repoFullName}.`
             : 'Issue discovery will scan the broader GitHub issue stream.',
         repoPath
@@ -599,11 +878,16 @@ export class AgentOrchestrator {
       async (task) =>
         issueTarget
           ? issueRankingService.loadTargetIssue(config, issueTarget)
-          : issueRankingService.loadRankedIssues(config, {
-              refresh,
-              repoFullName,
-              onStatus: (message) => task.setMessage(message),
-            }),
+          : scope?.mode === 'preset'
+            ? this.loadPresetRankedIssues(config, scope.repos, {
+                refresh,
+                onStatus: (message) => task.setMessage(message),
+              })
+            : issueRankingService.loadRankedIssues(config, {
+                refresh,
+                repoFullName,
+                onStatus: (message) => task.setMessage(message),
+              }),
     );
     if (rankedIssues.length === 0) {
       ui.emptyState(
@@ -628,13 +912,39 @@ export class AgentOrchestrator {
       const displayIssues = issueRankingService.diversifyScoutIssues(rankedIssues, 5);
       this.renderOpportunityList('Top ranked opportunities', displayIssues);
     }
+    const presetIssueFlowAllowed = !issueTarget &&
+      scope?.mode === 'preset' &&
+      (rankedIssues[0]?.opportunity.overallScore || 0) >= config.automation.minMatchScore;
+    const presetQualifiedIssue = presetIssueFlowAllowed
+      ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+      : undefined;
     const selectedIssue = issueTarget
       ? rankedIssues[0]
-      : headless
-        ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
-        : await this.promptForIssue(issueRankingService.diversifyScoutIssues(rankedIssues, 5));
+      : scope?.mode === 'preset'
+        ? presetQualifiedIssue
+          ? headless
+            ? presetQualifiedIssue
+            : await this.promptForIssue(issueRankingService.diversifyScoutIssues(rankedIssues, 5))
+          : undefined
+        : headless
+          ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+          : await this.promptForIssue(issueRankingService.diversifyScoutIssues(rankedIssues, 5));
 
     if (!selectedIssue) {
+      if (!issueTarget && scope?.mode === 'preset') {
+        await this.runPresetAnalysisFallback({
+          config,
+          repos: scope.repos,
+          headless,
+          runChecks,
+          draftOnly,
+          refresh,
+          options,
+          completedStages,
+        });
+        return;
+      }
+
       ui.emptyState(
         'OpenMeta Agent',
         issueTarget ? 'Target issue could not be selected' : 'No issue met the automation threshold',
@@ -893,25 +1203,35 @@ export class AgentOrchestrator {
   async scout(options: ScoutRunOptions | number = {}): Promise<void> {
     const limit = typeof options === 'number' ? options : (options.limit ?? 10);
     const refresh = typeof options === 'number' ? false : Boolean(options.refresh);
-    const repoFullName =
+    const explicitRepo =
       typeof options === 'number' || !options.repo ? undefined : parseGitHubRepoFullName(options.repo);
     const config = await configService.get();
+    const scope =
+      typeof options === 'number'
+        ? repositoryTargetingService.resolveScope(config)
+        : repositoryTargetingService.resolveScope(config, {
+            repo: options.repo,
+            preset: options.preset,
+            allRepos: options.allRepos,
+          });
+    const repoFullName = explicitRepo ?? scope.repo;
     await this.validateConfig(config);
     await this.initializeClients(config, { validateGithub: true, validateLlm: true });
 
     ui.hero({
       label: 'OpenMeta Scout',
       title: 'Read the field before you spend your focus',
-      subtitle:
-        'OpenMeta turns a noisy issue stream into a shortlist shaped by technical fit, timing, and real opening momentum.',
+      subtitle: 'OpenMeta turns a noisy issue stream into a shortlist shaped by technical fit, timing, and real opening momentum.',
       lines: [
         `Saved threshold reference: ${config.automation.minMatchScore}/100.`,
         refresh
           ? 'This scout run will ignore the local GitHub issue cache.'
           : 'This scout run may reuse the short local GitHub issue cache.',
-        repoFullName
-          ? `Issue discovery is limited to ${repoFullName}.`
-          : 'Issue discovery will scan the broader GitHub issue stream.',
+        scope.mode === 'preset'
+          ? `Issue discovery is limited to preset ${scope.presetName} (${scope.repos.length} repositories).`
+          : repoFullName
+            ? `Issue discovery is limited to ${repoFullName}.`
+            : 'Issue discovery will scan the broader GitHub issue stream.',
         'LLM scoring will refine the local candidate shortlist.',
       ],
     });
@@ -923,12 +1243,20 @@ export class AgentOrchestrator {
         failedMessage: 'Contribution opportunity scoring failed',
         tone: 'info',
       },
-      async (task) =>
-        issueRankingService.loadRankedIssues(config, {
+      async (task) => {
+        if (scope.mode === 'preset') {
+          return this.loadPresetRankedIssues(config, scope.repos, {
+            refresh,
+            onStatus: (message) => task.setMessage(message),
+          });
+        }
+
+        return issueRankingService.loadRankedIssues(config, {
           refresh,
           repoFullName,
           onStatus: (message) => task.setMessage(message),
-        }),
+        });
+      },
     );
     if (rankedIssues.length === 0) {
       const emptyExplanation = this.buildScoutEmptyExplanation(config, { repoFullName, refresh });
@@ -953,8 +1281,13 @@ export class AgentOrchestrator {
     const totalSteps = 3;
     const limit = options.limit ?? 10;
     const refresh = Boolean(options.refresh);
-    const repoFullName = options.repo ? parseGitHubRepoFullName(options.repo) : undefined;
     const config = await configService.get();
+    const scope = repositoryTargetingService.resolveScope(config, {
+      repo: options.repo,
+      preset: options.preset,
+      allRepos: options.allRepos,
+    });
+    const repoFullName = scope.mode === 'single' ? scope.repo : undefined;
 
     await this.validateConfig(config);
     await this.initializeClients(config, {
@@ -977,15 +1310,25 @@ export class AgentOrchestrator {
           message: 'Still scoring contribution opportunities',
         },
       },
-      async (task) =>
-        issueRankingService.loadRankedIssues(config, {
+      async (task) => {
+        if (scope.mode === 'preset') {
+          return this.loadPresetRankedIssues(config, scope.repos, {
+            refresh,
+            onStatus: (message) => task.setMessage(message),
+          });
+        }
+
+        return issueRankingService.loadRankedIssues(config, {
           refresh,
           repoFullName,
           onStatus: (message) => task.setMessage(message),
-        }),
+        });
+      },
     );
     const emptyExplanation =
-      rankedIssues.length === 0 ? this.buildScoutEmptyExplanation(config, { repoFullName, refresh }) : undefined;
+      rankedIssues.length === 0
+        ? this.buildScoutEmptyExplanation(config, { repoFullName, refresh })
+        : undefined;
 
     return {
       opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
@@ -1494,6 +1837,418 @@ export class AgentOrchestrator {
         tone: 'warning',
       });
     }
+  }
+
+  private async loadPresetRankedIssues(
+    config: AppConfig,
+    repos: string[],
+    options: {
+      refresh?: boolean;
+      onStatus?: (message: string) => void;
+    } = {},
+  ): Promise<RankedIssue[]> {
+    const issueMap = new Map<string, RankedIssue>();
+
+    for (const repoFullName of repos) {
+      options.onStatus?.(`Scouting ${repoFullName}`);
+      const issues = await issueRankingService.loadRankedIssues(config, {
+        refresh: options.refresh,
+        repoFullName,
+      });
+
+      for (const issue of issues) {
+        const key = `${issue.repoFullName}#${issue.number}`;
+        const existing = issueMap.get(key);
+        if (!existing || issue.opportunity.overallScore > existing.opportunity.overallScore) {
+          issueMap.set(key, issue);
+        }
+      }
+    }
+
+    return [...issueMap.values()].sort(
+      (left, right) =>
+        right.opportunity.overallScore - left.opportunity.overallScore ||
+        right.matchScore - left.matchScore ||
+        right.updatedAt.localeCompare(left.updatedAt),
+    );
+  }
+
+  private async runPresetAnalysisFallback(input: {
+    config: AppConfig;
+    repos: string[];
+    headless: boolean;
+    runChecks: boolean;
+    draftOnly: boolean;
+    refresh: boolean;
+    options: AgentRunOptions;
+    completedStages: Set<AgentStageId>;
+  }): Promise<void> {
+    ui.callout({
+      label: 'OpenMeta Agent',
+      title: 'Preset issue scout did not clear the automation threshold',
+      subtitle: 'OpenMeta will switch from issue-first scouting to repository analysis across the active preset.',
+      lines: [
+        `Repositories: ${input.repos.join(', ')}`,
+        `Threshold: ${input.config.automation.minMatchScore}/100`,
+      ],
+      tone: 'info',
+    });
+
+    const selectedCandidate = await this.selectPresetAnalysisCandidate(input.repos, {
+      headless: input.headless,
+      runChecks: input.runChecks,
+    });
+    const selectedIssue = this.buildSyntheticIssueFromSuggestion(
+      selectedCandidate.repoFullName,
+      selectedCandidate.suggestion,
+    );
+    const memory = selectedCandidate.memory;
+    const completedStages = input.completedStages;
+    completedStages.add('select');
+    this.showSelectedOpportunity(selectedIssue, input.headless);
+
+    this.renderAgentStage('prepare', completedStages, `Cloning and inspecting ${selectedIssue.repoFullName}.`);
+    completedStages.add('prepare');
+    this.showWorkspaceSummary(selectedCandidate.workspace, memory);
+
+    this.renderAgentStage('draft', completedStages, 'Drafting patch strategy and turning it into concrete file changes.');
+    const patchDraftResult = await ui.task(
+      {
+        title: 'Generating patch strategy',
+        doneMessage: 'Patch strategy generated',
+        failedMessage: 'Patch strategy generation failed',
+        tone: 'info',
+      },
+      async () => llmService.generatePatchDraft(selectedIssue, selectedCandidate.workspace, memory),
+    );
+    const patchDraft = patchDraftResult.data;
+    if (patchDraftResult.status !== 'success') {
+      this.showStructuredReviewNotice({
+        title: 'Patch strategy requires review',
+        subtitle:
+          'OpenMeta marked the generated patch plan as review-required, so this run will preserve artifacts but skip concrete code edits.',
+        lines: [`Goal: ${patchDraft.goal}`],
+      });
+    }
+    const implementationWorkspace = this.buildImplementationWorkspace(selectedCandidate.workspace, patchDraft);
+    const implementation =
+      patchDraftResult.status === 'success'
+        ? await this.generateConcretePatch(
+            selectedIssue,
+            implementationWorkspace,
+            patchDraft,
+            input.runChecks,
+            input.draftOnly,
+          )
+        : {
+            changedFiles: [],
+            validationResults: implementationWorkspace.testResults,
+            reviewRequired: true,
+          };
+    completedStages.add('draft');
+    const workspaceForArtifacts: RepoWorkspaceContext = {
+      ...implementationWorkspace,
+      testResults: implementation.validationResults,
+    };
+
+    this.renderAgentStage('validate', completedStages, 'Reviewing validation outcomes before opening or publishing anything.');
+    this.showValidationSummary(workspaceForArtifacts, implementation.changedFiles);
+    completedStages.add('validate');
+
+    this.renderAgentStage('pr', completedStages, 'Drafting PR narrative and deciding whether to open a real draft PR.');
+    const prDraftResult = await ui.task(
+      {
+        title: 'Generating PR narrative',
+        doneMessage: 'PR narrative generated',
+        failedMessage: 'PR narrative generation failed',
+        tone: 'info',
+      },
+      async () => llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts),
+    );
+    const prDraft = prDraftResult.data;
+    if (prDraftResult.status !== 'success') {
+      this.showStructuredReviewNotice({
+        title: 'PR narrative requires review',
+        subtitle:
+          'OpenMeta marked the generated PR draft as review-required, so this run will stay in draft-only mode and skip opening a real PR.',
+        lines: [`Title: ${prDraft.title}`],
+      });
+    }
+    const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+
+    const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
+      config: input.config,
+      allowRealPr: patchDraftResult.status === 'success' && prDraftResult.status === 'success',
+      headless: input.headless,
+      issue: selectedIssue,
+      prDraft,
+      workspace: workspaceForArtifacts,
+      changedFiles: implementation.changedFiles,
+      validationResults: implementation.validationResults,
+    });
+    completedStages.add('pr');
+
+    const artifacts = this.prepareLocalArtifactPaths(selectedIssue);
+
+    const inboxItem = {
+      id: `${selectedIssue.repoFullName}#${selectedIssue.number}`,
+      repoFullName: selectedIssue.repoFullName,
+      issueNumber: selectedIssue.number,
+      issueTitle: selectedIssue.title,
+      summary: selectedIssue.opportunity.summary,
+      overallScore: selectedIssue.opportunity.overallScore,
+      opportunityScore: selectedIssue.opportunity.score,
+      status: 'ready' as const,
+      artifactDir: artifacts.artifactDir,
+      generatedAt: new Date().toISOString(),
+    };
+    const inboxItems = inboxService.saveItem(inboxItem);
+
+    const proofRecord = {
+      id: `${selectedIssue.repoFullName}#${selectedIssue.number}@${Date.now()}`,
+      repoFullName: selectedIssue.repoFullName,
+      issueNumber: selectedIssue.number,
+      issueTitle: selectedIssue.title,
+      overallScore: selectedIssue.opportunity.overallScore,
+      opportunityScore: selectedIssue.opportunity.score,
+      branchName: workspaceForArtifacts.branchName,
+      artifactDir: artifacts.artifactDir,
+      generatedAt: new Date().toISOString(),
+      published: false,
+      pullRequestUrl: contributionPullRequest.url,
+      pullRequestNumber: contributionPullRequest.number,
+    };
+
+    const dossier = contentService.formatContributionDossier(selectedIssue, workspaceForArtifacts, memory, patchDraft, prDraft);
+    const proofMarkdown = proofOfWorkService.renderMarkdown([
+      proofRecord,
+      ...proofOfWorkService.load().records,
+    ].slice(0, 100));
+
+    this.renderAgentStage('publish', completedStages, 'Saving dossier assets, updating long-term memory, and deciding whether to publish them.');
+    this.showArtifactPreview({
+      issue: selectedIssue,
+      artifactRelativeDir: join('contributions', getLocalDateStamp(), `${selectedIssue.repoFullName.replace(/\//g, '__')}__${selectedIssue.number}`),
+      draftTitle: prDraft.title,
+      changedFiles: implementation.changedFiles,
+      validationResults: implementation.validationResults,
+      pullRequestUrl: contributionPullRequest.url,
+    });
+
+    await ui.task(
+      {
+        title: 'Writing local artifacts',
+        doneMessage: 'Local artifacts written',
+        failedMessage: 'Local artifact write failed',
+        tone: 'info',
+      },
+      async () => {
+        this.writeLocalArtifacts({
+          artifacts,
+          dossier,
+          patchDraftMarkdown,
+          prDraftMarkdown,
+          memoryMarkdown: memoryService.renderMarkdown(memory),
+          inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+          proofMarkdown,
+        });
+      },
+    );
+
+    const publishResult = Boolean(input.options.localArtifactsOnly)
+      ? { published: false }
+      : await this.publishArtifactsIfNeeded({
+          config: input.config,
+          headless: input.headless,
+          dryRun: input.options.dryRun,
+          issue: selectedIssue,
+          patchDraftMarkdown,
+          prDraftMarkdown,
+          dossier,
+          memoryMarkdown: memoryService.renderMarkdown(memory),
+          inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+          proofMarkdown,
+          changedFiles: implementation.changedFiles,
+          validationResults: implementation.validationResults,
+          pullRequestUrl: contributionPullRequest.url,
+        });
+
+    const reviewRequired =
+      patchDraftResult.status !== 'success' || implementation.reviewRequired || prDraftResult.status !== 'success';
+    const finalProofRecord = {
+      ...proofRecord,
+      published: publishResult.published,
+    };
+    const finalMemory = memoryService.recordOutcome({
+      issue: selectedIssue,
+      workspace: workspaceForArtifacts,
+      changedFiles: implementation.changedFiles,
+      validationResults: implementation.validationResults,
+      published: publishResult.published,
+      pullRequestUrl: contributionPullRequest.url,
+      reviewRequired,
+    });
+    proofOfWorkService.record(finalProofRecord);
+    const finalProofMarkdown = proofOfWorkService.renderMarkdown(proofOfWorkService.load().records);
+    this.writeLocalArtifacts({
+      artifacts,
+      dossier,
+      patchDraftMarkdown,
+      prDraftMarkdown,
+      memoryMarkdown: memoryService.renderMarkdown(finalMemory),
+      inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+      proofMarkdown: finalProofMarkdown,
+    });
+    completedStages.add('publish');
+
+    this.showResult({
+      issue: selectedIssue,
+      workspace: workspaceForArtifacts,
+      memory: finalMemory,
+      patchDraft,
+      prDraft,
+      dossier,
+      artifacts,
+      inboxItem,
+      proofRecord: finalProofRecord,
+      changedFiles: implementation.changedFiles,
+      pullRequestUrl: contributionPullRequest.url,
+    });
+  }
+
+  private async selectPresetAnalysisCandidate(
+    repos: string[],
+    options: {
+      headless: boolean;
+      runChecks: boolean;
+    },
+  ): Promise<PresetAnalyzeCandidate> {
+    const candidates: PresetAnalyzeCandidate[] = [];
+
+    for (const repoFullName of repos) {
+      const memory = memoryService.load(repoFullName);
+      const workspace = await ui.task(
+        {
+          title: `Preparing repository workspace for ${repoFullName}`,
+          doneMessage: 'Repository workspace prepared',
+          failedMessage: 'Repository workspace preparation failed',
+          tone: 'info',
+        },
+        async () =>
+          workspaceService.prepareRepositoryWorkspace(
+            repoFullName,
+            memory,
+            options.runChecks,
+            options.headless ? 'headless' : 'interactive',
+          ),
+      );
+
+      const suggestionsResult = await ui.task(
+        {
+          title: `Analyzing repository contribution paths for ${repoFullName}`,
+          doneMessage: 'Repository suggestions generated',
+          failedMessage: 'Repository analysis failed',
+          tone: 'info',
+        },
+        async () => llmService.analyzeRepository(repoFullName, workspace, memory),
+      );
+
+      candidates.push(
+        ...suggestionsResult.data.map((suggestion) => ({
+          repoFullName,
+          workspace,
+          memory,
+          suggestion,
+        })),
+      );
+    }
+
+    if (candidates.length === 0) {
+      throw new Error('No repository suggestions were generated from the active preset.');
+    }
+
+    ui.recordList(
+      'Preset repository analysis candidates',
+      candidates.slice(0, 5).map((candidate) => ({
+        title: `${candidate.repoFullName} - ${candidate.suggestion.title}`,
+        subtitle: candidate.suggestion.summary,
+        meta: [
+          `score ${candidate.suggestion.prPotentialScore}`,
+          `workload ${candidate.suggestion.estimatedWorkload}`,
+        ],
+        lines: [`Files: ${candidate.suggestion.targetFiles.map((file) => file.path).join(', ')}`],
+        tone: candidate.suggestion.prPotentialScore >= 80 ? 'success' : 'info',
+      })),
+    );
+
+    return this.selectTopPresetAnalysisCandidate(candidates);
+  }
+
+  private selectTopPresetAnalysisCandidate(candidates: PresetAnalyzeCandidate[]): PresetAnalyzeCandidate {
+    const [selected] = [...candidates].sort(
+      (left, right) => right.suggestion.prPotentialScore - left.suggestion.prPotentialScore,
+    );
+    if (!selected) {
+      throw new Error('No repository suggestions are available to select.');
+    }
+
+    return selected;
+  }
+
+  private buildSyntheticIssueFromSuggestion(
+    repoFullName: string,
+    suggestion: RepositoryImprovementSuggestion,
+  ): RankedIssue {
+    const now = new Date().toISOString();
+    const repoName = repoFullName.split('/').at(-1) || repoFullName;
+
+    return {
+      id: 0,
+      number: 0,
+      title: suggestion.title,
+      body: [
+        suggestion.summary,
+        '',
+        suggestion.rationale,
+        '',
+        'Target files:',
+        ...suggestion.targetFiles.map((file) => `- ${file.path}: ${file.reason}`),
+        '',
+        'Proposed changes:',
+        ...suggestion.proposedChanges.map((change) => `- ${change}`),
+        '',
+        'Validation plan:',
+        ...suggestion.validationPlan.map((step) => `- ${step}`),
+      ].join('\n'),
+      htmlUrl: `https://github.com/${repoFullName}`,
+      repoName,
+      repoFullName,
+      repoDescription: 'Repository analysis suggestion generated by OpenMeta.',
+      repoStars: 0,
+      labels: ['openmeta-analysis'],
+      createdAt: now,
+      updatedAt: now,
+      matchScore: suggestion.prPotentialScore,
+      analysis: {
+        coreDemand: suggestion.summary,
+        techRequirements: suggestion.targetFiles.map((file) => file.path),
+        solutionSuggestion: suggestion.proposedChanges.join(' '),
+        estimatedWorkload: suggestion.estimatedWorkload,
+      },
+      opportunity: {
+        score: suggestion.prPotentialScore,
+        overallScore: suggestion.prPotentialScore,
+        summary: suggestion.rationale,
+        breakdown: {
+          technicalFit: suggestion.prPotentialScore,
+          freshness: 70,
+          onboardingClarity: 70,
+          mergePotential: suggestion.prPotentialScore,
+          impact: suggestion.prPotentialScore,
+        },
+      },
+    };
   }
 
   private prepareLocalArtifactPaths(issue: RankedIssue) {

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -11,11 +11,19 @@ import {
   selectPrompt,
   ui,
 } from '../infra/index.js';
-import { contentService, githubService, llmService, memoryService, workspaceService } from '../services/index.js';
-import type { AppConfig, RankedIssue, RepoWorkspaceContext } from '../types/index.js';
+import {
+  contentService,
+  githubService,
+  llmService,
+  memoryService,
+  repositoryTargetingService,
+  workspaceService,
+} from '../services/index.js';
+import type { AppConfig, RankedIssue, RepoMemory, RepoWorkspaceContext } from '../types/index.js';
 
 export interface AnalyzeRunOptions {
   repo?: string;
+  preset?: string;
   repoPath?: string;
   headless?: boolean;
   runChecks?: boolean;
@@ -39,6 +47,20 @@ interface AnalyzeResult {
   artifacts: AnalyzeArtifacts;
 }
 
+interface PresetAnalyzeGroup {
+  repoFullName: string;
+  workspace: RepoWorkspaceContext;
+  memory: RepoMemory;
+  suggestions: RepositoryImprovementSuggestion[];
+}
+
+interface PresetAnalyzeCandidate {
+  repoFullName: string;
+  workspace: RepoWorkspaceContext;
+  memory: RepoMemory;
+  suggestion: RepositoryImprovementSuggestion;
+}
+
 export class AnalyzeOrchestrator {
   async runMachine(options: AnalyzeRunOptions = {}): Promise<
     AnalyzeResult & {
@@ -49,12 +71,17 @@ export class AnalyzeOrchestrator {
       };
     }
   > {
-    if (!options.repo) {
+    const config = await configService.get();
+    const scope = repositoryTargetingService.resolveScope(config, {
+      repo: options.repo,
+      preset: options.preset,
+      allowGlobal: false,
+    });
+
+    if (scope.mode === 'none') {
       throw new Error('Repository analysis requires --repo, for example: openmeta analyze --repo owner/name.');
     }
 
-    const repoFullName = parseGitHubRepoFullName(options.repo);
-    const config = await configService.get();
     const headless = Boolean(options.headless);
     const runChecks = Boolean(options.runChecks);
     const dryRun = Boolean(options.dryRun);
@@ -65,45 +92,36 @@ export class AnalyzeOrchestrator {
     this.showLocalRepositoryHint(repoPath);
 
     const totalSteps = 7;
-    const memory = memoryService.load(repoFullName);
-    const workspace = await ui.task(
-      {
-        title: 'Preparing repository workspace',
-        doneMessage: 'Repository workspace prepared',
-        failedMessage: 'Repository workspace preparation failed',
-        tone: 'info',
-        step: { index: 3, total: totalSteps },
-        heartbeat: {
-          message: 'Still preparing repository workspace',
-        },
-      },
-      async () =>
-        workspaceService.prepareRepositoryWorkspace(
-          repoFullName,
-          memory,
+    const groups = scope.mode === 'single'
+      ? [
+          await this.collectSingleAnalysisGroup(scope.repo!, {
+            headless,
+            runChecks,
+            repoPath,
+            totalSteps,
+          }),
+        ]
+      : await this.collectAnalysisGroups(scope.repos, {
+          headless,
           runChecks,
-          headless ? 'headless' : 'interactive',
-          repoPath,
-        ),
+          totalSteps,
+        });
+    const candidates = groups.flatMap((group) =>
+      group.suggestions.map((suggestion) => ({
+        repoFullName: group.repoFullName,
+        workspace: group.workspace,
+        memory: group.memory,
+        suggestion,
+      }) satisfies PresetAnalyzeCandidate),
     );
-
-    const suggestionsResult = await ui.task(
-      {
-        title: 'Inspecting repository for grounded contribution ideas',
-        doneMessage: 'Repository suggestions generated',
-        failedMessage: 'Repository suggestion analysis failed',
-        tone: 'info',
-        step: { index: 4, total: totalSteps },
-        heartbeat: {
-          message: 'Still inspecting repository context',
-        },
-      },
-      async () => llmService.analyzeRepository(repoFullName, workspace, memory),
-    );
-    const suggestions = suggestionsResult.data;
-    const selectedSuggestion = headless
-      ? this.selectTopSuggestion(suggestions)
-      : await this.promptForSuggestion(suggestions);
+    const selectedCandidate = headless
+      ? this.selectTopCandidate(candidates)
+      : await this.promptForCandidate(candidates);
+    const repoFullName = selectedCandidate.repoFullName;
+    const workspace = selectedCandidate.workspace;
+    const memory = selectedCandidate.memory;
+    const selectedSuggestion = selectedCandidate.suggestion;
+    const suggestions = groups.find((group) => group.repoFullName === repoFullName)?.suggestions || [selectedSuggestion];
     const syntheticIssue = this.buildSyntheticIssue(repoFullName, selectedSuggestion);
 
     await ui.task(
@@ -152,6 +170,12 @@ export class AnalyzeOrchestrator {
       workspace,
       suggestions,
       selectedSuggestion,
+      scope.mode === 'preset'
+        ? groups.map((group) => ({
+            repoFullName: group.repoFullName,
+            suggestions: group.suggestions,
+          }))
+        : undefined,
     );
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
     const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
@@ -184,6 +208,17 @@ export class AnalyzeOrchestrator {
   async run(options: AnalyzeRunOptions = {}): Promise<void> {
     const result = await this.runMachine(options);
     const { repoFullName, mode, workspace, suggestions, selectedSuggestion, patchDraft, prDraft, artifacts } = result;
+    const config = await configService.get();
+    const scope = repositoryTargetingService.resolveScope(config, {
+      repo: options.repo,
+      preset: options.preset,
+      allowGlobal: false,
+    });
+    const scopeLabel = scope.mode === 'single'
+      ? scope.repo!
+      : scope.presetName
+        ? `preset ${scope.presetName}`
+        : `${scope.repos.length} repositories`;
 
     ui.hero({
       label: 'OpenMeta Analyze',
@@ -191,7 +226,7 @@ export class AnalyzeOrchestrator {
       subtitle:
         'OpenMeta will inspect the repository, ask the model for grounded improvement ideas, and draft PR-ready artifacts for the strongest suggestion.',
       lines: [
-        `Repository: ${repoFullName}`,
+        `Scope: ${scopeLabel}`,
         mode.runChecks
           ? 'Detected validation commands may run during workspace preparation.'
           : 'This analysis will skip baseline validation commands.',
@@ -201,7 +236,17 @@ export class AnalyzeOrchestrator {
       ],
     });
 
-    this.showWorkspaceSummary(workspace);
+    if (scope.mode === 'single') {
+      this.showWorkspaceSummary(workspace);
+    } else {
+      const candidates = suggestions.length;
+      ui.stats('Preset analysis scope', [
+        { label: 'Repositories', value: String(scope.repos.length), tone: 'success' },
+        { label: 'Candidates', value: String(candidates), tone: 'info' },
+        { label: 'Top score', value: String(selectedSuggestion.prPotentialScore), tone: 'accent' },
+        { label: 'Preset', value: scope.presetName || 'custom', tone: 'info' },
+      ]);
+    }
     if (suggestions.length === 0) {
       ui.emptyState(
         'OpenMeta Analyze',
@@ -370,6 +415,17 @@ export class AnalyzeOrchestrator {
     );
   }
 
+  private selectTopCandidate(candidates: PresetAnalyzeCandidate[]): PresetAnalyzeCandidate {
+    const [selected] = [...candidates].sort(
+      (left, right) => right.suggestion.prPotentialScore - left.suggestion.prPotentialScore,
+    );
+    if (!selected) {
+      throw new Error('No repository suggestions are available to select.');
+    }
+
+    return selected;
+  }
+
   private selectTopSuggestion(suggestions: RepositoryImprovementSuggestion[]): RepositoryImprovementSuggestion {
     const [selected] = [...suggestions].sort((left, right) => right.prPotentialScore - left.prPotentialScore);
     if (!selected) {
@@ -391,6 +447,126 @@ export class AnalyzeOrchestrator {
         value: suggestion,
       })),
     });
+  }
+
+  private async promptForCandidate(candidates: PresetAnalyzeCandidate[]): Promise<PresetAnalyzeCandidate> {
+    if (candidates.length === 1) {
+      return candidates[0]!;
+    }
+
+    return selectPrompt<PresetAnalyzeCandidate>({
+      message: 'Select a repository suggestion to draft:',
+      pageSize: Math.min(10, candidates.length),
+      choices: candidates.slice(0, 10).map((candidate) => ({
+        name: `${candidate.repoFullName} - ${candidate.suggestion.title}`,
+        description: `score ${candidate.suggestion.prPotentialScore} | ${candidate.suggestion.summary.slice(0, 72)}`,
+        value: candidate,
+      })),
+    });
+  }
+
+  private async collectSingleAnalysisGroup(
+    repoFullName: string,
+    options: {
+      headless: boolean;
+      runChecks: boolean;
+      repoPath?: string;
+      totalSteps: number;
+    },
+  ): Promise<PresetAnalyzeGroup> {
+    const memory = memoryService.load(repoFullName);
+    const workspace = await ui.task(
+      {
+        title: 'Preparing repository workspace',
+        doneMessage: 'Repository workspace prepared',
+        failedMessage: 'Repository workspace preparation failed',
+        tone: 'info',
+        step: { index: 3, total: options.totalSteps },
+        heartbeat: {
+          message: 'Still preparing repository workspace',
+        },
+      },
+      async () =>
+        workspaceService.prepareRepositoryWorkspace(
+          repoFullName,
+          memory,
+          options.runChecks,
+          options.headless ? 'headless' : 'interactive',
+          options.repoPath,
+        ),
+    );
+
+    const suggestionsResult = await ui.task(
+      {
+        title: 'Inspecting repository for grounded contribution ideas',
+        doneMessage: 'Repository suggestions generated',
+        failedMessage: 'Repository suggestion analysis failed',
+        tone: 'info',
+        step: { index: 4, total: options.totalSteps },
+        heartbeat: {
+          message: 'Still inspecting repository context',
+        },
+      },
+      async () => llmService.analyzeRepository(repoFullName, workspace, memory),
+    );
+
+    return {
+      repoFullName,
+      workspace,
+      memory,
+      suggestions: suggestionsResult.data,
+    };
+  }
+
+  private async collectAnalysisGroups(
+    repos: string[],
+    options: {
+      headless: boolean;
+      runChecks: boolean;
+      totalSteps: number;
+    },
+  ): Promise<PresetAnalyzeGroup[]> {
+    const groups: PresetAnalyzeGroup[] = [];
+
+    for (const repoFullName of repos) {
+      const memory = memoryService.load(repoFullName);
+      const workspace = await ui.task(
+        {
+          title: `Preparing repository workspace for ${repoFullName}`,
+          doneMessage: 'Repository workspace prepared',
+          failedMessage: 'Repository workspace preparation failed',
+          tone: 'info',
+          step: { index: 3, total: options.totalSteps },
+        },
+        async () =>
+          workspaceService.prepareRepositoryWorkspace(
+            repoFullName,
+            memory,
+            options.runChecks,
+            options.headless ? 'headless' : 'interactive',
+          ),
+      );
+
+      const suggestionsResult = await ui.task(
+        {
+          title: `Analyzing repository contribution paths for ${repoFullName}`,
+          doneMessage: 'Repository suggestions generated',
+          failedMessage: 'Repository analysis failed',
+          tone: 'info',
+          step: { index: 4, total: options.totalSteps },
+        },
+        async () => llmService.analyzeRepository(repoFullName, workspace, memory),
+      );
+
+      groups.push({
+        repoFullName,
+        workspace,
+        memory,
+        suggestions: suggestionsResult.data,
+      });
+    }
+
+    return groups;
   }
 
   private buildSyntheticIssue(repoFullName: string, suggestion: RepositoryImprovementSuggestion): RankedIssue {

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -3,6 +3,7 @@ import {
   getPreset,
   normalizeOverallWeights,
   normalizeWeights,
+  repositoryTargetingService,
   SCORING_PRESETS,
   schedulerService,
 } from '../services/index.js';
@@ -43,6 +44,7 @@ export class ConfigOrchestrator {
   async getMachineSnapshot(): Promise<{
     userProfile: AppConfig['userProfile'];
     github: { username: string; pat: string; targetRepoPath?: string };
+    repositoryTargeting: AppConfig['repositoryTargeting'];
     llm: {
       provider: AppConfig['llm']['provider'];
       apiBaseUrl: string;
@@ -67,6 +69,7 @@ export class ConfigOrchestrator {
         pat: ui.maskSecret(config.github.pat),
         targetRepoPath: config.github.targetRepoPath,
       },
+      repositoryTargeting: config.repositoryTargeting,
       llm: {
         provider: config.llm.provider,
         apiBaseUrl: config.llm.apiBaseUrl,
@@ -149,7 +152,25 @@ export class ConfigOrchestrator {
         tone: config.github.username ? 'info' : 'warning',
       },
       { label: 'PAT', value: ui.maskSecret(config.github.pat), tone: config.github.pat ? 'info' : 'warning' },
-      { label: 'Target repo', value: config.github.targetRepoPath || 'Auto-managed private repository', tone: 'info' },
+      { label: 'Artifact repo', value: config.github.targetRepoPath || 'Auto-managed private repository', tone: 'info' },
+    ]);
+
+    ui.keyValues('Repository targeting', [
+      {
+        label: 'Active preset',
+        value: config.repositoryTargeting.activePreset || '(none)',
+        tone: config.repositoryTargeting.activePreset ? 'success' : 'muted',
+      },
+      {
+        label: 'Saved presets',
+        value: String(Object.keys(config.repositoryTargeting.presets || {}).length),
+        tone: Object.keys(config.repositoryTargeting.presets || {}).length > 0 ? 'info' : 'muted',
+      },
+      {
+        label: 'Active repos',
+        value: repositoryTargetingService.getActiveRepos(config).join(', ') || '(none)',
+        tone: repositoryTargetingService.getActiveRepos(config).length > 0 ? 'info' : 'muted',
+      },
     ]);
 
     ui.keyValues('LLM', [

--- a/src/orchestration/doctor.ts
+++ b/src/orchestration/doctor.ts
@@ -9,7 +9,12 @@ import {
   getOpenMetaWorkspaceRoot,
   ui,
 } from '../infra/index.js';
-import { type BinaryResolution, inspectBinaryOnPath, schedulerService } from '../services/index.js';
+import {
+  type BinaryResolution,
+  inspectBinaryOnPath,
+  repositoryTargetingService,
+  schedulerService,
+} from '../services/index.js';
 import type { AppConfig } from '../types/index.js';
 
 export type DoctorCheckStatus = 'pass' | 'warn' | 'fail';
@@ -114,6 +119,7 @@ export class DoctorOrchestrator {
       this.checkLlmConfig(resolvedConfig),
       this.checkProfileConfig(resolvedConfig),
       await this.checkTargetRepository(resolvedConfig),
+      this.checkRepositoryTargeting(resolvedConfig),
       this.checkSchedulerConfig(resolvedConfig),
     ];
     const totals = this.countStatuses(checks);
@@ -414,6 +420,19 @@ export class DoctorOrchestrator {
         remediation: 'Check the repository path and git permissions.',
       };
     }
+  }
+
+  private checkRepositoryTargeting(config: AppConfig): DoctorCheck {
+    const result = repositoryTargetingService.validateConfig(config);
+
+    return {
+      id: 'repository-targeting',
+      label: 'Repository targeting',
+      status: result.status,
+      summary: result.summary,
+      detail: result.detail,
+      remediation: result.remediation,
+    };
   }
 
   private checkSchedulerConfig(config: AppConfig): DoctorCheck {

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -6,6 +6,7 @@ export { DailyOrchestrator, dailyOrchestrator } from './daily.js';
 export { DoctorOrchestrator, doctorOrchestrator } from './doctor.js';
 export { InitOrchestrator, initOrchestrator } from './init.js';
 export * from './machine/index.js';
+export { PresetOrchestrator, presetOrchestrator } from './preset.js';
 export { ProviderOrchestrator, providerOrchestrator } from './provider.js';
 export { RunsOrchestrator, runsOrchestrator } from './runs.js';
 export * from './skill/index.js';

--- a/src/orchestration/init.ts
+++ b/src/orchestration/init.ts
@@ -8,6 +8,7 @@ import {
   ui,
 } from '../infra/index.js';
 import {
+  repositoryTargetingService,
   findLLMProviderPreset,
   githubService,
   LLM_PROVIDER_PRESETS,
@@ -49,7 +50,7 @@ const FOCUS_AREA_CHOICES = [
   { name: 'Open Source', value: 'open-source' },
 ];
 
-type SetupStepId = 'github' | 'llm' | 'profile' | 'targetRepo' | 'automation';
+type SetupStepId = 'github' | 'llm' | 'profile' | 'repositoryPresets' | 'targetRepo' | 'automation';
 
 const SETUP_STEPS: Array<{ id: SetupStepId; label: string }> = [
   {
@@ -65,8 +66,12 @@ const SETUP_STEPS: Array<{ id: SetupStepId; label: string }> = [
     label: 'Matching profile',
   },
   {
+    id: 'repositoryPresets',
+    label: 'Repository presets',
+  },
+  {
     id: 'targetRepo',
-    label: 'Target repository',
+    label: 'Artifact repository',
   },
   {
     id: 'automation',
@@ -93,6 +98,7 @@ export class InitOrchestrator {
 
     type ConfigPatch = {
       github?: Partial<AppConfig['github']>;
+      repositoryTargeting?: Partial<AppConfig['repositoryTargeting']>;
       llm?: Partial<AppConfig['llm']>;
       userProfile?: Partial<AppConfig['userProfile']>;
       automation?: Partial<AppConfig['automation']>;
@@ -102,6 +108,7 @@ export class InitOrchestrator {
       workingConfig = {
         ...workingConfig,
         github: { ...workingConfig.github, ...patch.github },
+        repositoryTargeting: { ...workingConfig.repositoryTargeting, ...patch.repositoryTargeting },
         llm: { ...workingConfig.llm, ...patch.llm },
         userProfile: { ...workingConfig.userProfile, ...patch.userProfile },
         automation: { ...workingConfig.automation, ...patch.automation },
@@ -397,19 +404,146 @@ export class InitOrchestrator {
       },
     );
 
-    // ── Step 4: Target repo ───────────────────────────────────────────────────
+    // ── Step 4: Repository presets ────────────────────────────────────────────
+
+    let repositoryTargeting = config.repositoryTargeting;
+
+    await stepOrSkip(
+      'repositoryPresets',
+      Object.keys(repositoryTargeting.presets || {}).length > 0 &&
+        Boolean(repositoryTargeting.activePreset) &&
+        Boolean(repositoryTargeting.presets?.[repositoryTargeting.activePreset]),
+      'Repository presets are already configured.',
+      () => {
+        ui.keyValues('Repository presets', [
+          { label: 'Active preset', value: repositoryTargeting.activePreset, tone: 'success' },
+          { label: 'Saved presets', value: String(Object.keys(repositoryTargeting.presets || {}).length), tone: 'info' },
+          {
+            label: 'Active repos',
+            value: repositoryTargetingService.getActiveRepos({ ...workingConfig, repositoryTargeting }).join(', '),
+            tone: 'info',
+          },
+        ]);
+      },
+      'Save a reusable repository target set so later scout, analyze, and agent runs can start from known contribution terrain.',
+      async () => {
+        const { createPreset } = await prompt<{ createPreset: boolean }>([
+          {
+            type: 'confirm',
+            name: 'createPreset',
+            message: 'Create a reusable repository preset now?',
+            default: true,
+          },
+        ]);
+
+        if (!createPreset) {
+          completedSteps.add('repositoryPresets');
+          ui.keyValues('Repository presets', [
+            { label: 'Active preset', value: '(none)', tone: 'muted' },
+            { label: 'Saved presets', value: '0', tone: 'muted' },
+            { label: 'Active repos', value: '(none)', tone: 'muted' },
+          ]);
+          return true;
+        }
+
+        const { presetName } = await prompt<{ presetName: string }>([
+          {
+            type: 'input',
+            name: 'presetName',
+            message: 'Preset name:',
+            default: 'default',
+            filter: (input: string) => input.trim(),
+            validate: (input: string) => {
+              try {
+                repositoryTargetingService.normalizePresetName(input);
+                return true;
+              } catch (error) {
+                return error instanceof Error ? error.message : 'Invalid preset name.';
+              }
+            },
+          },
+        ]);
+
+        const { presetRepos } = await prompt<{ presetRepos: string }>([
+          {
+            type: 'input',
+            name: 'presetRepos',
+            message: 'Repositories (comma-separated owner/name or GitHub URLs):',
+            filter: (input: string) => input.trim(),
+            validate: (input: string) => {
+              try {
+                repositoryTargetingService.normalizeRepos(
+                  input
+                    .split(',')
+                    .map((item) => item.trim())
+                    .filter(Boolean),
+                );
+                return true;
+              } catch (error) {
+                return error instanceof Error ? error.message : 'Invalid repository list.';
+              }
+            },
+          },
+        ]);
+
+        const { activatePreset } = await prompt<{ activatePreset: boolean }>([
+          {
+            type: 'confirm',
+            name: 'activatePreset',
+            message: 'Use this repository preset as the default target set?',
+            default: true,
+          },
+        ]);
+
+        const normalizedName = repositoryTargetingService.normalizePresetName(presetName);
+        const repos = repositoryTargetingService.normalizeRepos(
+          presetRepos
+            .split(',')
+            .map((item) => item.trim())
+            .filter(Boolean),
+        );
+
+        repositoryTargeting = {
+          activePreset: activatePreset ? normalizedName : '',
+          presets: {
+            ...(repositoryTargeting.presets || {}),
+            [normalizedName]: { repos },
+          },
+        };
+
+        completedSteps.add('repositoryPresets');
+        await commit({ repositoryTargeting });
+        ui.keyValues('Repository presets', [
+          {
+            label: 'Active preset',
+            value: repositoryTargeting.activePreset || '(none)',
+            tone: repositoryTargeting.activePreset ? 'success' : 'muted',
+          },
+          { label: 'Saved presets', value: String(Object.keys(repositoryTargeting.presets || {}).length), tone: 'info' },
+          {
+            label: 'Active repos',
+            value:
+              repositoryTargetingService.getActiveRepos({ ...workingConfig, repositoryTargeting }).join(', ') || '(none)',
+            tone: 'info',
+          },
+        ]);
+        return true;
+      },
+    );
+
+    // ── Step 5: Artifact repo ────────────────────────────────────────────────
 
     this.renderStep(
       'targetRepo',
       completedSteps,
-      'Leave this blank if you want OpenMeta to manage a dedicated private repo for you.',
+      'Leave this blank if you want OpenMeta to manage a dedicated private artifact repo for you.',
     );
 
-    const { targetRepoPath } = await prompt<{ targetRepoPath: string }>([
+    const { artifactRepoPath } = await prompt<{ artifactRepoPath: string }>([
       {
         type: 'input',
-        name: 'targetRepoPath',
-        message: 'Enter the path to your private repository (optional):',
+        name: 'artifactRepoPath',
+        message: 'Enter the path to your private artifact repository (optional):',
         default: config.github.targetRepoPath || '',
         filter: (input: string) => input.trim(),
         validate: async (input: string) => {
@@ -423,16 +557,16 @@ export class InitOrchestrator {
     ]);
 
     completedSteps.add('targetRepo');
-    await commit({ github: { targetRepoPath: targetRepoPath || undefined } });
-    ui.keyValues('Target repository policy', [
+    await commit({ github: { targetRepoPath: artifactRepoPath || undefined } });
+    ui.keyValues('Artifact repository policy', [
       {
         label: 'Publish destination',
-        value: targetRepoPath || 'Auto-managed private repository',
-        tone: targetRepoPath ? 'info' : 'accent',
+        value: artifactRepoPath || 'Auto-managed private repository',
+        tone: artifactRepoPath ? 'info' : 'accent',
       },
     ]);
 
-    // ── Step 5: Automation ────────────────────────────────────────────────────
+    // ── Step 6: Automation ────────────────────────────────────────────────────
 
     this.renderStep(
       'automation',
@@ -532,7 +666,12 @@ export class InitOrchestrator {
       { label: 'Model', value: modelValue, hint: selectedProvider?.name, tone: 'success' },
       { label: 'Reasoning', value: reasoningEffort, tone: 'info' },
       { label: 'Streaming', value: stream ? 'YES' : 'NO', tone: stream ? 'info' : 'muted' },
-      { label: 'Repo policy', value: targetRepoPath ? 'CUSTOM' : 'MANAGED', tone: 'accent' },
+      {
+        label: 'Repository preset',
+        value: repositoryTargeting.activePreset || '(none)',
+        tone: repositoryTargeting.activePreset ? 'info' : 'muted',
+      },
+      { label: 'Repo policy', value: artifactRepoPath ? 'CUSTOM' : 'MANAGED', tone: 'accent' },
       {
         label: 'Automation',
         value: automationEnabled ? 'ENABLED' : 'MANUAL',
@@ -543,7 +682,12 @@ export class InitOrchestrator {
       { label: 'Tech stack', value: techStack.join(', '), tone: 'info' },
       { label: 'Proficiency', value: proficiency, tone: 'info' },
       { label: 'Focus areas', value: focusAreas.join(', '), tone: 'info' },
-      { label: 'Target repo', value: targetRepoPath || 'Auto-managed private repository', tone: 'info' },
+      {
+        label: 'Repository preset',
+        value: repositoryTargeting.activePreset || '(none)',
+        tone: 'info',
+      },
+      { label: 'Artifact repo', value: artifactRepoPath || 'Auto-managed private repository', tone: 'info' },
       {
         label: 'Automation',
         value: this.formatAutomationSummary(workingConfig, schedulerResult),

--- a/src/orchestration/preset.ts
+++ b/src/orchestration/preset.ts
@@ -1,0 +1,130 @@
+import { configService, ui } from '../infra/index.js';
+import { repositoryTargetingService } from '../services/index.js';
+
+interface PresetAddOptions {
+  repo?: string[];
+  activate?: boolean;
+}
+
+export class PresetOrchestrator {
+  async list(): Promise<void> {
+    const config = await configService.get();
+    const presets = config.repositoryTargeting.presets || {};
+    const names = Object.keys(presets).sort();
+
+    ui.hero({
+      label: 'OpenMeta Preset',
+      title: names.length > 0 ? 'Saved repository presets are ready to reuse' : 'No repository presets saved yet',
+      subtitle: 'Repository presets let you reuse fixed exploration targets across scout, analyze, and agent runs.',
+      lines: [
+        `Active preset: ${config.repositoryTargeting.activePreset || '(none)'}`,
+      ],
+      tone: names.length > 0 ? 'accent' : 'warning',
+    });
+
+    if (names.length === 0) {
+      ui.emptyState(
+        'OpenMeta Preset',
+        'No presets found',
+        'Run "openmeta preset add <name> --repo <owner/name>" to create a reusable repository target set.',
+      );
+      return;
+    }
+
+    ui.recordList('Repository presets', names.map((name) => ({
+      title: name,
+      subtitle: `${presets[name]?.repos.length || 0} repository target(s)`,
+      meta: [
+        config.repositoryTargeting.activePreset === name ? 'active' : 'saved',
+      ],
+      lines: (presets[name]?.repos || []).map((repo) => `- ${repo}`),
+      tone: config.repositoryTargeting.activePreset === name ? 'success' : 'info',
+    })));
+  }
+
+  async add(nameInput: string, options: PresetAddOptions): Promise<void> {
+    const name = repositoryTargetingService.normalizePresetName(nameInput);
+    const config = await configService.get();
+    const repos = repositoryTargetingService.normalizeRepos(options.repo || []);
+
+    const updated = await configService.update({
+      repositoryTargeting: {
+        activePreset: options.activate ? name : config.repositoryTargeting.activePreset,
+        presets: {
+          ...(config.repositoryTargeting.presets || {}),
+          [name]: { repos },
+        },
+      },
+    });
+
+    ui.card({
+      label: 'OpenMeta Preset',
+      title: 'Repository preset saved',
+      subtitle: options.activate ? 'This preset is now the active exploration target set.' : 'Switch to it later with "openmeta preset use <name>".',
+      lines: [
+        `Preset: ${name}`,
+        `Repositories: ${repos.join(', ')}`,
+        `Active preset: ${updated.repositoryTargeting.activePreset || '(none)'}`,
+      ],
+      tone: 'success',
+    });
+  }
+
+  async use(nameInput: string): Promise<void> {
+    const name = repositoryTargetingService.normalizePresetName(nameInput);
+    const config = await configService.get();
+    const preset = config.repositoryTargeting.presets?.[name];
+    if (!preset) {
+      throw new Error(`Repository preset "${name}" does not exist. Run "openmeta preset list" to see saved presets.`);
+    }
+
+    await configService.update({
+      repositoryTargeting: {
+        ...config.repositoryTargeting,
+        activePreset: name,
+      },
+    });
+
+    ui.card({
+      label: 'OpenMeta Preset',
+      title: 'Active repository preset switched',
+      subtitle: 'OpenMeta will use this preset by default unless a command overrides the target scope.',
+      lines: [
+        `Preset: ${name}`,
+        `Repositories: ${preset.repos.join(', ')}`,
+      ],
+      tone: 'success',
+    });
+  }
+
+  async remove(nameInput: string): Promise<void> {
+    const name = repositoryTargetingService.normalizePresetName(nameInput);
+    const config = await configService.get();
+    const presets = { ...(config.repositoryTargeting.presets || {}) };
+    if (!presets[name]) {
+      throw new Error(`Repository preset "${name}" does not exist.`);
+    }
+
+    delete presets[name];
+    const activePreset = config.repositoryTargeting.activePreset === name ? '' : config.repositoryTargeting.activePreset;
+    await configService.update({
+      repositoryTargeting: {
+        activePreset,
+        presets,
+      },
+    });
+
+    ui.card({
+      label: 'OpenMeta Preset',
+      title: 'Repository preset removed',
+      subtitle: activePreset ? 'The active preset remained unchanged.' : 'The removed preset was active, so no preset is now marked active.',
+      lines: [
+        `Preset: ${name}`,
+        `Active preset: ${activePreset || '(none)'}`,
+      ],
+      tone: 'success',
+    });
+  }
+}
+
+export const presetOrchestrator = new PresetOrchestrator();

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -136,6 +136,10 @@ export class ContentService {
     workspace: RepoWorkspaceContext,
     suggestions: RepositoryImprovementSuggestion[],
     selectedSuggestion?: RepositoryImprovementSuggestion,
+    groups?: Array<{
+      repoFullName: string;
+      suggestions: RepositoryImprovementSuggestion[];
+    }>,
   ): string {
     const lines = [
       `# Repository Analysis - ${repoFullName}`,
@@ -159,6 +163,39 @@ export class ContentService {
 
     if (selectedSuggestion) {
       lines.push('## Selected Suggestion', '', ...this.formatRepositorySuggestionMarkdown(selectedSuggestion), '');
+    }
+
+    if (groups && groups.length > 0) {
+      lines.push(
+        '## Repository Groups',
+        '',
+        ...groups.flatMap((group) => {
+          const groupLines = [
+            `### ${group.repoFullName}`,
+            '',
+          ];
+
+          if (selectedSuggestion && group.repoFullName === repoFullName) {
+            groupLines.push('Selected across all preset repositories', '');
+          }
+
+          if (group.suggestions.length === 0) {
+            groupLines.push('- No repository suggestions were generated.', '');
+            return groupLines;
+          }
+
+          groupLines.push(...group.suggestions.flatMap((suggestion) => ([
+            `#### ${suggestion.title}`,
+            '',
+            `ID: ${suggestion.id}`,
+            `PR Potential: ${suggestion.prPotentialScore}/100`,
+            `Target Files: ${suggestion.targetFiles.map((file) => file.path).join(', ') || 'n/a'}`,
+            '',
+          ])));
+
+          return groupLines;
+        }),
+      );
     }
 
     lines.push(

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,6 +9,11 @@ export { findLLMProviderPreset, LLM_PROVIDER_PRESETS, type LLMProviderPreset } f
 export { MemoryService, memoryService } from './memory.js';
 export { OpportunityService, opportunityService } from './opportunity.js';
 export { ProofOfWorkService, proofOfWorkService } from './proof-of-work.js';
+export {
+  type ResolvedRepositoryScope,
+  RepositoryTargetingService,
+  repositoryTargetingService,
+} from './repository-targeting.js';
 export { RunHistoryService, runHistoryService } from './run-history.js';
 export { type BinaryResolution, inspectBinaryOnPath } from './runtime-diagnostics.js';
 export type { SchedulerSyncResult } from './scheduler.js';

--- a/src/services/repository-targeting.ts
+++ b/src/services/repository-targeting.ts
@@ -1,0 +1,154 @@
+import { parseGitHubRepoFullName } from '../infra/index.js';
+import type { AppConfig, RepositoryPreset } from '../types/index.js';
+
+export interface ResolvedRepositoryScope {
+  mode: 'single' | 'preset' | 'global' | 'none';
+  repo?: string;
+  presetName?: string;
+  repos: string[];
+}
+
+export class RepositoryTargetingService {
+  normalizePresetName(nameInput: string): string {
+    const name = nameInput.trim();
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
+      throw new Error('Repository preset name must start with a letter or number and may contain letters, numbers, dots, underscores, or dashes.');
+    }
+
+    return name;
+  }
+
+  normalizeRepos(repoInputs: string[]): string[] {
+    const repos = [...new Set(repoInputs.map((value) => parseGitHubRepoFullName(value)))];
+    if (repos.length < 1 || repos.length > 10) {
+      throw new Error('A repository preset must contain between 1 and 10 repositories.');
+    }
+
+    return repos;
+  }
+
+  getPreset(config: AppConfig, nameInput: string): { name: string; preset: RepositoryPreset } {
+    const name = this.normalizePresetName(nameInput);
+    const preset = config.repositoryTargeting.presets?.[name];
+    if (!preset) {
+      throw new Error(`Repository preset "${name}" does not exist.`);
+    }
+
+    return { name, preset };
+  }
+
+  getActivePreset(config: AppConfig): { name: string; preset: RepositoryPreset } | null {
+    const targeting = config.repositoryTargeting ?? { activePreset: '', presets: {} };
+    const activeName = targeting.activePreset?.trim();
+    if (!activeName) {
+      return null;
+    }
+
+    const preset = targeting.presets?.[activeName];
+    if (!preset) {
+      return null;
+    }
+
+    return {
+      name: activeName,
+      preset,
+    };
+  }
+
+  getActiveRepos(config: AppConfig): string[] {
+    return this.getActivePreset(config)?.preset.repos || [];
+  }
+
+  resolveScope(
+    config: AppConfig,
+    options: { repo?: string; preset?: string; allRepos?: boolean; allowGlobal?: boolean } = {},
+  ): ResolvedRepositoryScope {
+    if (options.repo) {
+      const repo = parseGitHubRepoFullName(options.repo);
+      return {
+        mode: 'single',
+        repo,
+        repos: [repo],
+      };
+    }
+
+    if (options.allRepos) {
+      return {
+        mode: options.allowGlobal === false ? 'none' : 'global',
+        repos: [],
+      };
+    }
+
+    if (options.preset) {
+      const { name, preset } = this.getPreset(config, options.preset);
+      return {
+        mode: 'preset',
+        presetName: name,
+        repos: preset.repos,
+      };
+    }
+
+    const active = this.getActivePreset(config);
+    if (active) {
+      return {
+        mode: 'preset',
+        presetName: active.name,
+        repos: active.preset.repos,
+      };
+    }
+
+    return {
+      mode: options.allowGlobal === false ? 'none' : 'global',
+      repos: [],
+    };
+  }
+
+  validateConfig(config: AppConfig): { status: 'pass' | 'warn' | 'fail'; summary: string; detail?: string; remediation?: string } {
+    const targeting = config.repositoryTargeting ?? { activePreset: '', presets: {} };
+    const presets = targeting.presets || {};
+    const names = Object.keys(presets);
+
+    if (names.length === 0) {
+      return {
+        status: 'pass',
+        summary: 'No repository presets are configured.',
+      };
+    }
+
+    if (!targeting.activePreset) {
+      return {
+        status: 'warn',
+        summary: 'Repository presets exist but no active preset is selected.',
+        remediation: 'Run "openmeta preset use <name>" to choose the default exploration target set.',
+      };
+    }
+
+    const active = presets[targeting.activePreset];
+    if (!active) {
+      return {
+        status: 'fail',
+        summary: 'The active repository preset does not exist in the saved preset list.',
+        detail: targeting.activePreset,
+        remediation: 'Select a valid preset with "openmeta preset use <name>" or remove the stale active preset.',
+      };
+    }
+
+    try {
+      const repos = this.normalizeRepos(active.repos || []);
+      return {
+        status: 'pass',
+        summary: `Active repository preset "${targeting.activePreset}" is configured.`,
+        detail: repos.join(', '),
+      };
+    } catch (error) {
+      return {
+        status: 'fail',
+        summary: 'The active repository preset contains invalid repository entries.',
+        detail: error instanceof Error ? error.message : String(error),
+        remediation: 'Update the preset with "openmeta preset add <name> --repo <owner/name>" and switch back to it.',
+      };
+    }
+  }
+}
+
+export const repositoryTargetingService = new RepositoryTargetingService();

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -15,6 +15,15 @@ export interface GitHubConfig {
   targetRepoPath?: string;
 }
 
+export interface RepositoryPreset {
+  repos: string[];
+}
+
+export interface RepositoryTargetingConfig {
+  activePreset: string;
+  presets: Record<string, RepositoryPreset>;
+}
+
 export type LLMProvider = 'openai' | 'minimax' | 'moonshot' | 'zhipu' | 'gemini' | 'claude' | 'custom';
 export type LLMReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
@@ -80,6 +89,7 @@ export interface ScoringConfig {
 export interface AppConfig {
   userProfile: UserProfile;
   github: GitHubConfig;
+  repositoryTargeting: RepositoryTargetingConfig;
   llm: LLMConfig;
   automation: AutomationConfig;
   scoring: ScoringConfig;

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -226,7 +226,7 @@ afterEach(() => {
 });
 
 describe('AgentOrchestrator support behavior', () => {
-  test('validateConfig allows explicitly skipping the LLM requirement', async () => {
+  test('validateConfig accepts local-only scout runs without an LLM key', async () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
 
     await expect(
@@ -816,7 +816,7 @@ describe('AgentOrchestrator support behavior', () => {
     ).mockResolvedValue(undefined as never);
     spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
 
-    await orchestrator.scout();
+    await orchestrator.scout({ localOnly: true });
 
     expect(emptyStateSpy).toHaveBeenCalledWith(
       'OpenMeta Scout',

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -33,6 +33,8 @@ interface AgentRunInternals {
     localArtifactsOnly?: boolean;
     refresh?: boolean;
     repo?: string;
+    preset?: string;
+    allRepos?: boolean;
     repoPath?: string;
     issue?: string;
     dryRun?: boolean;
@@ -68,6 +70,7 @@ interface AgentRunInternals {
 interface AnalyzeRunInternals {
   run(options: {
     repo?: string;
+    preset?: string;
     repoPath?: string;
     headless?: boolean;
     runChecks?: boolean;
@@ -75,6 +78,7 @@ interface AnalyzeRunInternals {
   }): Promise<void>;
   runMachine(options: {
     repo?: string;
+    preset?: string;
     repoPath?: string;
     headless?: boolean;
     runChecks?: boolean;
@@ -106,6 +110,10 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       pat: 'ghp_test_token',
       username: 'octocat',
     },
+    repositoryTargeting: {
+      activePreset: '',
+      presets: {},
+    },
     llm: {
       provider: 'custom',
       apiBaseUrl: 'https://example.com/v1',
@@ -129,6 +137,14 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     },
     commitTemplate: 'feat: {{title}}',
     ...overrides,
+    repositoryTargeting: {
+      activePreset: '',
+      presets: {},
+      ...overrides.repositoryTargeting,
+      presets: {
+        ...((overrides.repositoryTargeting?.presets as Record<string, { repos: string[] }> | undefined) ?? {}),
+      },
+    },
   };
 }
 
@@ -453,6 +469,177 @@ describe('AgentOrchestrator run flow', () => {
     );
   });
 
+  test('uses the active preset for scout discovery and falls back to repository analysis when no issue clears the threshold', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+    const baseAutomation = createConfig().automation;
+    const config = createConfig({
+      repositoryTargeting: {
+        activePreset: 'frontend',
+        presets: {
+          frontend: {
+            repos: ['vercel/next.js', 'facebook/react'],
+          },
+        },
+      },
+      automation: {
+        ...baseAutomation,
+        minMatchScore: 95,
+      },
+    });
+    const weakIssue = createRankedIssue({
+      repoFullName: 'vercel/next.js',
+      opportunity: {
+        score: 72,
+        overallScore: 74,
+        summary: 'Below threshold',
+        breakdown: {
+          technicalFit: 70,
+          freshness: 70,
+          onboardingClarity: 72,
+          mergePotential: 74,
+          impact: 76,
+        },
+      },
+    });
+    const nextWorkspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-nextjs',
+      branchName: 'openmeta/analyze-vercel-next-js',
+      candidateFiles: ['README.md'],
+    });
+    const reactWorkspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-react',
+      branchName: 'openmeta/analyze-facebook-react',
+      candidateFiles: ['packages/react/index.js'],
+    });
+    const nextMemory = createMemory({ repoFullName: 'vercel/next.js' });
+    const reactMemory = createMemory({ repoFullName: 'facebook/react' });
+    const selectedSuggestion = createRepositorySuggestion({
+      id: 'next-analysis',
+      title: 'Tighten next config validation',
+      prPotentialScore: 97,
+      targetFiles: [{ path: 'packages/next/src/server/config.ts', reason: 'Validation logic' }],
+    });
+    const lowerSuggestion = createRepositorySuggestion({
+      id: 'react-analysis',
+      title: 'Document react packaging edge case',
+      prPotentialScore: 81,
+      targetFiles: [{ path: 'packages/react/README.md', reason: 'Docs' }],
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const artifacts = createArtifacts();
+    const showResultSpy = spyOn(
+      orchestrator as object as { showResult: AgentRunInternals['showResult'] },
+      'showResult',
+    ).mockImplementation(() => {});
+    const loadRankedIssuesSpy = spyOn(issueRankingService, 'loadRankedIssues')
+      .mockResolvedValueOnce([weakIssue])
+      .mockResolvedValueOnce([]);
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(
+      orchestrator as object as { initializeClients: AgentRunInternals['initializeClients'] },
+      'initializeClients',
+    ).mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValueOnce(nextMemory).mockReturnValueOnce(reactMemory);
+    spyOn(workspaceService, 'prepareRepositoryWorkspace')
+      .mockResolvedValueOnce(nextWorkspace)
+      .mockResolvedValueOnce(reactWorkspace);
+    spyOn(llmService, 'analyzeRepository')
+      .mockResolvedValueOnce({
+        version: '1',
+        kind: 'repository_suggestion_list',
+        status: 'success',
+        data: [selectedSuggestion],
+      })
+      .mockResolvedValueOnce({
+        version: '1',
+        kind: 'repository_suggestion_list',
+        status: 'success',
+        data: [lowerSuggestion],
+      });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(
+      orchestrator as object as { generateConcretePatch: AgentRunInternals['generateConcretePatch'] },
+      'generateConcretePatch',
+    ).mockResolvedValue({
+      changedFiles: ['packages/next/src/server/config.ts'],
+      validationResults: [],
+      reviewRequired: false,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+    spyOn(contentService, 'formatContributionDossier').mockReturnValue('# Dossier');
+    spyOn(
+      orchestrator as object as {
+        submitContributionPullRequestIfPossible: AgentRunInternals['submitContributionPullRequestIfPossible'];
+      },
+      'submitContributionPullRequestIfPossible',
+    ).mockResolvedValue({
+      changedFiles: ['packages/next/src/server/config.ts'],
+      validationResults: [],
+    });
+    spyOn(
+      orchestrator as object as { prepareLocalArtifactPaths: AgentRunInternals['prepareLocalArtifactPaths'] },
+      'prepareLocalArtifactPaths',
+    ).mockReturnValue(artifacts);
+    spyOn(
+      orchestrator as object as { writeLocalArtifacts: AgentRunInternals['writeLocalArtifacts'] },
+      'writeLocalArtifacts',
+    ).mockImplementation(() => {});
+    spyOn(
+      orchestrator as object as { publishArtifactsIfNeeded: AgentRunInternals['publishArtifactsIfNeeded'] },
+      'publishArtifactsIfNeeded',
+    ).mockResolvedValue({
+      published: false,
+    });
+    spyOn(inboxService, 'saveItem').mockReturnValue([createInboxItem()]);
+    spyOn(inboxService, 'renderMarkdown').mockReturnValue('# Inbox');
+    spyOn(proofOfWorkService, 'load').mockReturnValue({ records: [] });
+    spyOn(proofOfWorkService, 'renderMarkdown').mockReturnValue('# Proof');
+    spyOn(proofOfWorkService, 'record').mockReturnValue([createProofRecord()]);
+    spyOn(memoryService, 'renderMarkdown').mockReturnValue('# Memory');
+    spyOn(memoryService, 'recordOutcome').mockReturnValue(nextMemory);
+
+    await orchestrator.run();
+
+    expect(loadRankedIssuesSpy).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        repoFullName: 'vercel/next.js',
+      }),
+    );
+    expect(workspaceService.prepareRepositoryWorkspace).toHaveBeenCalledTimes(2);
+    expect(llmService.generatePatchDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoFullName: 'vercel/next.js',
+        title: 'Tighten next config validation',
+      }),
+      nextWorkspace,
+      nextMemory,
+    );
+    expect(showResultSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue: expect.objectContaining({
+          repoFullName: 'vercel/next.js',
+          number: 0,
+        }),
+        changedFiles: ['packages/next/src/server/config.ts'],
+      }),
+    );
+  });
+
   test('keeps the run in review mode when patch and PR drafts require review', async () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
     const issue = createRankedIssue();
@@ -660,6 +847,139 @@ describe('AnalyzeOrchestrator run flow', () => {
       expect.objectContaining({
         repoFullName: 'acme/demo',
         selectedSuggestion: topSuggestion,
+        artifacts,
+      }),
+    );
+  });
+
+  test('analyzes repositories from the active preset and picks the strongest cross-repo suggestion', async () => {
+    const orchestrator = new AnalyzeOrchestrator() as unknown as AnalyzeRunInternals;
+    const config = createConfig({
+      repositoryTargeting: {
+        activePreset: 'frontend',
+        presets: {
+          frontend: {
+            repos: ['acme/demo', 'acme/docs'],
+          },
+        },
+      },
+    });
+    const demoWorkspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-demo',
+      branchName: 'openmeta/analyze-acme-demo',
+      candidateFiles: ['README.md'],
+    });
+    const docsWorkspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-docs',
+      branchName: 'openmeta/analyze-acme-docs',
+      candidateFiles: ['docs/setup.md'],
+    });
+    const demoMemory = createMemory({ repoFullName: 'acme/demo' });
+    const docsMemory = createMemory({ repoFullName: 'acme/docs' });
+    const demoSuggestion = createRepositorySuggestion({
+      id: 'demo-high',
+      title: 'Add runtime config guard',
+      prPotentialScore: 96,
+      targetFiles: [{ path: 'src/config.ts', reason: 'Guard invalid config' }],
+    });
+    const docsSuggestion = createRepositorySuggestion({
+      id: 'docs-lower',
+      title: 'Clarify setup docs',
+      prPotentialScore: 78,
+      targetFiles: [{ path: 'docs/setup.md', reason: 'Onboarding docs' }],
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const artifacts = {
+      artifactDir: '/tmp/openmeta/artifacts/preset-analyze',
+      analysisPath: '/tmp/openmeta/artifacts/preset-analyze/repository-analysis.md',
+      patchDraftPath: '/tmp/openmeta/artifacts/preset-analyze/patch-draft.md',
+      prDraftPath: '/tmp/openmeta/artifacts/preset-analyze/pr-draft.md',
+    };
+    const writeArtifactsSpy = spyOn(
+      orchestrator as object as { writeLocalArtifacts: AnalyzeRunInternals['writeLocalArtifacts'] },
+      'writeLocalArtifacts',
+    ).mockImplementation(() => {});
+    const showResultSpy = spyOn(
+      orchestrator as object as { showResult: AnalyzeRunInternals['showResult'] },
+      'showResult',
+    ).mockImplementation(() => {});
+    const analysisMarkdownSpy = spyOn(contentService, 'formatRepositoryAnalysisMarkdown').mockReturnValue(
+      '# Repository Analysis',
+    );
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(
+      orchestrator as object as { initializeClients: AnalyzeRunInternals['initializeClients'] },
+      'initializeClients',
+    ).mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValueOnce(demoMemory).mockReturnValueOnce(docsMemory);
+    spyOn(workspaceService, 'prepareRepositoryWorkspace')
+      .mockResolvedValueOnce(demoWorkspace)
+      .mockResolvedValueOnce(docsWorkspace);
+    spyOn(llmService, 'analyzeRepository')
+      .mockResolvedValueOnce({
+        version: '1',
+        kind: 'repository_suggestion_list',
+        status: 'success',
+        data: [demoSuggestion],
+      })
+      .mockResolvedValueOnce({
+        version: '1',
+        kind: 'repository_suggestion_list',
+        status: 'success',
+        data: [docsSuggestion],
+      });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+    spyOn(
+      orchestrator as object as { prepareArtifactPaths: AnalyzeRunInternals['prepareArtifactPaths'] },
+      'prepareArtifactPaths',
+    ).mockReturnValue(artifacts);
+
+    await orchestrator.run({ headless: true });
+
+    expect(workspaceService.prepareRepositoryWorkspace).toHaveBeenCalledTimes(2);
+    expect(llmService.generatePatchDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoFullName: 'acme/demo',
+        title: 'Add runtime config guard',
+      }),
+      demoWorkspace,
+      demoMemory,
+    );
+    expect(analysisMarkdownSpy).toHaveBeenCalledWith(
+      'acme/demo',
+      demoWorkspace,
+      [demoSuggestion],
+      demoSuggestion,
+      [
+        { repoFullName: 'acme/demo', suggestions: [demoSuggestion] },
+        { repoFullName: 'acme/docs', suggestions: [docsSuggestion] },
+      ],
+    );
+    expect(writeArtifactsSpy).toHaveBeenCalledWith({
+      artifacts,
+      analysisMarkdown: '# Repository Analysis',
+      patchDraftMarkdown: '# Patch',
+      prDraftMarkdown: '# PR',
+    });
+    expect(showResultSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoFullName: 'acme/demo',
+        selectedSuggestion: demoSuggestion,
         artifacts,
       }),
     );

--- a/test/config-orchestrator.test.ts
+++ b/test/config-orchestrator.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ConfigService, configService } from '../src/infra/config.js';
+import * as infra from '../src/infra/index.js';
 import { ConfigOrchestrator } from '../src/orchestration/config.js';
 import type { AppConfig } from '../src/types/index.js';
 
@@ -21,6 +22,7 @@ describe('ConfigOrchestrator', () => {
   });
 
   afterEach(() => {
+    mock.restore();
     clearSharedConfigCache();
     delete process.env['OPENMETA_CONFIG_DIR'];
     delete process.env['OPENMETA_HOME'];
@@ -93,5 +95,51 @@ describe('ConfigOrchestrator', () => {
     expect(result.appliedValue).toBe('***cret');
     expect(result.snapshot.llm.apiKey).toBe('***cret');
     expect(result.scheduler.status).toBe('unchanged');
+  });
+
+  test('renders repository preset summary and artifact repository terminology in config view', async () => {
+    const orchestrator = new ConfigOrchestrator();
+    const heroSpy = spyOn(infra.ui, 'hero').mockImplementation(() => {});
+    const keyValuesSpy = spyOn(infra.ui, 'keyValues').mockImplementation(() => {});
+    const statsSpy = spyOn(infra.ui, 'stats').mockImplementation(() => {});
+    const cardSpy = spyOn(infra.ui, 'card').mockImplementation(() => {});
+
+    await configService.save({
+      ...(await configService.get()),
+      github: {
+        pat: 'ghp_secret',
+        username: 'octocat',
+        targetRepoPath: '/tmp/private-artifacts',
+      },
+      repositoryTargeting: {
+        activePreset: 'frontend',
+        presets: {
+          frontend: {
+            repos: ['vercel/next.js', 'facebook/react'],
+          },
+          tools: {
+            repos: ['oven-sh/bun'],
+          },
+        },
+      },
+      llm: {
+        ...(await configService.get()).llm,
+        apiKey: 'sk-secret',
+      },
+    });
+
+    await orchestrator.view();
+
+    expect(heroSpy).toHaveBeenCalled();
+    expect(statsSpy).toHaveBeenCalled();
+    expect(cardSpy).toHaveBeenCalled();
+    expect(keyValuesSpy).toHaveBeenCalledWith('GitHub', expect.arrayContaining([
+      expect.objectContaining({ label: 'Artifact repo', value: '/tmp/private-artifacts' }),
+    ]));
+    expect(keyValuesSpy).toHaveBeenCalledWith('Repository targeting', [
+      { label: 'Active preset', value: 'frontend', tone: 'success' },
+      { label: 'Saved presets', value: '2', tone: 'info' },
+      { label: 'Active repos', value: 'vercel/next.js, facebook/react', tone: 'info' },
+    ]);
   });
 });

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -97,6 +97,60 @@ describe('contentService', () => {
     expect(markdown).toContain('### Document local install');
   });
 
+  test('formats grouped repository analysis markdown for preset-scoped multi-repo suggestions', () => {
+    const markdown = contentService.formatRepositoryAnalysisMarkdown(
+      'acme/demo',
+      createWorkspace({
+        workspacePath: '/tmp/openmeta-demo',
+        defaultBranch: 'main',
+        candidateFiles: ['README.md', 'src/config.ts'],
+      }),
+      [
+        createRepositorySuggestion({
+          id: 'demo-high',
+          title: 'Add runtime config guard',
+          prPotentialScore: 96,
+          targetFiles: [{ path: 'src/config.ts', reason: 'Guard invalid config' }],
+        }),
+      ],
+      createRepositorySuggestion({
+        id: 'demo-high',
+        title: 'Add runtime config guard',
+        prPotentialScore: 96,
+        targetFiles: [{ path: 'src/config.ts', reason: 'Guard invalid config' }],
+      }),
+      [
+        {
+          repoFullName: 'acme/demo',
+          suggestions: [
+            createRepositorySuggestion({
+              id: 'demo-high',
+              title: 'Add runtime config guard',
+              prPotentialScore: 96,
+              targetFiles: [{ path: 'src/config.ts', reason: 'Guard invalid config' }],
+            }),
+          ],
+        },
+        {
+          repoFullName: 'acme/docs',
+          suggestions: [
+            createRepositorySuggestion({
+              id: 'docs-setup',
+              title: 'Clarify setup docs',
+              prPotentialScore: 78,
+              targetFiles: [{ path: 'docs/setup.md', reason: 'Onboarding docs' }],
+            }),
+          ],
+        },
+      ],
+    );
+
+    expect(markdown).toContain('## Repository Groups');
+    expect(markdown).toContain('### acme/demo');
+    expect(markdown).toContain('### acme/docs');
+    expect(markdown).toContain('Selected across all preset repositories');
+  });
+
   test('formats inbox and proof-of-work markdown summaries', () => {
     const inboxMarkdown = contentService.formatInboxMarkdown([createInboxItem()]);
     const proofMarkdown = contentService.formatProofOfWorkMarkdown([createProofRecord()]);

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -26,6 +26,10 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       apiKey: 'sk-test-key',
       modelName: 'gpt-4o-mini',
     },
+    repositoryTargeting: {
+      activePreset: '',
+      presets: {},
+    },
     automation: {
       enabled: false,
       scheduleTime: '09:00',
@@ -152,5 +156,33 @@ describe('DoctorOrchestrator', () => {
 
     expect(report.ready).toBe(false);
     expect(report.checks.find((check) => check.id === 'target-repo')?.status).toBe('fail');
+  });
+
+  test('warns when presets exist without an active preset and fails on invalid active preset references', async () => {
+    const doctor = new DoctorOrchestrator();
+
+    const warned = await doctor.inspect(createConfig({
+      repositoryTargeting: {
+        activePreset: '',
+        presets: {
+          frontend: {
+            repos: ['vercel/next.js'],
+          },
+        },
+      },
+    }));
+    expect(warned.checks.find((check) => check.id === 'repository-targeting')?.status).toBe('warn');
+
+    const failed = await doctor.inspect(createConfig({
+      repositoryTargeting: {
+        activePreset: 'missing',
+        presets: {
+          frontend: {
+            repos: ['vercel/next.js'],
+          },
+        },
+      },
+    }));
+    expect(failed.checks.find((check) => check.id === 'repository-targeting')?.status).toBe('fail');
   });
 });

--- a/test/init-orchestrator.test.ts
+++ b/test/init-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, spyOn, test } from 'bun:test';
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import * as infra from '../src/infra/index.js';
 import { InitOrchestrator } from '../src/orchestration/init.js';
 import type { LLMReasoningEffort } from '../src/types/index.js';
@@ -9,6 +9,10 @@ interface InitOrchestratorInternals {
 }
 
 describe('InitOrchestrator LLM reasoning setup', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
   test('defaults reasoning effort selection to none during init', async () => {
     const orchestrator = new InitOrchestrator() as unknown as InitOrchestratorInternals;
     const selectSpy = spyOn(infra, 'selectPrompt').mockResolvedValue('none');
@@ -51,5 +55,83 @@ describe('InitOrchestrator LLM reasoning setup', () => {
     } finally {
       promptSpy.mockRestore();
     }
+  });
+
+  test('prompts for a first repository preset during init before artifact repository setup', async () => {
+    const orchestrator = new InitOrchestrator();
+    spyOn(infra.configService, 'get').mockResolvedValue({
+      userProfile: {
+        techStack: [],
+        proficiency: 'beginner',
+        focusAreas: [],
+      },
+      github: {
+        pat: 'ghp_test',
+        username: 'octocat',
+        targetRepoPath: '',
+      },
+      repositoryTargeting: {
+        activePreset: '',
+        presets: {},
+      },
+      llm: {
+        provider: 'openai',
+        apiBaseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        modelName: 'gpt-4o-mini',
+        apiHeaders: {},
+        reasoningEffort: 'none',
+        stream: false,
+        activeProfile: '',
+        profiles: {},
+      },
+      automation: {
+        enabled: false,
+        scheduleTime: '09:00',
+        timezone: 'UTC',
+        contentType: 'research_note',
+        scheduler: 'manual',
+        minMatchScore: 70,
+        skipIfAlreadyGeneratedToday: true,
+      },
+      commitTemplate: 'feat: {{title}}',
+    });
+    const saveSpy = spyOn(infra.configService, 'save').mockResolvedValue(undefined);
+    spyOn(infra.ui, 'hero').mockImplementation(() => {});
+    spyOn(infra.ui, 'section').mockImplementation(() => {});
+    spyOn(infra.ui, 'keyValues').mockImplementation(() => {});
+    spyOn(infra.ui, 'stats').mockImplementation(() => {});
+    spyOn(infra.ui, 'callout').mockImplementation(() => {});
+    spyOn(infra.ui, 'task').mockImplementation(async (_options, task) => task({ setMessage() {} } as never));
+    spyOn(infra, 'selectPrompt')
+      .mockResolvedValueOnce('beginner')
+      .mockResolvedValueOnce('research_note');
+    const promptSpy = spyOn(infra, 'prompt')
+      .mockResolvedValueOnce({ techStack: ['TypeScript'] })
+      .mockResolvedValueOnce({ focusAreas: ['open-source'] })
+      .mockResolvedValueOnce({ createPreset: true })
+      .mockResolvedValueOnce({ presetName: 'default' })
+      .mockResolvedValueOnce({ presetRepos: 'vercel/next.js, facebook/react' })
+      .mockResolvedValueOnce({ activatePreset: true })
+      .mockResolvedValueOnce({ artifactRepoPath: '' })
+      .mockResolvedValueOnce({ automationEnabled: false });
+    await orchestrator.execute();
+
+    expect(promptSpy).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'createPreset',
+        message: 'Create a reusable repository preset now?',
+      }),
+    ]));
+    expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryTargeting: {
+        activePreset: 'default',
+        presets: {
+          default: {
+            repos: ['vercel/next.js', 'facebook/react'],
+          },
+        },
+      },
+    }));
   });
 });

--- a/test/issue-ranking.test.ts
+++ b/test/issue-ranking.test.ts
@@ -188,6 +188,10 @@ describe('IssueRankingService', () => {
             username: 'octocat',
             targetRepoPath: '',
           },
+          repositoryTargeting: {
+            activePreset: '',
+            presets: {},
+          },
           llm: {
             provider: 'openai',
             apiBaseUrl: 'https://api.openai.com/v1',
@@ -254,6 +258,10 @@ describe('IssueRankingService', () => {
             pat: 'ghp-test',
             username: 'octocat',
             targetRepoPath: '',
+          },
+          repositoryTargeting: {
+            activePreset: '',
+            presets: {},
           },
           llm: {
             provider: 'openai',

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { Command } from 'commander';
+import { registerPresetCommand } from '../src/commands/preset.js';
+
+describe('registerPresetCommand', () => {
+  test('registers preset management commands and options', () => {
+    const program = new Command();
+    registerPresetCommand(program);
+
+    const presetCommand = program.commands.find((command) => command.name() === 'preset');
+    const help = presetCommand?.helpInformation() ?? '';
+    const addHelp = presetCommand?.commands.find((command) => command.name() === 'add')?.helpInformation() ?? '';
+
+    expect(help).toContain('list');
+    expect(help).toContain('add');
+    expect(help).toContain('use');
+    expect(help).toContain('remove');
+    expect(addHelp).toContain('--repo <repository>');
+    expect(addHelp).toContain('--activate');
+  });
+});

--- a/test/preset-orchestrator.test.ts
+++ b/test/preset-orchestrator.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { configService } from '../src/infra/config.js';
+import { PresetOrchestrator } from '../src/orchestration/preset.js';
+import type { AppConfig } from '../src/types/index.js';
+
+let tempRoot = '';
+
+function clearSharedConfigCache(): void {
+  (configService as unknown as { config: AppConfig | null }).config = null;
+}
+
+describe('PresetOrchestrator', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'openmeta-preset-orchestrator-'));
+    process.env['OPENMETA_CONFIG_DIR'] = join(tempRoot, '.config', 'openmeta');
+    process.env['OPENMETA_HOME'] = join(tempRoot, '.openmeta');
+    clearSharedConfigCache();
+  });
+
+  afterEach(() => {
+    clearSharedConfigCache();
+    delete process.env['OPENMETA_CONFIG_DIR'];
+    delete process.env['OPENMETA_HOME'];
+
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = '';
+    }
+  });
+
+  test('adds repository presets with normalized deduplicated repos and can switch the active preset', async () => {
+    const orchestrator = new PresetOrchestrator();
+
+    await orchestrator.add('frontend-core', {
+      repo: [
+        'vercel/next.js',
+        'https://github.com/vercel/next.js',
+        'git@github.com:facebook/react.git',
+      ],
+      activate: true,
+    });
+    await orchestrator.add('tooling', {
+      repo: [
+        'oven-sh/bun',
+      ],
+    });
+    await orchestrator.use('tooling');
+
+    const loaded = await configService.get();
+
+    expect(loaded.repositoryTargeting.presets['frontend-core']).toEqual({
+      repos: ['vercel/next.js', 'facebook/react'],
+    });
+    expect(loaded.repositoryTargeting.presets['tooling']).toEqual({
+      repos: ['oven-sh/bun'],
+    });
+    expect(loaded.repositoryTargeting.activePreset).toBe('tooling');
+  });
+
+  test('rejects invalid preset repositories and repo counts beyond the configured limit', async () => {
+    const orchestrator = new PresetOrchestrator();
+
+    await expect(orchestrator.add('broken', {
+      repo: ['https://gitlab.com/acme/demo'],
+    })).rejects.toThrow('Repository must be a GitHub repository');
+
+    await expect(orchestrator.add('too-many', {
+      repo: Array.from({ length: 11 }, (_, index) => `acme/demo-${index}`),
+    })).rejects.toThrow('must contain between 1 and 10 repositories');
+  });
+
+  test('removes repository presets and clears the active preset when needed', async () => {
+    const orchestrator = new PresetOrchestrator();
+
+    await orchestrator.add('default', {
+      repo: ['acme/demo'],
+      activate: true,
+    });
+    await orchestrator.remove('default');
+
+    const loaded = await configService.get();
+    expect(loaded.repositoryTargeting.presets['default']).toBeUndefined();
+    expect(loaded.repositoryTargeting.activePreset).toBe('');
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -38,7 +38,7 @@ function createIsolatedDir(): string {
 }
 
 function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
-  return {
+  const base: AppConfig = {
     userProfile: {
       techStack: [],
       proficiency: 'beginner',
@@ -48,6 +48,10 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       pat: 'ghp_test',
       username: 'nianjiu',
       targetRepoPath: '',
+    },
+    repositoryTargeting: {
+      activePreset: '',
+      presets: {},
     },
     llm: {
       provider: 'openai',
@@ -70,7 +74,31 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       preset: 'balanced',
     },
     commitTemplate: 'feat(daily): {{title}}\n\n{{content}}',
+  };
+
+  return {
+    ...base,
     ...overrides,
+    github: {
+      ...base.github,
+      ...overrides.github,
+    },
+    repositoryTargeting: {
+      ...base.repositoryTargeting,
+      ...overrides.repositoryTargeting,
+      presets: {
+        ...base.repositoryTargeting.presets,
+        ...overrides.repositoryTargeting?.presets,
+      },
+    },
+    llm: {
+      ...base.llm,
+      ...overrides.llm,
+    },
+    automation: {
+      ...base.automation,
+      ...overrides.automation,
+    },
   };
 }
 

--- a/test/scout-targeting.test.ts
+++ b/test/scout-targeting.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import * as infra from '../src/infra/index.js';
+import { AgentOrchestrator } from '../src/orchestration/agent.js';
+import { issueRankingService } from '../src/services/index.js';
+import type { AppConfig } from '../src/types/index.js';
+import { createRankedIssue } from './helpers/factories.js';
+
+function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  const base: AppConfig = {
+    userProfile: {
+      techStack: ['typescript', 'react'],
+      proficiency: 'intermediate',
+      focusAreas: ['frontend'],
+    },
+    github: {
+      pat: 'ghp_test_token',
+      username: 'octocat',
+    },
+    repositoryTargeting: {
+      activePreset: '',
+      presets: {},
+    },
+    llm: {
+      provider: 'custom',
+      apiBaseUrl: 'https://example.com/v1',
+      apiKey: 'sk-test',
+      modelName: 'test-model',
+      apiHeaders: {},
+    },
+    automation: {
+      enabled: true,
+      scheduleTime: '09:00',
+      timezone: 'UTC',
+      contentType: 'research_note',
+      scheduler: 'manual',
+      minMatchScore: 75,
+      skipIfAlreadyGeneratedToday: false,
+    },
+    commitTemplate: 'feat: {{title}}',
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    github: {
+      ...base.github,
+      ...overrides.github,
+    },
+    repositoryTargeting: {
+      ...base.repositoryTargeting,
+      ...overrides.repositoryTargeting,
+      presets: {
+        ...base.repositoryTargeting.presets,
+        ...overrides.repositoryTargeting?.presets,
+      },
+    },
+    llm: {
+      ...base.llm,
+      ...overrides.llm,
+    },
+    automation: {
+      ...base.automation,
+      ...overrides.automation,
+    },
+  };
+}
+
+beforeEach(() => {
+  spyOn(infra.ui, 'hero').mockImplementation(() => {});
+  spyOn(infra.ui, 'stats').mockImplementation(() => {});
+  spyOn(infra.ui, 'recordList').mockImplementation(() => {});
+  spyOn(infra.ui, 'emptyState').mockImplementation(() => {});
+  spyOn(infra.ui, 'task').mockImplementation(async (_options, task) => task({
+    setMessage() {},
+  } as never));
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('AgentOrchestrator scout targeting', () => {
+  test('auto-applies the active preset during scout discovery', async () => {
+    const orchestrator = new AgentOrchestrator();
+    const config = createConfig({
+      repositoryTargeting: {
+        activePreset: 'frontend',
+        presets: {
+          frontend: {
+            repos: ['vercel/next.js', 'facebook/react'],
+          },
+        },
+      },
+    });
+    const loadRankedIssuesSpy = spyOn(issueRankingService, 'loadRankedIssues')
+      .mockResolvedValueOnce([createRankedIssue({ repoFullName: 'vercel/next.js', number: 1 })])
+      .mockResolvedValueOnce([createRankedIssue({ repoFullName: 'facebook/react', number: 2 })]);
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as unknown as { validateConfig(config: AppConfig, options?: { requireLlm?: boolean }): Promise<void> }, 'validateConfig')
+      .mockResolvedValue(undefined);
+    spyOn(orchestrator as unknown as { initializeClients(config: AppConfig, options?: { validateLlm?: boolean }): Promise<void> }, 'initializeClients')
+      .mockResolvedValue(undefined);
+
+    await orchestrator.scout({ limit: 5 });
+
+    expect(loadRankedIssuesSpy).toHaveBeenNthCalledWith(1, config, expect.objectContaining({
+      repoFullName: 'vercel/next.js',
+    }));
+    expect(loadRankedIssuesSpy).toHaveBeenNthCalledWith(2, config, expect.objectContaining({
+      repoFullName: 'facebook/react',
+    }));
+  });
+
+  test('bypasses the active preset when scout runs with --all-repos', async () => {
+    const orchestrator = new AgentOrchestrator();
+    const config = createConfig({
+      repositoryTargeting: {
+        activePreset: 'frontend',
+        presets: {
+          frontend: {
+            repos: ['vercel/next.js', 'facebook/react'],
+          },
+        },
+      },
+    });
+    const loadRankedIssuesSpy = spyOn(issueRankingService, 'loadRankedIssues')
+      .mockResolvedValue([createRankedIssue()]);
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as unknown as { validateConfig(config: AppConfig, options?: { requireLlm?: boolean }): Promise<void> }, 'validateConfig')
+      .mockResolvedValue(undefined);
+    spyOn(orchestrator as unknown as { initializeClients(config: AppConfig, options?: { validateLlm?: boolean }): Promise<void> }, 'initializeClients')
+      .mockResolvedValue(undefined);
+
+    await orchestrator.scout({ allRepos: true, limit: 5 });
+
+    expect(loadRankedIssuesSpy).toHaveBeenCalledTimes(1);
+    expect(loadRankedIssuesSpy).toHaveBeenCalledWith(config, expect.not.objectContaining({
+      repoFullName: 'vercel/next.js',
+    }));
+  });
+});

--- a/test/state-services.test.ts
+++ b/test/state-services.test.ts
@@ -54,6 +54,8 @@ describe('stateful services', () => {
 
     expect(loaded.github.pat).toBe('ghp_test_token');
     expect(loaded.llm.apiKey).toBe('sk-test-key');
+    expect(loaded.repositoryTargeting.activePreset).toBe('');
+    expect(loaded.repositoryTargeting.presets).toEqual({});
   });
 
   test('config service resets to defaults and keeps a backup of the previous file', async () => {
@@ -98,6 +100,8 @@ describe('stateful services', () => {
     expect(loaded.llm.modelName).toBe('gpt-4o-mini');
     expect(loaded.automation.enabled).toBe(false);
     expect(loaded.automation.scheduleTime).toBe('09:00');
+    expect(loaded.repositoryTargeting.activePreset).toBe('');
+    expect(loaded.repositoryTargeting.presets).toEqual({});
   });
 
   test('memory service persists repo memory snapshots', () => {

--- a/test/targeting-commands.test.ts
+++ b/test/targeting-commands.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { Command } from 'commander';
+import { registerAgentCommand } from '../src/commands/agent.js';
+import { registerAnalyzeCommand } from '../src/commands/analyze.js';
+import { registerScoutCommand } from '../src/commands/scout.js';
+
+describe('repository targeting command options', () => {
+  test('registers scout targeting options for presets and all-repos fallback', () => {
+    const program = new Command();
+    registerScoutCommand(program);
+
+    const scoutCommand = program.commands.find((command) => command.name() === 'scout');
+    const help = scoutCommand?.helpInformation() ?? '';
+
+    expect(help).toContain('--preset <name>');
+    expect(help).toContain('--all-repos');
+  });
+
+  test('registers agent targeting options for presets and all-repos fallback', () => {
+    const program = new Command();
+    registerAgentCommand(program);
+
+    const agentCommand = program.commands.find((command) => command.name() === 'agent');
+    const help = agentCommand?.helpInformation() ?? '';
+
+    expect(help).toContain('--preset <name>');
+    expect(help).toContain('--all-repos');
+  });
+
+  test('registers analyze targeting options for presets', () => {
+    const program = new Command();
+    registerAnalyzeCommand(program);
+
+    const analyzeCommand = program.commands.find((command) => command.name() === 'analyze');
+    const help = analyzeCommand?.helpInformation() ?? '';
+
+    expect(help).toContain('--repo <repository>');
+    expect(help).toContain('--preset <name>');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a reusable repository preset system for contribution targeting, so users can save fixed sets of GitHub repositories, mark one preset as active, and reuse that scope across `scout`, `agent`, and `analyze` without retyping repositories every time.

In addition to the new preset model and CLI surface, this PR also updates the runtime behavior so the active preset is automatically applied by default, while still preserving explicit overrides such as `--repo`, `--preset`, and `--all-repos`.

It also keeps the existing artifact publishing repository behavior intact, but renames the user-facing terminology from "target repository" to "artifact repository" to reduce ambiguity between publishing configuration and contribution exploration scope.
close: #27

## What Changed

### 1. Added repository targeting config support

Introduced a new top-level `repositoryTargeting` config section with:

- `activePreset`
- `presets: Record<string, { repos: string[] }>`

This includes:

- defaults for new configs
- backward-compatible loading for existing configs
- config normalization for preset names and repository entries
- repo deduplication while preserving order
- validation for 1 to 10 repositories per preset

### 2. Added `openmeta preset` management commands

Added a dedicated preset command group:

- `openmeta preset list`
- `openmeta preset add <name> --repo ... [--activate]`
- `openmeta preset use <name>`
- `openmeta preset remove <name>`

These commands are wired into the CLI and orchestration layers and persist their state through the existing config service.

### 3. Extended runtime commands with preset-aware targeting

Updated command surfaces for:

- `openmeta scout`
- `openmeta agent`
- `openmeta analyze`

New options include:

- `--preset <name>` for all three commands
- `--all-repos` for `scout` and `agent`

Resolution precedence is now effectively:

1. `--all-repos` bypasses preset targeting for `scout` and `agent`
2. `--repo` overrides everything else
3. `--preset <name>` selects that named preset
4. otherwise the active preset is auto-applied if configured
5. otherwise behavior falls back to the existing global or explicit-repo model

### 4. Added shared repository targeting service

Introduced a shared service to centralize:

- preset name normalization
- repo normalization
- preset lookup
- active preset lookup
- active repo retrieval
- target scope resolution
- doctor validation

This keeps the targeting precedence and validation logic consistent across multiple commands.

### 5. Updated `openmeta init`, `config view`, and `doctor`

`openmeta init` now includes a repository preset setup step before artifact repository setup.

Behavior includes:

- prompting for a first preset when none exists
- default-friendly preset creation flow
- optional activation during setup
- summary/skip behavior when a valid active preset already exists

`config view` now surfaces:

- active preset
- saved preset count
- active preset repo list

`doctor` now validates repository targeting state and distinguishes between:

- no presets configured
- presets configured with no active preset
- invalid or missing active preset configuration

### 6. Added multi-repo preset behavior to `analyze`

`analyze` now supports:

- explicit `--repo`
- explicit `--preset`
- implicit active preset application
- multi-repo repository analysis for preset scopes

For preset-scoped analysis, the runtime now:

- prepares a repository workspace per repo
- loads repo memory per repo
- runs `llmService.analyzeRepository(...)` per repo
- flattens and globally ranks cross-repo suggestions by `prPotentialScore`
- auto-selects the top candidate in headless mode
- supports interactive cross-repo candidate selection when not headless
- continues patch draft / PR draft generation only for the selected repository
- renders repository analysis artifacts with grouped multi-repo output and selection context

### 7. Added preset-aware `agent` fallback flow

`agent` now understands preset scopes and uses them in a two-step strategy:

1. issue-first scouting across the preset's repositories
2. repository-analysis fallback when no issue clears `automation.minMatchScore`

This means the agent can still produce a contribution path even when preset-scoped issue discovery is not strong enough.

The fallback path reuses the same repository-analysis selection model and then continues through the normal patch draft, implementation, PR draft, artifact, inbox, and proof-of-work flow.

### 8. Added preset-aware `scout`

`scout` now:

- auto-applies the active preset by default
- supports explicit `--preset`
- supports `--all-repos` to bypass preset targeting
- aggregates repo-scoped issue discovery across preset repositories before ranking and display

### 9. Updated content rendering and docs

Repository analysis markdown output now supports grouped multi-repo rendering for preset-based analysis.

README/help-facing documentation was also updated to cover:

- preset management
- active preset default behavior
- `--all-repos`
- artifact repository terminology

## Why This Change

Before this PR, users had to repeatedly pass repository targets at runtime, even when they were exploring the same set of repositories over and over.

That made the contribution loop more repetitive than it needed to be, especially for users who want a stable exploration lane such as:

- a frontend stack shortlist
- a docs-only contribution lane
- a tooling-focused target set
- a fixed set of repos for scheduled automation

This PR makes repository targeting a first-class saved configuration concept while preserving the existing explicit command overrides.

## User Impact

With this change, users can now:

- define named exploration target sets once
- make one preset active and reuse it automatically
- run `scout`, `agent`, and `analyze` against that preset by default
- temporarily override with a different preset or a single repository
- force global discovery again with `--all-repos`

This reduces repeated CLI input and makes scheduled or repeated open-source exploration much smoother.

## Validation

Fresh verification run before publishing:

- `bunx tsc --noEmit`
- `bun test test/agent-run.test.ts test/scout-targeting.test.ts test/content.test.ts test/config-orchestrator.test.ts test/doctor.test.ts test/init-orchestrator.test.ts test/preset-orchestrator.test.ts test/preset-command.test.ts test/targeting-commands.test.ts test/state-services.test.ts test/agent-orchestrator.test.ts test/scheduler.test.ts test/issue-ranking.test.ts`

Result:

- Typecheck passed
- Test suite segment passed with `92 pass / 0 fail`

## Notes

This is intentionally a v1 preset system focused on fixed named repository sets.

It does not add:

- dynamic query presets
- tag-based preset selection
- parallel patch generation for every analyzed repository in a preset

Those could be layered on later if we want to expand the exploration model.
