### PR TITLE
[codex] add machine interface and universal skill bundles

### DIFF
--- a/docs/superpowers/plans/2026-06-08-openmeta-machine-interface-and-skill-bundle.md
+++ b/docs/superpowers/plans/2026-06-08-openmeta-machine-interface-and-skill-bundle.md
@@ -1,0 +1,864 @@
+# OpenMeta Machine Interface And Skill Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a stable `openmeta machine` automation surface and a package-shipped skill bundle system that lets Claude Code and OpenClaw drive OpenMeta through structured JSON instead of scraping human UI.
+
+**Architecture:** Keep existing human commands intact and introduce a thin machine runtime plus machine-specific orchestrators that call shared result-building methods extracted from existing orchestrators. Add a separate skill bundle pipeline that renders host bundles from one canonical OpenMeta skill definition, then verify the published package includes both runtime and skill assets.
+
+**Tech Stack:** Bun, Commander, TypeScript, existing OpenMeta orchestrators/services, JSON serialization, local filesystem packaging.
+
+---
+
+### Task 1: Machine Type Contracts And Runtime
+
+**Files:**
+- Create: `src/orchestration/machine/types.ts`
+- Create: `src/orchestration/machine/errors.ts`
+- Create: `src/orchestration/machine/runtime.ts`
+- Create: `src/orchestration/machine/index.ts`
+- Modify: `src/orchestration/index.ts`
+- Test: `test/machine-runtime.test.ts`
+
+- [ ] **Step 1: Write the failing runtime contract tests**
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import { buildMachineEnvelope, buildMachineErrorEnvelope, mapMachineError } from '../src/orchestration/machine/index.js';
+
+describe('machine runtime', () => {
+  test('builds a success envelope with command, version, timestamp, and data', () => {
+    const envelope = buildMachineEnvelope('machine doctor', { ready: true });
+
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe('machine doctor');
+    expect(envelope.timestamp).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(envelope.data).toEqual({ ready: true });
+  });
+
+  test('maps invalid argument failures to exit code 2 and INVALID_ARGUMENT', () => {
+    const mapped = mapMachineError('machine config set', new Error('llm.stream must be a boolean value.'));
+
+    expect(mapped.exitCode).toBe(2);
+    expect(mapped.payload.error.code).toBe('INVALID_ARGUMENT');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/machine-runtime.test.ts`
+Expected: FAIL because `src/orchestration/machine/index.ts` does not exist yet
+
+- [ ] **Step 3: Write minimal machine runtime implementation**
+
+```ts
+// src/orchestration/machine/types.ts
+export type MachineErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'CONFIG_MISSING'
+  | 'CONFIG_INVALID'
+  | 'GITHUB_AUTH_FAILED'
+  | 'LLM_AUTH_FAILED'
+  | 'REPO_PREP_FAILED'
+  | 'VALIDATION_FAILED'
+  | 'DIRTY_WORKSPACE'
+  | 'PR_CREATION_SKIPPED'
+  | 'PR_CREATION_FAILED'
+  | 'SKILL_HOST_UNSUPPORTED'
+  | 'SKILL_INSTALL_FAILED'
+  | 'INTERNAL_ERROR';
+
+export interface MachineEnvelope<T> {
+  version: 1;
+  command: string;
+  timestamp: string;
+  data: T;
+}
+
+export interface MachineErrorEnvelope {
+  version: 1;
+  command: string;
+  timestamp: string;
+  error: {
+    code: MachineErrorCode;
+    message: string;
+    details?: unknown;
+  };
+}
+```
+
+```ts
+// src/orchestration/machine/runtime.ts
+import { getErrorMessage } from '../../infra/index.js';
+import type { MachineEnvelope, MachineErrorCode, MachineErrorEnvelope } from './types.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export function buildMachineEnvelope<T>(command: string, data: T): MachineEnvelope<T> {
+  return {
+    version: 1,
+    command,
+    timestamp: now(),
+    data,
+  };
+}
+
+export function buildMachineErrorEnvelope(
+  command: string,
+  code: MachineErrorCode,
+  message: string,
+  details?: unknown,
+): MachineErrorEnvelope {
+  return {
+    version: 1,
+    command,
+    timestamp: now(),
+    error: {
+      code,
+      message,
+      ...(details === undefined ? {} : { details }),
+    },
+  };
+}
+
+export function mapMachineError(command: string, error: unknown): { exitCode: number; payload: MachineErrorEnvelope } {
+  const message = getErrorMessage(error);
+
+  if (/must be|is required|does not exist|unknown configuration key|requires --repo|not found/i.test(message)) {
+    return {
+      exitCode: 2,
+      payload: buildMachineErrorEnvelope(command, 'INVALID_ARGUMENT', message),
+    };
+  }
+
+  if (/configuration is incomplete|run "openmeta init"|missing github|missing llm/i.test(message)) {
+    return {
+      exitCode: 3,
+      payload: buildMachineErrorEnvelope(command, 'CONFIG_MISSING', message),
+    };
+  }
+
+  if (/validation failed|access failed|connection failed/i.test(message)) {
+    return {
+      exitCode: 4,
+      payload: buildMachineErrorEnvelope(command, 'VALIDATION_FAILED', message),
+    };
+  }
+
+  return {
+    exitCode: 5,
+    payload: buildMachineErrorEnvelope(command, 'INTERNAL_ERROR', message),
+  };
+}
+```
+
+```ts
+// src/orchestration/machine/index.ts
+export * from './types.js';
+export * from './runtime.js';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test test/machine-runtime.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/machine-runtime.test.ts src/orchestration/machine/types.ts src/orchestration/machine/errors.ts src/orchestration/machine/runtime.ts src/orchestration/machine/index.ts src/orchestration/index.ts
+git commit -m "feat: add machine runtime primitives"
+```
+
+### Task 2: Shared Config Snapshot And Provider Result Builders
+
+**Files:**
+- Modify: `src/orchestration/config.ts`
+- Modify: `src/orchestration/provider.ts`
+- Modify: `src/infra/index.ts`
+- Test: `test/config-orchestrator.test.ts`
+- Test: `test/provider-orchestrator.test.ts`
+
+- [ ] **Step 1: Write failing tests for machine-safe config and provider results**
+
+```ts
+test('returns a masked machine config snapshot', async () => {
+  const snapshot = await new ConfigOrchestrator().getMachineSnapshot();
+
+  expect(snapshot.github.pat).toBe('***oken');
+  expect(snapshot.llm.apiKey).toBe('***-key');
+  expect(snapshot.llm.modelName).toBeDefined();
+});
+
+test('returns provider result data when switching profiles', async () => {
+  const orchestrator = new ProviderOrchestrator();
+  await orchestrator.add('machine-profile', {
+    provider: 'custom',
+    baseUrl: 'https://example.com/v1',
+    model: 'example-model',
+    apiKey: 'sk-machine-secret',
+  });
+
+  const result = await orchestrator.useProfile('machine-profile');
+
+  expect(result.profileName).toBe('machine-profile');
+  expect(result.activeProfile).toBe('machine-profile');
+  expect(result.apiKey).toBe('***cret');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/config-orchestrator.test.ts test/provider-orchestrator.test.ts`
+Expected: FAIL because `getMachineSnapshot()` and `useProfile()` do not exist yet
+
+- [ ] **Step 3: Implement extracted result builders**
+
+```ts
+// src/orchestration/config.ts
+async getMachineSnapshot(): Promise<{
+  userProfile: AppConfig['userProfile'];
+  github: { username: string; pat: string; targetRepoPath?: string };
+  llm: {
+    provider: AppConfig['llm']['provider'];
+    apiBaseUrl: string;
+    apiKey: string;
+    modelName: string;
+    apiHeaders: Record<string, string>;
+    reasoningEffort?: AppConfig['llm']['reasoningEffort'];
+    stream?: boolean;
+    activeProfile?: string;
+    savedProfiles: string[];
+  };
+  automation: AppConfig['automation'];
+  commitTemplate: string;
+}> {
+  const config = await configService.get();
+  return {
+    userProfile: config.userProfile,
+    github: {
+      username: config.github.username,
+      pat: ui.maskSecret(config.github.pat),
+      targetRepoPath: config.github.targetRepoPath,
+    },
+    llm: {
+      provider: config.llm.provider,
+      apiBaseUrl: config.llm.apiBaseUrl,
+      apiKey: ui.maskSecret(config.llm.apiKey),
+      modelName: config.llm.modelName,
+      apiHeaders: config.llm.apiHeaders ?? {},
+      reasoningEffort: config.llm.reasoningEffort,
+      stream: config.llm.stream,
+      activeProfile: config.llm.activeProfile,
+      savedProfiles: Object.keys(config.llm.profiles ?? {}).sort(),
+    },
+    automation: config.automation,
+    commitTemplate: config.commitTemplate,
+  };
+}
+```
+
+```ts
+// src/orchestration/provider.ts
+async useProfile(nameInput: string, options: ProviderUseOptions = {}): Promise<{
+  profileName: string;
+  activeProfile: string;
+  provider: LLMProvider;
+  modelName: string;
+  apiBaseUrl: string;
+  apiKey: string;
+  apiHeaders: Record<string, string>;
+  reasoningEffort?: LLMReasoningEffort;
+  stream?: boolean;
+  validation: 'skipped' | 'passed' | 'failed';
+  validationMessage: string;
+}> {
+  const name = this.normalizeProfileName(nameInput);
+  const config = await configService.get();
+  const profile = config.llm.profiles?.[name];
+  if (!profile) {
+    throw new Error(`Provider profile "${name}" does not exist. Run "openmeta provider list" to see saved profiles.`);
+  }
+
+  const updated = await configService.update({
+    llm: {
+      ...config.llm,
+      ...profile,
+      apiHeaders: profile.apiHeaders ?? config.llm.apiHeaders ?? {},
+      reasoningEffort: profile.reasoningEffort ?? DEFAULT_LLM_REASONING_EFFORT,
+      stream: profile.stream === true,
+      activeProfile: name,
+      profiles: config.llm.profiles ?? {},
+    },
+  });
+
+  let validation: 'skipped' | 'passed' | 'failed' = 'skipped';
+  let validationMessage = 'Validation skipped.';
+  if (options.validate) {
+    const valid = await this.validateProfile(profile);
+    validation = valid ? 'passed' : 'failed';
+    validationMessage = valid
+      ? 'Provider validation succeeded.'
+      : `Provider validation failed: ${llmService.getLastValidationError() || 'unknown reason'}`;
+  }
+
+  return {
+    profileName: name,
+    activeProfile: updated.llm.activeProfile || '',
+    provider: updated.llm.provider,
+    modelName: updated.llm.modelName,
+    apiBaseUrl: updated.llm.apiBaseUrl,
+    apiKey: ui.maskSecret(updated.llm.apiKey),
+    apiHeaders: updated.llm.apiHeaders ?? {},
+    reasoningEffort: updated.llm.reasoningEffort,
+    stream: updated.llm.stream,
+    validation,
+    validationMessage,
+  };
+}
+```
+
+- [ ] **Step 4: Update existing UI methods to call the extracted helpers**
+
+Run the existing `set()` / `use()` methods through the new helpers so human and machine paths share behavior.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test test/config-orchestrator.test.ts test/provider-orchestrator.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orchestration/config.ts src/orchestration/provider.ts src/infra/index.ts test/config-orchestrator.test.ts test/provider-orchestrator.test.ts
+git commit -m "feat: extract machine-safe config and provider results"
+```
+
+### Task 3: Machine Doctor, Config, Provider, And Runs Commands
+
+**Files:**
+- Create: `src/commands/machine.ts`
+- Create: `src/orchestration/machine/doctor.ts`
+- Create: `src/orchestration/machine/config.ts`
+- Create: `src/orchestration/machine/provider.ts`
+- Create: `src/orchestration/machine/runs.ts`
+- Modify: `src/commands/index.ts`
+- Modify: `src/cli.ts`
+- Test: `test/machine-commands.test.ts`
+
+- [ ] **Step 1: Write failing command tests for the first machine surface**
+
+```ts
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { Command } from 'commander';
+import { registerMachineCommand } from '../src/commands/machine.js';
+import * as infra from '../src/infra/index.js';
+
+function captureWrites() {
+  const writes: string[] = [];
+  const spy = spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  return { writes, spy };
+}
+
+describe('machine commands', () => {
+  afterEach(() => {
+    mock.restore();
+    process.exitCode = 0;
+  });
+
+  test('registers machine doctor and config commands', () => {
+    const program = new Command();
+    registerMachineCommand(program);
+
+    const machine = program.commands.find((command) => command.name() === 'machine');
+    const help = machine?.helpInformation() ?? '';
+
+    expect(help).toContain('doctor');
+    expect(help).toContain('config');
+    expect(help).toContain('provider');
+    expect(help).toContain('runs');
+  });
+
+  test('machine doctor writes only JSON to stdout', async () => {
+    const { writes } = captureWrites();
+    const program = new Command();
+    registerMachineCommand(program);
+    spyOn(infra.configService, 'get').mockResolvedValue({
+      userProfile: { techStack: [], proficiency: 'beginner', focusAreas: [] },
+      github: { pat: '', username: '', targetRepoPath: '' },
+      llm: { provider: 'openai', apiBaseUrl: 'https://api.openai.com/v1', apiKey: '', modelName: 'gpt-4o-mini', apiHeaders: {}, profiles: {}, activeProfile: '' },
+      automation: { enabled: false, scheduleTime: '09:00', timezone: 'UTC', contentType: 'research_note', scheduler: 'manual', minMatchScore: 70, skipIfAlreadyGeneratedToday: true },
+      commitTemplate: 'feat: {{title}}',
+    });
+
+    await program.parseAsync(['node', 'openmeta', 'machine', 'doctor'], { from: 'user' });
+
+    const output = writes.join('');
+    expect(() => JSON.parse(output)).not.toThrow();
+    expect(output).not.toContain('OpenMeta Doctor');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/machine-commands.test.ts`
+Expected: FAIL because `registerMachineCommand` and machine orchestrators do not exist yet
+
+- [ ] **Step 3: Implement the first machine command family**
+
+```ts
+// src/commands/machine.ts
+import { Command } from 'commander';
+import {
+  machineConfigOrchestrator,
+  machineDoctorOrchestrator,
+  machineProviderOrchestrator,
+  machineRunsOrchestrator,
+} from '../orchestration/machine/index.js';
+
+export function registerMachineCommand(program: Command): void {
+  const machine = program.command('machine').description('Stable JSON-first automation surface');
+
+  machine
+    .command('doctor')
+    .description('Inspect local prerequisites and return machine-readable diagnostics')
+    .action(() => machineDoctorOrchestrator.execute());
+
+  const config = machine.command('config').description('Machine-safe configuration access');
+  config.command('get').action(() => machineConfigOrchestrator.get());
+  config.command('set <key> <value>').action((key: string, value: string) => machineConfigOrchestrator.set(key, value));
+
+  const provider = machine.command('provider').description('Machine-safe provider profile management');
+  provider
+    .command('add <name>')
+    .requiredOption('--base-url <url>')
+    .requiredOption('--model <model>')
+    .requiredOption('--api-key <key>')
+    .option('--provider <provider>')
+    .option('--reasoning-effort <effort>')
+    .option('--stream <enabled>')
+    .option('--header <key=value>', '', (value, previous: string[] = []) => [...previous, value], [])
+    .action((name, options) => machineProviderOrchestrator.add(name, options));
+  provider.command('use <name>').action((name: string) => machineProviderOrchestrator.use(name));
+
+  machine
+    .command('runs [id]')
+    .option('--limit <count>', 'Number of runs to show', '10')
+    .action((id: string | undefined, options: { limit?: string }) => machineRunsOrchestrator.show(id, options));
+}
+```
+
+- [ ] **Step 4: Wire the runtime through JSON-only stdout**
+
+Each machine orchestrator should:
+
+```ts
+const payload = buildMachineEnvelope('machine config get', await configOrchestrator.getMachineSnapshot());
+process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+```
+
+and on errors:
+
+```ts
+const mapped = mapMachineError('machine config get', error);
+process.stdout.write(`${JSON.stringify(mapped.payload, null, 2)}\n`);
+process.exitCode = mapped.exitCode;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test test/machine-runtime.test.ts test/machine-commands.test.ts test/config-orchestrator.test.ts test/provider-orchestrator.test.ts test/doctor.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/machine.ts src/commands/index.ts src/cli.ts src/orchestration/machine/doctor.ts src/orchestration/machine/config.ts src/orchestration/machine/provider.ts src/orchestration/machine/runs.ts test/machine-runtime.test.ts test/machine-commands.test.ts test/config-orchestrator.test.ts test/provider-orchestrator.test.ts test/doctor.test.ts
+git commit -m "feat: add machine doctor config provider and runs commands"
+```
+
+### Task 4: Machine Runs, Inbox, And Proof-Of-Work Result Surfaces
+
+**Files:**
+- Modify: `src/orchestration/runs.ts`
+- Modify: `src/orchestration/agent.ts`
+- Create: `src/orchestration/machine/inbox.ts`
+- Create: `src/orchestration/machine/pow.ts`
+- Modify: `src/commands/machine.ts`
+- Test: `test/machine-state-commands.test.ts`
+
+- [ ] **Step 1: Write failing tests for machine runs, inbox, and pow payloads**
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import { AgentOrchestrator } from '../src/orchestration/agent.js';
+import { RunsOrchestrator } from '../src/orchestration/runs.js';
+
+describe('machine state result builders', () => {
+  test('returns run history list data with totals', async () => {
+    const result = await new RunsOrchestrator().listMachine({ limit: 10 });
+    expect(result.records).toBeArray();
+    expect(result.totals).toBeDefined();
+  });
+
+  test('returns inbox items ordered by score', async () => {
+    const result = await new AgentOrchestrator().getInboxMachineResult();
+    expect(result.items).toBeArray();
+  });
+
+  test('returns proof-of-work records with publication metadata', async () => {
+    const result = await new AgentOrchestrator().getProofOfWorkMachineResult();
+    expect(result.records).toBeArray();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/machine-state-commands.test.ts`
+Expected: FAIL because machine result methods do not exist yet
+
+- [ ] **Step 3: Implement extracted result builders**
+
+```ts
+// src/orchestration/runs.ts
+async listMachine(options: RunsListOptions = {}) {
+  const limit = Math.max(1, options.limit ?? 10);
+  const state = runHistoryService.load();
+  const records = state.records.slice(0, limit);
+  const totals = state.records.reduce<Record<AgentRunStatus, number>>((acc, record) => {
+    acc[record.status] += 1;
+    return acc;
+  }, { running: 0, success: 0, failed: 0, cancelled: 0 });
+  return { records, totals, ledgerPath: runHistoryService.getPath() };
+}
+```
+
+```ts
+// src/orchestration/agent.ts
+async getInboxMachineResult() {
+  const items = [...inboxService.load().items].sort((left, right) => right.overallScore - left.overallScore);
+  return {
+    items,
+    inboxPath: inboxService.getPath(),
+    nextActions: items.length === 0 ? ['run_machine_scout'] : ['inspect_artifact_paths'],
+  };
+}
+
+async getProofOfWorkMachineResult() {
+  const records = [...proofOfWorkService.load().records];
+  return {
+    records,
+    proofOfWorkPath: proofOfWorkService.getPath(),
+    nextActions: records.length === 0 ? ['run_machine_agent'] : ['inspect_recent_publications'],
+  };
+}
+```
+
+- [ ] **Step 4: Expose the machine commands**
+
+Add `machine inbox` and `machine pow` commands that wrap the new result builders in `MachineEnvelope`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test test/machine-state-commands.test.ts test/agent-run.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orchestration/runs.ts src/orchestration/agent.ts src/orchestration/machine/inbox.ts src/orchestration/machine/pow.ts src/commands/machine.ts test/machine-state-commands.test.ts test/agent-run.test.ts
+git commit -m "feat: add machine inbox pow and run state surfaces"
+```
+
+### Task 5: Machine Scout, Analyze, And Agent Result Builders
+
+**Files:**
+- Modify: `src/orchestration/agent.ts`
+- Modify: `src/orchestration/analyze.ts`
+- Create: `src/orchestration/machine/scout.ts`
+- Create: `src/orchestration/machine/analyze.ts`
+- Create: `src/orchestration/machine/agent.ts`
+- Modify: `src/commands/machine.ts`
+- Test: `test/machine-agent.test.ts`
+- Test: `test/agent-run.test.ts`
+- Test: `test/analyze-command.test.ts`
+
+- [ ] **Step 1: Write failing machine flow tests**
+
+```ts
+test('machine scout returns ranked opportunities with mode metadata', async () => {
+  const result = await new AgentOrchestrator().scoutMachine({ limit: 5, refresh: true, localOnly: true });
+  expect(result.mode.localOnly).toBe(true);
+  expect(result.opportunities).toBeArray();
+});
+
+test('machine analyze returns selected suggestion and artifact paths', async () => {
+  const result = await new AnalyzeOrchestrator().runMachine({ repo: 'acme/demo', dryRun: true, headless: true });
+  expect(result.repoFullName).toBe('acme/demo');
+  expect(result.artifacts.analysisPath).toContain('analysis');
+});
+
+test('machine agent draft-only flow returns explicit execution flags', async () => {
+  const result = await new AgentOrchestrator().runMachine({ issue: 'https://github.com/acme/demo/issues/42', draftOnly: true, dryRun: true });
+  expect(result.executionOutcome).toBe('draft_only');
+  expect(result.repoMutated).toBe(false);
+  expect(result.prCreated).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/machine-agent.test.ts test/agent-run.test.ts test/analyze-command.test.ts`
+Expected: FAIL because `scoutMachine()`, `runMachine()`, and machine flow wrappers do not exist yet
+
+- [ ] **Step 3: Extract reusable scout result building**
+
+Implement `AgentOrchestrator.scoutMachine(options)` so it reuses `issueRankingService.loadRankedIssues(...)` and returns:
+
+```ts
+{
+  opportunities: RankedIssue[];
+  mode: {
+    limit: number;
+    refresh: boolean;
+    repo?: string;
+    localOnly: boolean;
+  };
+  nextActions: string[];
+}
+```
+
+- [ ] **Step 4: Extract reusable analyze result building**
+
+Implement `AnalyzeOrchestrator.runMachine(options)` so it reuses the same workspace preparation, LLM generation, suggestion selection, and artifact path logic as the human path, but returns a typed result object instead of rendering cards.
+
+- [ ] **Step 5: Extract reusable agent result building**
+
+Implement `AgentOrchestrator.runMachine(options)` by reusing the current run path and returning:
+
+```ts
+{
+  issue: RankedIssue;
+  workspace: RepoWorkspaceContext;
+  artifacts: ContributionAgentResult['artifacts'];
+  changedFiles: string[];
+  validationResults: TestResult[];
+  reviewRequired: boolean;
+  published: boolean;
+  prCreated: boolean;
+  repoMutated: boolean;
+  executionOutcome: 'draft_only' | 'local_artifacts_written' | 'changes_applied' | 'pr_opened' | 'blocked';
+  executionPolicy: {
+    headless: boolean;
+    draftOnly: boolean;
+    runChecks: boolean;
+    dryRun: boolean;
+    refresh: boolean;
+  };
+  skipReasons: string[];
+  nextActions: string[];
+}
+```
+
+- [ ] **Step 6: Register the machine flow commands**
+
+Add `machine scout`, `machine analyze`, and `machine agent` to `src/commands/machine.ts` and serialize their results through `MachineEnvelope`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `bun test test/machine-agent.test.ts test/agent-run.test.ts test/analyze-command.test.ts`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/orchestration/agent.ts src/orchestration/analyze.ts src/orchestration/machine/scout.ts src/orchestration/machine/analyze.ts src/orchestration/machine/agent.ts src/commands/machine.ts test/machine-agent.test.ts test/agent-run.test.ts test/analyze-command.test.ts
+git commit -m "feat: add machine scout analyze and agent flows"
+```
+
+### Task 6: Skill Bundle Assets, Export, Install, And Doctor
+
+**Files:**
+- Create: `skills/core/openmeta.md`
+- Create: `skills/schema/capability-catalog.json`
+- Create: `skills/templates/claude-code/`
+- Create: `skills/templates/openclaw/`
+- Create: `skills/examples/`
+- Create: `src/commands/skill.ts`
+- Create: `src/orchestration/skill/index.ts`
+- Create: `src/orchestration/skill/catalog.ts`
+- Create: `src/orchestration/skill/renderer.ts`
+- Create: `src/orchestration/skill/installer.ts`
+- Create: `src/orchestration/skill/doctor.ts`
+- Modify: `src/commands/index.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/orchestration/index.ts`
+- Test: `test/skill-bundle.test.ts`
+
+- [ ] **Step 1: Write failing skill bundle tests**
+
+```ts
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { renderSkillBundle, getSupportedSkillHosts } from '../src/orchestration/skill/index.js';
+
+let tempRoot = '';
+
+describe('skill bundle rendering', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'openmeta-skill-bundle-'));
+  });
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = '';
+    }
+  });
+
+  test('renders claude-code and openclaw bundles from one canonical spec', async () => {
+    expect(getSupportedSkillHosts()).toEqual(['claude-code', 'openclaw']);
+
+    const claude = await renderSkillBundle('claude-code', tempRoot);
+    const openclaw = await renderSkillBundle('openclaw', tempRoot);
+
+    expect(readFileSync(claude.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
+    expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test test/skill-bundle.test.ts`
+Expected: FAIL because `src/orchestration/skill/index.ts` and `skills/**` do not exist yet
+
+- [ ] **Step 3: Add the canonical skill asset tree**
+
+Create:
+
+```text
+skills/core/openmeta.md
+skills/schema/capability-catalog.json
+skills/templates/claude-code/skill.md
+skills/templates/openclaw/skill.md
+skills/examples/claude-code.md
+skills/examples/openclaw.md
+```
+
+The canonical skill must instruct agents to use:
+
+```text
+openmeta machine doctor
+openmeta machine config set
+openmeta machine provider add
+openmeta machine provider use
+openmeta machine scout
+openmeta machine analyze
+openmeta machine agent
+```
+
+- [ ] **Step 4: Implement skill rendering and install/doctor logic**
+
+Implement:
+
+```ts
+export function getSupportedSkillHosts(): Array<'claude-code' | 'openclaw'> {
+  return ['claude-code', 'openclaw'];
+}
+```
+
+```ts
+export async function renderSkillBundle(host: 'claude-code' | 'openclaw', outputDir: string): Promise<{ host: string; files: string[] }> {
+  // read canonical skill + capability catalog + host template
+  // write rendered files into outputDir/host
+}
+```
+
+Implement `skill list`, `skill export`, `skill install`, and `skill doctor` on top of these functions.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test test/skill-bundle.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills src/commands/skill.ts src/orchestration/skill src/commands/index.ts src/cli.ts src/orchestration/index.ts test/skill-bundle.test.ts
+git commit -m "feat: add host-generated skill bundle commands"
+```
+
+### Task 7: Package Publishing Surface And Final Verification
+
+**Files:**
+- Modify: `package.json`
+- Test: `test/skill-bundle.test.ts`
+
+- [ ] **Step 1: Write a failing package file assertion test**
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import packageJson from '../package.json';
+
+describe('package files', () => {
+  test('publishes skill assets with the CLI binary', () => {
+    expect(packageJson.files).toContain('bin/openmeta.js');
+    expect(packageJson.files).toContain('skills');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test test/skill-bundle.test.ts`
+Expected: FAIL because `package.json` does not yet include `skills`
+
+- [ ] **Step 3: Update package publishing files**
+
+```json
+{
+  "files": [
+    "bin/openmeta.js",
+    "README.md",
+    "package.json",
+    "skills"
+  ]
+}
+```
+
+- [ ] **Step 4: Run targeted verification**
+
+Run: `bun test test/machine-runtime.test.ts test/machine-commands.test.ts test/machine-state-commands.test.ts test/machine-agent.test.ts test/skill-bundle.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full verification**
+
+Run: `bun test`
+Expected: PASS
+
+Run: `bun run typecheck`
+Expected: PASS
+
+Run: `bun run build`
+Expected: PASS
+
+Run: `npm pack --dry-run --json`
+Expected: PASS and output includes `bin/openmeta.js` plus the `skills/` asset tree
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json test/skill-bundle.test.ts
+git commit -m "chore: publish machine and skill bundle assets"
+```

--- a/docs/superpowers/specs/2026-06-08-openmeta-machine-interface-and-skill-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-08-openmeta-machine-interface-and-skill-bundle-design.md
@@ -1,0 +1,492 @@
+# OpenMeta Machine Interface And Universal Skill Bundle Design
+
+## Goal
+
+Make OpenMeta usable as a real execution substrate for external coding agents by adding:
+
+1. a stable JSON-first `openmeta machine ...` command surface
+2. a package-included, host-agnostic skill bundle system
+3. generated host bundles for Claude Code and OpenClaw
+4. packaging and verification that prove the machine surface and skill assets ship together
+
+The product goal for v1 is not "some JSON flags exist." The goal is that an agent can install `openmeta-cli`, bootstrap configuration through machine commands, inspect structured results without scraping prose, and drive real OpenMeta workflows from discovery through draft or execution.
+
+## Non-Goals
+
+- Do not turn the existing human-first commands into the stable automation API.
+- Do not add `openmeta machine init` in v1.
+- Do not embed host-specific business logic into core contribution services.
+- Do not require MCP for first-class agent integration.
+- Do not rewrite the whole orchestration layer around a new application framework.
+
+## Chosen Approach
+
+Use a thin machine layer plus an independent skill bundle system.
+
+- Existing human commands stay human-first and keep their current UI behavior.
+- New `machine` commands become the only stability-promised automation surface.
+- Machine commands call result-building methods that reuse existing orchestration and service logic, then serialize through a shared JSON runtime.
+- Skill bundles are generated from one canonical OpenMeta skill spec plus a capability catalog, with thin host renderers for Claude Code and OpenClaw.
+
+This approach is preferred over:
+
+- retrofitting current human commands with ad hoc `--json` flags, which would leak unstable UI-era semantics into the external API
+- large orchestrator rewrites, which would increase risk across already-working flows
+
+## Command Surface
+
+### Machine Commands
+
+Add:
+
+```bash
+openmeta machine doctor
+openmeta machine config get
+openmeta machine config set <key> <value>
+openmeta machine provider add <name> --base-url <url> --model <model> --api-key <key>
+openmeta machine provider use <name>
+openmeta machine scout [--limit <count>] [--refresh] [--repo <repository>] [--local]
+openmeta machine analyze --repo <repository> [--headless] [--run-checks] [--dry-run]
+openmeta machine agent [--headless] [--run-checks] [--draft-only] [--refresh] [--repo <repository>] [--issue <issue>] [--dry-run]
+openmeta machine runs [id]
+openmeta machine inbox
+openmeta machine pow
+```
+
+### Skill Commands
+
+Add:
+
+```bash
+openmeta skill list
+openmeta skill export --host <claude-code|openclaw> --output <dir>
+openmeta skill install --host <claude-code|openclaw>
+openmeta skill doctor --host <claude-code|openclaw>
+```
+
+Behavior:
+
+- `skill list` shows supported hosts, whether a local install target can be discovered, and the canonical asset source path in the package
+- `skill export` writes generated host files into the requested directory and reports the created paths
+- `skill install` writes into a discovered host path when that path can be resolved safely; otherwise it returns explicit manual placement instructions plus an exported bundle path
+- `skill doctor` verifies that the generated host bundle exists, points to `openmeta machine` commands, and that the `openmeta` binary is available on PATH
+
+## Machine Runtime Contract
+
+Every successful machine command writes JSON only to stdout:
+
+```ts
+type MachineEnvelope<T> = {
+  version: 1;
+  command: string;
+  timestamp: string;
+  data: T;
+};
+```
+
+Every failed machine command writes JSON only to stdout and uses stderr only for optional human diagnostics:
+
+```ts
+type MachineErrorEnvelope = {
+  version: 1;
+  command: string;
+  timestamp: string;
+  error: {
+    code: MachineErrorCode;
+    message: string;
+    details?: unknown;
+  };
+};
+```
+
+### Exit Codes
+
+- `0`: success
+- `2`: invalid input or schema error
+- `3`: missing prerequisites or incomplete configuration
+- `4`: external dependency failure
+- `5`: execution failure after work started
+
+### Machine Error Codes
+
+At minimum:
+
+- `INVALID_ARGUMENT`
+- `CONFIG_MISSING`
+- `CONFIG_INVALID`
+- `GITHUB_AUTH_FAILED`
+- `LLM_AUTH_FAILED`
+- `REPO_PREP_FAILED`
+- `VALIDATION_FAILED`
+- `DIRTY_WORKSPACE`
+- `PR_CREATION_SKIPPED`
+- `PR_CREATION_FAILED`
+- `SKILL_HOST_UNSUPPORTED`
+- `SKILL_INSTALL_FAILED`
+- `INTERNAL_ERROR`
+
+## Machine Payload Families
+
+Add versioned outward-facing machine types that are separate from current LLM contracts:
+
+- `MachineDoctorReport`
+- `MachineConfigSnapshot`
+- `MachineProviderResult`
+- `MachineScoutResult`
+- `MachineAnalyzeResult`
+- `MachineAgentResult`
+- `MachineRunsResult`
+- `MachineRunRecordResult`
+- `MachineInboxResult`
+- `MachineProofOfWorkResult`
+
+These types should wrap current domain data in stable external names rather than exposing raw internal types unchanged.
+
+### Shared Payload Rules
+
+Where relevant, payloads must include:
+
+- stable identifiers
+- normalized repository and issue references
+- artifact paths
+- workspace paths
+- validation commands and results
+- changed files
+- PR URLs and numbers
+- `reviewRequired`
+- `published`
+- `nextActions: string[]`
+
+### `machine doctor`
+
+Return the existing doctor report plus:
+
+- `ready`
+- `configPath`
+- `homePath`
+- `nextActions`
+
+### `machine config get`
+
+Return a masked configuration snapshot:
+
+- GitHub username and masked token
+- LLM provider, base URL, model, masked API key, headers summary, active profile
+- automation settings
+- user profile
+
+### `machine config set`
+
+Return:
+
+- `updatedKey`
+- `appliedValue`
+- updated masked snapshot
+- scheduler sync summary where applicable
+
+### `machine provider add` and `machine provider use`
+
+Return:
+
+- profile name
+- active profile
+- provider
+- model
+- base URL
+- masked API key
+- headers summary
+- validation status if requested later
+
+### `machine scout`
+
+Return a stable ranked opportunity list:
+
+- `opportunities[]`
+- per-item repo, issue number, issue URL, score, summary, breakdown
+- invocation mode metadata such as `refresh`, `repo`, and `localOnly`
+
+### `machine analyze`
+
+Return:
+
+- repository identity
+- selected suggestion
+- suggestion list summary
+- patch draft
+- PR draft
+- workspace summary
+- artifact paths
+- mode metadata: `headless`, `runChecks`, `dryRun`
+
+### `machine agent`
+
+Return one payload shape for both dry and write flows, with explicit outcome fields:
+
+- `executionOutcome`: `draft_only | local_artifacts_written | changes_applied | pr_opened | blocked`
+- `artifactsWritten: boolean`
+- `repoMutated: boolean`
+- `prCreated: boolean`
+- `reviewRequired: boolean`
+- `published: boolean`
+- `executionPolicy`
+- `skipReasons[]`
+
+The payload must still include the selected issue, patch draft summary, validation results, changed files, artifact paths, and PR metadata when present.
+
+### `machine runs`
+
+Return either:
+
+- a list envelope with run records and totals
+- or a single run record envelope when `id` is provided
+
+### `machine inbox` and `machine pow`
+
+Return stable list payloads with the current stored items and their key identifiers and artifact paths.
+
+## Architecture
+
+### Command Layer
+
+Add thin command registration files:
+
+- `src/commands/machine.ts`
+- `src/commands/skill.ts`
+
+Update:
+
+- `src/commands/index.ts`
+- `src/cli.ts`
+
+These files should only define flags and dispatch into orchestrators.
+
+### Machine Orchestration Layer
+
+Add:
+
+```text
+src/orchestration/machine/
+  index.ts
+  runtime.ts
+  errors.ts
+  types.ts
+  doctor.ts
+  config.ts
+  provider.ts
+  scout.ts
+  analyze.ts
+  agent.ts
+  runs.ts
+  inbox.ts
+  pow.ts
+```
+
+Responsibilities:
+
+- convert thrown errors into machine envelopes and exit codes
+- guarantee JSON-only stdout
+- call shared result-building methods
+- never render through `ui.*`
+
+### Shared Result Building
+
+Refactor by extraction, not rewrite.
+
+Keep current human orchestrators as the UX layer, but extract machine-safe result methods from:
+
+- `DoctorOrchestrator.inspect()`
+- `ConfigOrchestrator`
+- `ProviderOrchestrator`
+- `AgentOrchestrator`
+- `AnalyzeOrchestrator`
+- `RunsOrchestrator`
+
+Target shape:
+
+- human methods keep calling domain services and rendering through `ui.*`
+- machine methods call the same domain paths but return typed result objects
+
+Priority extraction targets:
+
+1. `doctor`: already close to reusable
+2. `runs`: current JSON path can be normalized into machine envelopes
+3. `config` and `provider`: need non-UI result-returning methods
+4. `analyze` and `agent`: need the most work because result building and UI are currently interleaved
+5. `inbox` and `pow`: likely thin wrappers around current stored state
+
+### Skill Bundle Layer
+
+Add:
+
+```text
+src/orchestration/skill/
+  index.ts
+  catalog.ts
+  renderer.ts
+  installer.ts
+  doctor.ts
+```
+
+Responsibilities:
+
+- load the canonical OpenMeta skill definition
+- render host-specific bundles
+- export bundles into arbitrary directories
+- install bundles into discovered host paths when safe
+- diagnose missing bundles, missing binary access, and unsupported hosts
+
+## Skill Bundle Assets
+
+Ship a new package asset tree:
+
+```text
+skills/
+  core/
+  schema/
+  templates/
+    claude-code/
+    openclaw/
+  examples/
+```
+
+The CLI runtime must resolve these assets from the installed package location rather than from the repository root, so generated bundle commands continue to work after `npm i -g openmeta-cli`.
+
+### Canonical Skill Content
+
+Maintain one host-agnostic OpenMeta skill spec that teaches agents to:
+
+1. run `openmeta machine doctor` first
+2. use `openmeta machine config set` and `openmeta machine provider add/use` to resolve bootstrap gaps
+3. use `openmeta machine scout` for issue discovery
+4. use `openmeta machine analyze` when repository-first analysis is needed
+5. use `openmeta machine agent` only when the user explicitly asks for execution
+6. parse JSON payloads rather than prose
+7. surface artifact paths, validation failures, and PR links back to the user
+
+### Capability Catalog
+
+Define a small machine-readable catalog that lists:
+
+- supported commands
+- required arguments
+- outcome expectations
+- dangerous execution notes for `machine agent`
+
+### Host Adapters
+
+Host-specific templates may vary in:
+
+- file names
+- metadata wrappers
+- command invocation examples
+- installation target paths
+
+They must not vary in:
+
+- workflow logic
+- domain behavior
+- contribution strategy
+
+## Packaging
+
+Update `package.json` `files` so published tarballs include:
+
+- `bin/openmeta.js`
+- `README.md`
+- `package.json`
+- `skills/**`
+
+If runtime-loaded schemas or templates live outside the bundled binary, include any required runtime assets as published package files too.
+
+## File and Type Changes
+
+Expected touched areas:
+
+- `src/cli.ts`
+- `src/commands/index.ts`
+- `src/commands/machine.ts`
+- `src/commands/skill.ts`
+- `src/orchestration/index.ts`
+- `src/orchestration/machine/**`
+- `src/orchestration/skill/**`
+- existing orchestrators for extracted result methods
+- `src/types/**` for machine-facing types
+- `package.json`
+
+The current `src/contracts/agent-contracts.ts` remains the LLM boundary. Machine payloads are a separate external API and should not be mixed into the LLM contract file.
+
+## Testing
+
+### Machine Command Tests
+
+Add focused tests for:
+
+- `machine doctor` success and missing-config failure
+- `machine config get`
+- `machine config set`
+- `machine provider add`
+- `machine provider use`
+- `machine scout`
+- `machine analyze --repo owner/name`
+- `machine agent --draft-only`
+- `machine runs`
+- `machine inbox`
+- `machine pow`
+
+### Failure-Path Tests
+
+Cover:
+
+- invalid repo or issue input
+- missing GitHub config
+- missing LLM config
+- GitHub credential failure
+- LLM validation failure
+- repository preparation failure
+- dirty workspace restrictions
+- blocked PR creation due to validation or review-required state
+- unsupported skill host
+
+### Skill Bundle Tests
+
+Add tests that verify:
+
+- one canonical skill spec renders both Claude Code and OpenClaw bundles
+- generated host bundles reference `openmeta machine` commands only
+- installer and doctor behavior are correct when host paths are present, absent, or unsupported
+
+### Packaging Verification
+
+Before completion, verify:
+
+```bash
+npm pack --dry-run --json
+```
+
+and assert the package includes:
+
+- the CLI binary
+- skill assets
+- any required templates, schemas, and examples
+
+### Standard Verification
+
+Before implementation completion:
+
+```bash
+bun test
+bun run typecheck
+bun run build
+```
+
+## Rollout Notes
+
+Implementation should be staged in this order:
+
+1. machine runtime, types, and doctor/config/provider/runs surfaces
+2. scout/analyze/agent result extraction and machine commands
+3. inbox/pow surfaces
+4. skill rendering, export, install, and doctor
+5. packaging verification and end-to-end tests
+
+This order gets a working machine contract online early while keeping the full v1 goal intact.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "files": [
     "bin/openmeta.js",
     "README.md",
-    "package.json"
+    "package.json",
+    "skills"
   ],
   "publishConfig": {
     "access": "public"

--- a/skills/core/openmeta.md
+++ b/skills/core/openmeta.md
@@ -1,0 +1,14 @@
+# OpenMeta Machine Skill
+
+Use OpenMeta through machine-readable commands rather than scraping human CLI output.
+
+## Required Workflow
+
+1. Run `openmeta machine doctor` first.
+2. If doctor reports missing configuration, use `openmeta machine config set` to update config values.
+3. Use `openmeta machine provider add` and `openmeta machine provider use` to save and activate LLM backends.
+4. Use `openmeta machine scout` for issue discovery.
+5. Use `openmeta machine analyze` for repository-first contribution analysis.
+6. Use `openmeta machine agent` only when the user explicitly asks for execution.
+7. Parse JSON payloads instead of prose.
+8. Surface artifact paths, validation failures, and PR links back to the user.

--- a/skills/core/openmeta.md
+++ b/skills/core/openmeta.md
@@ -2,13 +2,315 @@
 
 Use OpenMeta through machine-readable commands rather than scraping human CLI output.
 
-## Required Workflow
+## Purpose
 
-1. Run `openmeta machine doctor` first.
-2. If doctor reports missing configuration, use `openmeta machine config set` to update config values.
-3. Use `openmeta machine provider add` and `openmeta machine provider use` to save and activate LLM backends.
-4. Use `openmeta machine scout` for issue discovery.
-5. Use `openmeta machine analyze` for repository-first contribution analysis.
-6. Use `openmeta machine agent` only when the user explicitly asks for execution.
-7. Parse JSON payloads instead of prose.
-8. Surface artifact paths, validation failures, and PR links back to the user.
+This skill lets an external agent treat OpenMeta as a stable execution substrate.
+
+- Prefer `openmeta machine ...` over human-first commands.
+- Read JSON envelopes from stdout.
+- Treat stderr as optional diagnostics only.
+- Escalate to `openmeta machine agent` only when the user explicitly asks for execution.
+
+## Installation Expectations
+
+- Install the OpenMeta CLI and ensure `openmeta` is on `PATH`.
+- Install this skill bundle with `openmeta skill install --host <host>` when automatic host placement is supported.
+- Validate host wiring with `openmeta skill doctor --host <host>`.
+- If automatic install is unavailable, export with `openmeta skill export --host <host> --output <dir>` and place the generated `skill.md` into the host's skill directory manually.
+
+## Host Paths
+
+- Claude Code default install path: `~/.claude/skills/openmeta`
+- OpenClaw default install path: `~/.openclaw/skills/openmeta`
+
+## Non-Negotiable Rules
+
+1. Start with `openmeta machine doctor`.
+2. Never scrape prose from human-first OpenMeta commands.
+3. Parse JSON from stdout only.
+4. Assume secrets are masked in returned snapshots.
+5. Do not run `openmeta machine agent` unless the user explicitly wants OpenMeta to execute work.
+6. When `reviewRequired` is true, do not claim the task is complete.
+7. When `executionOutcome` is `blocked`, surface `skipReasons`, `validationResults`, and `nextActions`.
+8. Treat `dry-run` and `draft-only` as planning or preview modes, not completion modes.
+
+## Recommended Workflow
+
+1. Run `openmeta machine doctor`.
+2. If `ready` is false, use `openmeta machine config set` and `openmeta machine provider add/use` until doctor is healthy.
+3. Run `openmeta machine scout` to discover ranked contribution opportunities.
+4. Run `openmeta machine analyze --repo <repository>` when the user wants repository-first analysis before choosing an issue.
+5. Run `openmeta machine agent` only for explicit execution requests.
+6. Use `openmeta machine runs`, `openmeta machine inbox`, and `openmeta machine pow` to inspect persisted state and prior outcomes.
+
+## Bootstrap Commands
+
+### Health and Configuration
+
+- `openmeta machine doctor`
+- `openmeta machine config get`
+- `openmeta machine config set <key> <value>`
+- `openmeta machine provider add <name> --base-url <url> --model <model> --api-key <key> [--provider <provider>] [--reasoning-effort <effort>] [--stream <true|false>] [--header key=value]`
+- `openmeta machine provider use <name>`
+
+### Discovery and Execution
+
+- `openmeta machine scout [--limit <count>] [--refresh] [--repo <owner/name>] [--local]`
+- `openmeta machine analyze --repo <owner/name|url> [--headless] [--run-checks] [--dry-run]`
+- `openmeta machine agent [--headless] [--run-checks] [--draft-only] [--refresh] [--repo <owner/name>] [--issue <number|url>] [--dry-run]`
+
+### State Inspection
+
+- `openmeta machine runs [id] [--limit <count>]`
+- `openmeta machine inbox`
+- `openmeta machine pow`
+
+## Config Keys For `machine config set`
+
+Accepted keys:
+
+- `userProfile.techStack` with comma-separated values
+- `userProfile.proficiency` with `beginner`, `intermediate`, or `advanced`
+- `userProfile.focusAreas` with comma-separated values
+- `github.username`
+- `github.pat`
+- `github.targetRepoPath`
+- `llm.provider`
+- `llm.apiBaseUrl`
+- `llm.apiKey`
+- `llm.modelName`
+- `llm.reasoningEffort`
+- `llm.stream`
+- `automation.enabled`
+- `automation.scheduleTime`
+- `automation.contentType`
+- `automation.minMatchScore`
+- `automation.skipIfAlreadyGeneratedToday`
+- `commitTemplate`
+
+Important value formats:
+
+- Boolean fields accept `true|false`, `yes|no`, `1|0`, or `on|off`.
+- `automation.scheduleTime` must use `HH:mm`.
+- `automation.contentType` must be `research_note` or `development_diary`.
+- `automation.minMatchScore` must be an integer from `0` to `100`.
+- `llm.reasoningEffort` must match the installed OpenMeta reasoning effort enum.
+
+## Result Interpretation
+
+### Standard Envelope
+
+Successful machine commands write:
+
+```json
+{
+  "version": 1,
+  "command": "machine scout",
+  "timestamp": "2026-06-08T12:34:56.000Z",
+  "data": {}
+}
+```
+
+Failed machine commands write:
+
+```json
+{
+  "version": 1,
+  "command": "machine scout",
+  "timestamp": "2026-06-08T12:34:56.000Z",
+  "error": {
+    "code": "CONFIG_MISSING",
+    "message": "..."
+  }
+}
+```
+
+### High-Value Fields
+
+- `nextActions`: follow-up actions the host agent should surface or perform
+- `reviewRequired`: generated output needs human review before claiming success
+- `validationResults`: baseline or repair check outcomes
+- `artifactPaths` or command-specific artifact fields: local files produced by OpenMeta
+- `pullRequestUrl` and PR metadata: downstream publication state
+- `executionOutcome`: canonical outcome for `machine agent`
+
+### `machine agent` Outcomes
+
+- `draft_only`: drafts were generated but repository files were not changed
+- `local_artifacts_written`: local artifact files were written without mutating the target repo
+- `changes_applied`: repository files changed locally but no PR was opened
+- `pr_opened`: repository changes were applied and a draft PR was opened
+- `blocked`: OpenMeta could not safely continue
+
+Execution guidance:
+
+- `repoMutated: true` means the repository working tree changed.
+- `prCreated: true` means a real PR exists and should be surfaced back to the user.
+- `published: true` means artifact publication succeeded.
+- `artifactsWritten: true` means dossier, drafts, inbox, or proof-of-work files were updated.
+
+## Command-Specific Guidance
+
+### `machine doctor`
+
+Use this to decide whether the host can proceed.
+
+Look for:
+
+- `ready`
+- `configPath`
+- `homePath`
+- `nextActions`
+
+If `ready` is false, stop and remediate before scout, analyze, or agent.
+
+### `machine config get`
+
+Use this when you need a masked snapshot of current machine state.
+
+Look for:
+
+- saved provider profiles
+- active provider profile
+- automation policy
+- masked GitHub and LLM secrets
+
+### `machine provider add` and `machine provider use`
+
+Use these to manage named LLM backends.
+
+Look for:
+
+- `profileName`
+- `activeProfile`
+- `provider`
+- `modelName`
+- `apiBaseUrl`
+- `validation`
+- `validationMessage`
+
+### `machine scout`
+
+Use this for opportunity discovery across repositories or inside one repository.
+
+Look for:
+
+- `opportunities`
+- per-item `repoFullName`, `issueNumber`, `issueUrl`, `overallScore`, and scoring breakdown
+- mode flags such as `refresh`, `repo`, and `localOnly`
+
+Use `--local` when the host wants heuristic ranking without LLM calls.
+
+### `machine analyze`
+
+Use this when the user wants repository-first planning before selecting a concrete issue.
+
+Look for:
+
+- `repoFullName`
+- `selectedSuggestion`
+- `suggestions`
+- `patchDraft`
+- `prDraft`
+- `workspace`
+- analysis artifact paths
+- mode flags `headless`, `runChecks`, `dryRun`
+
+### `machine agent`
+
+Use this only for explicit execution requests.
+
+Look for:
+
+- selected issue identity
+- `executionOutcome`
+- `reviewRequired`
+- `changedFiles`
+- `validationResults`
+- `pullRequestUrl`
+- artifact paths
+- `skipReasons`
+
+Safety rules:
+
+- Prefer `--dry-run` when the user wants a preview.
+- Prefer `--draft-only` when the user wants artifacts without repository mutation.
+- Use `--headless` only when unattended execution is explicitly desired.
+
+### `machine runs`
+
+Use this to inspect prior runs or a specific run record.
+
+Look for:
+
+- run identifiers
+- command names
+- started and finished timestamps
+- exit codes
+- ledger path
+
+### `machine inbox`
+
+Use this to inspect saved opportunity backlog.
+
+Look for:
+
+- sorted opportunity items
+- score ordering
+- inbox storage path
+
+### `machine pow`
+
+Use this to inspect proof-of-work records and publication history.
+
+Look for:
+
+- proof records
+- `published`
+- artifact paths
+- PR links
+
+## Error Handling
+
+Treat these machine error codes as stable:
+
+- `INVALID_ARGUMENT`: command syntax or option value is wrong
+- `CONFIG_MISSING`: required config is absent
+- `CONFIG_INVALID`: config exists but fails validation rules
+- `GITHUB_AUTH_FAILED`: GitHub credentials failed verification
+- `LLM_AUTH_FAILED`: LLM provider credentials failed verification
+- `REPO_PREP_FAILED`: target repository or workspace preparation failed
+- `VALIDATION_FAILED`: execution checks failed
+- `DIRTY_WORKSPACE`: workspace was not safe to mutate
+- `PR_CREATION_SKIPPED`: PR creation was intentionally skipped
+- `PR_CREATION_FAILED`: PR creation was attempted but failed
+- `SKILL_HOST_UNSUPPORTED`: requested host is not supported
+- `SKILL_INSTALL_FAILED`: skill bundle install failed
+- `INTERNAL_ERROR`: unexpected failure
+
+Exit code guidance:
+
+- `0`: success
+- `2`: invalid input
+- `3`: missing prerequisites or incomplete config
+- `4`: external validation or dependency failure
+- `5`: execution failed after work started
+
+## Recovery Playbook
+
+- On `CONFIG_MISSING`, run `machine doctor`, then patch config with `machine config set`, then retry.
+- On provider setup failures, save a named provider with `machine provider add`, switch with `machine provider use`, then rerun doctor.
+- On `VALIDATION_FAILED`, inspect `validationResults` and avoid claiming success.
+- On `DIRTY_WORKSPACE`, ask for a clean working tree before rerunning mutation flows.
+- On `PR_CREATION_FAILED`, report local artifacts and changed files; a successful draft generation is not the same as a published PR.
+
+## Reporting Back To The User
+
+Always surface:
+
+- what command ran
+- whether execution was preview-only, draft-only, local-write, or PR-opening
+- any validation failures
+- any artifact paths the user may need
+- any PR URL that was created
+- any `nextActions` or `skipReasons`

--- a/skills/examples/claude-code.md
+++ b/skills/examples/claude-code.md
@@ -1,0 +1,3 @@
+# Claude Code Example
+
+Run `openmeta skill export --host claude-code --output ./tmp`.

--- a/skills/examples/openclaw.md
+++ b/skills/examples/openclaw.md
@@ -1,0 +1,3 @@
+# OpenClaw Example
+
+Run `openmeta skill export --host openclaw --output ./tmp`.

--- a/skills/schema/capability-catalog.json
+++ b/skills/schema/capability-catalog.json
@@ -4,41 +4,110 @@
     {
       "name": "openmeta machine doctor",
       "requiredArgs": [],
-      "outcome": "machine_doctor_report"
+      "optionalArgs": [],
+      "outcome": "machine_doctor_report",
+      "purpose": "Check whether local configuration, credentials, directories, and automation prerequisites are ready for agent-driven use.",
+      "inspectFields": ["ready", "configPath", "homePath", "nextActions"]
+    },
+    {
+      "name": "openmeta machine config get",
+      "requiredArgs": [],
+      "optionalArgs": [],
+      "outcome": "machine_config_snapshot",
+      "purpose": "Read the masked machine-safe configuration snapshot without exposing raw secrets.",
+      "inspectFields": ["github", "llm", "automation", "commitTemplate"]
     },
     {
       "name": "openmeta machine config set",
       "requiredArgs": ["key", "value"],
-      "outcome": "machine_config_snapshot"
+      "optionalArgs": [],
+      "outcome": "machine_config_snapshot",
+      "purpose": "Set one configuration key and receive the masked resulting snapshot plus scheduler sync state.",
+      "inspectFields": ["updatedKey", "appliedValue", "snapshot", "scheduler"]
     },
     {
       "name": "openmeta machine provider add",
       "requiredArgs": ["name", "--base-url", "--model", "--api-key"],
-      "outcome": "machine_provider_result"
+      "optionalArgs": ["--provider", "--reasoning-effort", "--stream", "--header"],
+      "outcome": "machine_provider_result",
+      "purpose": "Save a named LLM provider profile for later machine-safe activation.",
+      "inspectFields": ["profileName", "activeProfile", "provider", "modelName", "apiBaseUrl", "validation"]
     },
     {
       "name": "openmeta machine provider use",
       "requiredArgs": ["name"],
-      "outcome": "machine_provider_result"
+      "optionalArgs": [],
+      "outcome": "machine_provider_result",
+      "purpose": "Switch the active provider profile used by scout, analyze, and agent flows.",
+      "inspectFields": ["profileName", "activeProfile", "provider", "modelName", "validation", "validationMessage"]
     },
     {
       "name": "openmeta machine scout",
       "requiredArgs": [],
-      "outcome": "machine_scout_result"
+      "optionalArgs": ["--limit", "--refresh", "--repo", "--local"],
+      "outcome": "machine_scout_result",
+      "purpose": "Return ranked contribution opportunities in a stable JSON shape.",
+      "inspectFields": ["opportunities", "mode", "nextActions"]
     },
     {
       "name": "openmeta machine analyze",
       "requiredArgs": ["--repo"],
-      "outcome": "machine_analyze_result"
+      "optionalArgs": ["--headless", "--run-checks", "--dry-run"],
+      "outcome": "machine_analyze_result",
+      "purpose": "Analyze one repository, generate a suggested patch and PR draft, and return artifact locations.",
+      "inspectFields": ["repoFullName", "selectedSuggestion", "patchDraft", "prDraft", "workspace", "artifacts", "mode"]
     },
     {
       "name": "openmeta machine agent",
       "requiredArgs": [],
+      "optionalArgs": ["--headless", "--run-checks", "--draft-only", "--refresh", "--repo", "--issue", "--dry-run"],
       "outcome": "machine_agent_result",
+      "purpose": "Execute the full contribution flow, from issue selection through artifacts and optional PR creation.",
+      "inspectFields": ["executionOutcome", "reviewRequired", "validationResults", "changedFiles", "pullRequestUrl", "artifacts", "skipReasons"],
       "dangerousExecutionNotes": [
         "Only run when the user explicitly asks for execution.",
-        "Review executionOutcome, validationResults, and pullRequestUrl before claiming completion."
+        "Prefer --dry-run for previews and --draft-only for artifact-only operation.",
+        "Review executionOutcome, reviewRequired, validationResults, and pullRequestUrl before claiming completion."
       ]
+    },
+    {
+      "name": "openmeta machine runs",
+      "requiredArgs": [],
+      "optionalArgs": ["[id]", "--limit"],
+      "outcome": "machine_runs_result",
+      "purpose": "Inspect machine-safe run history or one specific run record.",
+      "inspectFields": ["records", "totals", "ledgerPath"]
+    },
+    {
+      "name": "openmeta machine inbox",
+      "requiredArgs": [],
+      "optionalArgs": [],
+      "outcome": "machine_inbox_result",
+      "purpose": "Read the persisted ranked opportunity backlog.",
+      "inspectFields": ["items", "inboxPath"]
+    },
+    {
+      "name": "openmeta machine pow",
+      "requiredArgs": [],
+      "optionalArgs": [],
+      "outcome": "machine_proof_of_work_result",
+      "purpose": "Read proof-of-work records, publication state, and stored artifact references.",
+      "inspectFields": ["records", "proofOfWorkPath"]
     }
+  ],
+  "errorCodes": [
+    "INVALID_ARGUMENT",
+    "CONFIG_MISSING",
+    "CONFIG_INVALID",
+    "GITHUB_AUTH_FAILED",
+    "LLM_AUTH_FAILED",
+    "REPO_PREP_FAILED",
+    "VALIDATION_FAILED",
+    "DIRTY_WORKSPACE",
+    "PR_CREATION_SKIPPED",
+    "PR_CREATION_FAILED",
+    "SKILL_HOST_UNSUPPORTED",
+    "SKILL_INSTALL_FAILED",
+    "INTERNAL_ERROR"
   ]
 }

--- a/skills/schema/capability-catalog.json
+++ b/skills/schema/capability-catalog.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "commands": [
+    {
+      "name": "openmeta machine doctor",
+      "requiredArgs": [],
+      "outcome": "machine_doctor_report"
+    },
+    {
+      "name": "openmeta machine config set",
+      "requiredArgs": ["key", "value"],
+      "outcome": "machine_config_snapshot"
+    },
+    {
+      "name": "openmeta machine provider add",
+      "requiredArgs": ["name", "--base-url", "--model", "--api-key"],
+      "outcome": "machine_provider_result"
+    },
+    {
+      "name": "openmeta machine provider use",
+      "requiredArgs": ["name"],
+      "outcome": "machine_provider_result"
+    },
+    {
+      "name": "openmeta machine scout",
+      "requiredArgs": [],
+      "outcome": "machine_scout_result"
+    },
+    {
+      "name": "openmeta machine analyze",
+      "requiredArgs": ["--repo"],
+      "outcome": "machine_analyze_result"
+    },
+    {
+      "name": "openmeta machine agent",
+      "requiredArgs": [],
+      "outcome": "machine_agent_result",
+      "dangerousExecutionNotes": [
+        "Only run when the user explicitly asks for execution.",
+        "Review executionOutcome, validationResults, and pullRequestUrl before claiming completion."
+      ]
+    }
+  ]
+}

--- a/skills/templates/claude-code/skill.md
+++ b/skills/templates/claude-code/skill.md
@@ -1,0 +1,9 @@
+# Claude Code OpenMeta Skill
+
+Host: Claude Code
+
+{{coreSkill}}
+
+## Capability Catalog
+
+{{capabilityCatalog}}

--- a/skills/templates/claude-code/skill.md
+++ b/skills/templates/claude-code/skill.md
@@ -2,6 +2,14 @@
 
 Host: Claude Code
 
+Install target: `~/.claude/skills/openmeta`
+
+## Host Notes
+
+- Keep the generated file at `skill.md` inside the OpenMeta skill directory.
+- Re-run `openmeta skill install --host claude-code` after upgrading OpenMeta CLI.
+- Verify installation with `openmeta skill doctor --host claude-code`.
+
 {{coreSkill}}
 
 ## Capability Catalog

--- a/skills/templates/openclaw/skill.md
+++ b/skills/templates/openclaw/skill.md
@@ -1,0 +1,9 @@
+# OpenClaw OpenMeta Skill
+
+Host: OpenClaw
+
+{{coreSkill}}
+
+## Capability Catalog
+
+{{capabilityCatalog}}

--- a/skills/templates/openclaw/skill.md
+++ b/skills/templates/openclaw/skill.md
@@ -2,6 +2,14 @@
 
 Host: OpenClaw
 
+Install target: `~/.openclaw/skills/openmeta`
+
+## Host Notes
+
+- Keep the generated file at `skill.md` inside the OpenMeta skill directory.
+- Re-run `openmeta skill install --host openclaw` after upgrading OpenMeta CLI.
+- Verify installation with `openmeta skill doctor --host openclaw`.
+
 {{coreSkill}}
 
 ## Capability Catalog

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import {
   registerDailyCommand,
   registerDoctorCommand,
   registerInboxCommand,
+  registerMachineCommand,
   registerInitCommand,
   registerPowCommand,
   registerProviderCommand,
@@ -41,6 +42,7 @@ async function main(): Promise<void> {
   registerAutomationCommand(program);
   registerDoctorCommand(program);
   registerRunsCommand(program);
+  registerMachineCommand(program);
 
   program.on('command:*', () => {
     ui.commandFailed('openmeta', `Unknown command "${program.args.join(' ')}". Run "openmeta --help" to see available commands.`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
   registerProviderCommand,
   registerRunsCommand,
   registerScoutCommand,
+  registerSkillCommand,
 } from './commands/index.js';
 import { getErrorMessage, ui } from './infra/index.js';
 
@@ -43,6 +44,7 @@ async function main(): Promise<void> {
   registerDoctorCommand(program);
   registerRunsCommand(program);
   registerMachineCommand(program);
+  registerSkillCommand(program);
 
   program.on('command:*', () => {
     ui.commandFailed('openmeta', `Unknown command "${program.args.join(' ')}". Run "openmeta --help" to see available commands.`);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,3 +11,4 @@ export { registerAutomationCommand } from './automation.js';
 export { registerDoctorCommand } from './doctor.js';
 export { registerRunsCommand } from './runs.js';
 export { registerMachineCommand } from './machine.js';
+export { registerSkillCommand } from './skill.js';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,3 +10,4 @@ export { registerProviderCommand } from './provider.js';
 export { registerAutomationCommand } from './automation.js';
 export { registerDoctorCommand } from './doctor.js';
 export { registerRunsCommand } from './runs.js';
+export { registerMachineCommand } from './machine.js';

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -27,9 +27,34 @@ export function registerMachineCommand(program: Command): void {
     .description('Read a masked machine-safe configuration snapshot')
     .action(() => machineConfigOrchestrator.get());
 
+  config
+    .command('set <key> <value>')
+    .description('Update a configuration key and return the masked resulting snapshot')
+    .action((key: string, value: string) => machineConfigOrchestrator.set(key, value));
+
   const provider = machine
     .command('provider')
     .description('Machine-safe provider profile management');
+
+  provider
+    .command('add <name>')
+    .description('Save a provider profile and return its machine-readable state')
+    .requiredOption('--base-url <url>', 'OpenAI-compatible API base URL')
+    .requiredOption('--model <model>', 'Model name')
+    .requiredOption('--api-key <key>', 'Provider API key')
+    .option('--provider <provider>', 'Provider preset name')
+    .option('--reasoning-effort <effort>', 'Reasoning effort')
+    .option('--stream <enabled>', 'Streaming mode as true or false')
+    .option('--header <key=value>', 'Extra provider header', (value: string, previous: string[] = []) => [...previous, value], [])
+    .action((name: string, options: {
+      provider?: string;
+      baseUrl?: string;
+      model?: string;
+      apiKey?: string;
+      reasoningEffort?: string;
+      stream?: string;
+      header?: string[];
+    }) => machineProviderOrchestrator.add(name, options));
 
   provider
     .command('use <name>')
@@ -51,4 +76,40 @@ export function registerMachineCommand(program: Command): void {
     .command('pow')
     .description('Machine-safe proof-of-work list')
     .action(() => machineProofOfWorkOrchestrator.execute());
+
+  machine
+    .command('scout')
+    .description('Machine-safe opportunity discovery')
+    .option('--limit <count>', 'Number of opportunities to return', '10')
+    .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--repo <repository>', 'Limit issue discovery to one repository')
+    .option('--local', 'Use local heuristic scoring without calling the LLM provider')
+    .action(() => {
+      throw new Error('machine scout is not implemented yet.');
+    });
+
+  machine
+    .command('analyze')
+    .description('Machine-safe repository-first analysis')
+    .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name to analyze')
+    .option('--headless', 'Select the highest-scoring suggestion without prompting')
+    .option('--run-checks', 'Execute detected baseline validation commands during workspace preparation')
+    .option('--dry-run', 'Preview artifact paths without writing local analysis files')
+    .action(() => {
+      throw new Error('machine analyze is not implemented yet.');
+    });
+
+  machine
+    .command('agent')
+    .description('Machine-safe contribution execution flow')
+    .option('--headless', 'Run unattended using saved automation defaults')
+    .option('--run-checks', 'Execute detected baseline validation commands')
+    .option('--draft-only', 'Generate artifacts without applying file edits or opening a PR')
+    .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--repo <repository>', 'Limit issue discovery to one repository')
+    .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
+    .option('--dry-run', 'Preview artifacts without publishing them')
+    .action(() => {
+      throw new Error('machine agent is not implemented yet.');
+    });
 }

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -1,11 +1,14 @@
 import { Command } from 'commander';
 import {
+  machineAgentFlowOrchestrator,
+  machineAnalyzeOrchestrator,
   machineConfigOrchestrator,
   machineDoctorOrchestrator,
   machineInboxOrchestrator,
   machineProofOfWorkOrchestrator,
   machineProviderOrchestrator,
   machineRunsOrchestrator,
+  machineScoutOrchestrator,
 } from '../orchestration/machine/index.js';
 
 export function registerMachineCommand(program: Command): void {
@@ -84,9 +87,7 @@ export function registerMachineCommand(program: Command): void {
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one repository')
     .option('--local', 'Use local heuristic scoring without calling the LLM provider')
-    .action(() => {
-      throw new Error('machine scout is not implemented yet.');
-    });
+    .action((options: { limit?: string; refresh?: boolean; repo?: string; local?: boolean }) => machineScoutOrchestrator.execute(options));
 
   machine
     .command('analyze')
@@ -95,9 +96,7 @@ export function registerMachineCommand(program: Command): void {
     .option('--headless', 'Select the highest-scoring suggestion without prompting')
     .option('--run-checks', 'Execute detected baseline validation commands during workspace preparation')
     .option('--dry-run', 'Preview artifact paths without writing local analysis files')
-    .action(() => {
-      throw new Error('machine analyze is not implemented yet.');
-    });
+    .action((options: { repo?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) => machineAnalyzeOrchestrator.execute(options));
 
   machine
     .command('agent')
@@ -109,7 +108,13 @@ export function registerMachineCommand(program: Command): void {
     .option('--repo <repository>', 'Limit issue discovery to one repository')
     .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
     .option('--dry-run', 'Preview artifacts without publishing them')
-    .action(() => {
-      throw new Error('machine agent is not implemented yet.');
-    });
+    .action((options: {
+      headless?: boolean;
+      runChecks?: boolean;
+      draftOnly?: boolean;
+      refresh?: boolean;
+      repo?: string;
+      issue?: string;
+      dryRun?: boolean;
+    }) => machineAgentFlowOrchestrator.execute(options));
 }

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -1,0 +1,54 @@
+import { Command } from 'commander';
+import {
+  machineConfigOrchestrator,
+  machineDoctorOrchestrator,
+  machineInboxOrchestrator,
+  machineProofOfWorkOrchestrator,
+  machineProviderOrchestrator,
+  machineRunsOrchestrator,
+} from '../orchestration/machine/index.js';
+
+export function registerMachineCommand(program: Command): void {
+  const machine = program
+    .command('machine')
+    .description('Stable JSON-first automation surface');
+
+  machine
+    .command('doctor')
+    .description('Inspect local prerequisites and return machine-readable diagnostics')
+    .action(() => machineDoctorOrchestrator.execute());
+
+  const config = machine
+    .command('config')
+    .description('Machine-safe configuration access');
+
+  config
+    .command('get')
+    .description('Read a masked machine-safe configuration snapshot')
+    .action(() => machineConfigOrchestrator.get());
+
+  const provider = machine
+    .command('provider')
+    .description('Machine-safe provider profile management');
+
+  provider
+    .command('use <name>')
+    .description('Switch to a saved provider profile and return machine-readable state')
+    .action((name: string) => machineProviderOrchestrator.use(name));
+
+  machine
+    .command('runs [id]')
+    .description('Machine-safe run history access')
+    .option('--limit <count>', 'Number of runs to show', '10')
+    .action((id: string | undefined, options: { limit?: string }) => machineRunsOrchestrator.show(id, options));
+
+  machine
+    .command('inbox')
+    .description('Machine-safe drafted opportunity list')
+    .action(() => machineInboxOrchestrator.execute());
+
+  machine
+    .command('pow')
+    .description('Machine-safe proof-of-work list')
+    .action(() => machineProofOfWorkOrchestrator.execute());
+}

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,54 @@
+import { Command } from 'commander';
+import { doctorSkillBundle, getSkillsRoot, getSupportedSkillHosts, installSkillBundle, renderSkillBundle, type SkillHost } from '../orchestration/skill/index.js';
+
+function parseHost(value: string): SkillHost {
+  if (value === 'claude-code' || value === 'openclaw') {
+    return value;
+  }
+
+  throw new Error(`Unsupported skill host: ${value}`);
+}
+
+export function registerSkillCommand(program: Command): void {
+  const skill = program
+    .command('skill')
+    .description('Host-generated OpenMeta skill bundle management');
+
+  skill
+    .command('list')
+    .description('List supported skill hosts and the canonical asset source path')
+    .action(() => {
+      process.stdout.write(`${JSON.stringify({
+        hosts: getSupportedSkillHosts(),
+        sourceRoot: getSkillsRoot(),
+      }, null, 2)}\n`);
+    });
+
+  skill
+    .command('export')
+    .description('Render a host skill bundle into an output directory')
+    .requiredOption('--host <host>', 'Host name')
+    .requiredOption('--output <dir>', 'Output directory')
+    .action(async (options: { host?: string; output?: string }) => {
+      const result = await renderSkillBundle(parseHost(options.host || ''), options.output || '');
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    });
+
+  skill
+    .command('install')
+    .description('Install a host skill bundle into the default host path')
+    .requiredOption('--host <host>', 'Host name')
+    .action(async (options: { host?: string }) => {
+      const result = await installSkillBundle(parseHost(options.host || ''));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    });
+
+  skill
+    .command('doctor')
+    .description('Diagnose host skill bundle installation state')
+    .requiredOption('--host <host>', 'Host name')
+    .action(async (options: { host?: string }) => {
+      const result = await doctorSkillBundle(parseHost(options.host || ''));
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    });
+}

--- a/src/infra/execution-context.ts
+++ b/src/infra/execution-context.ts
@@ -1,0 +1,14 @@
+let machineContextDepth = 0;
+
+export function isMachineContext(): boolean {
+  return machineContextDepth > 0;
+}
+
+export async function runInMachineContext<T>(task: () => Promise<T>): Promise<T> {
+  machineContextDepth += 1;
+  try {
+    return await task();
+  } finally {
+    machineContextDepth = Math.max(0, machineContextDepth - 1);
+  }
+}

--- a/src/infra/index.ts
+++ b/src/infra/index.ts
@@ -17,6 +17,7 @@ export { DEFAULT_LLM_REASONING_EFFORT, LLM_REASONING_EFFORTS, parseLLMReasoningE
 export { prompt } from './prompts.js';
 export { selectPrompt } from './select.js';
 export { ui } from './ui.js';
+export { isMachineContext, runInMachineContext } from './execution-context.js';
 export {
   ISSUE_MATCH_PROMPT,
   DAILY_REPORT_GENERATE_PROMPT,

--- a/src/infra/index.ts
+++ b/src/infra/index.ts
@@ -17,7 +17,6 @@ export { DEFAULT_LLM_REASONING_EFFORT, LLM_REASONING_EFFORTS, parseLLMReasoningE
 export { prompt } from './prompts.js';
 export { selectPrompt } from './select.js';
 export { ui } from './ui.js';
-export { isMachineContext, runInMachineContext } from './execution-context.js';
 export {
   ISSUE_MATCH_PROMPT,
   DAILY_REPORT_GENERATE_PROMPT,

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { isMachineContext } from './execution-context.js';
 
 export type LogLevel = 'info' | 'success' | 'warn' | 'error' | 'debug';
 
@@ -31,7 +32,16 @@ export class Logger {
       .map((arg) => this.renderArg(arg))
       .filter((arg): arg is string => arg.length > 0);
 
-    console.log(`${chalk.gray(timestamp)} ${format[level]} ${prefix}${message}`, ...renderedArgs);
+    const line = [`${chalk.gray(timestamp)} ${format[level]} ${prefix}${message}`, ...renderedArgs]
+      .filter(Boolean)
+      .join(' ');
+
+    if (isMachineContext()) {
+      process.stderr.write(`${line}\n`);
+      return;
+    }
+
+    console.log(line);
   }
 
   info(message: string, ...args: unknown[]): void {

--- a/src/infra/prompts.ts
+++ b/src/infra/prompts.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { UserCancelledError } from './errors.js';
+import { isMachineContext } from './execution-context.js';
 
 type PromptQuestion =
   | {
@@ -143,6 +144,10 @@ async function askQuestion(question: PromptQuestion): Promise<unknown> {
 }
 
 export async function prompt<T extends object>(questions: unknown): Promise<T> {
+  if (isMachineContext()) {
+    throw new Error('Interactive prompts are unavailable in machine mode. Use explicit machine command flags instead.');
+  }
+
   const questionList = questions as PromptQuestion[];
   const answers: Record<string, unknown> = {};
 

--- a/src/infra/select.ts
+++ b/src/infra/select.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { UserCancelledError } from './errors.js';
+import { isMachineContext } from './execution-context.js';
 
 export interface SelectChoice<T> {
   name: string;
@@ -14,6 +15,10 @@ export async function selectPrompt<T>(options: {
   default?: T;
   pageSize?: number;
 }): Promise<T> {
+  if (isMachineContext()) {
+    throw new Error(`Interactive selection is unavailable in machine mode. ${options.message}`);
+  }
+
   const mappedOptions = options.choices.map((choice) => ({
     value: choice.value,
     label: choice.name,

--- a/src/infra/ui/index.ts
+++ b/src/infra/ui/index.ts
@@ -3,6 +3,7 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import figures from 'figures';
 import gradient from 'gradient-string';
+import { isMachineContext } from '../execution-context.js';
 import { getOpenMetaWordmarkLines } from './brand.js';
 import { getUiCapabilities } from './capabilities.js';
 import { padLine, visibleLength, wrapLine } from './layout.js';
@@ -104,10 +105,16 @@ function statusColor(state: StepState): (text: string) => string {
 }
 
 function printBlankLine(): void {
+  if (isMachineContext()) {
+    return;
+  }
   process.stdout.write('\n');
 }
 
 function clackLines(lines: string | string[]): void {
+  if (isMachineContext()) {
+    return;
+  }
   p.log.message(lines, {
     symbol: ' ',
     withGuide: false,
@@ -189,6 +196,9 @@ function buildCardText(capabilities: UiCapabilities, options: CardOptions, varia
 }
 
 function printCard(capabilities: UiCapabilities, options: CardOptions, variant: CardVariant = 'standard'): void {
+  if (isMachineContext()) {
+    return;
+  }
   const tone = options.tone ?? 'info';
   const palette = paletteForTone(tone);
   const content = buildCardText(capabilities, options, variant);
@@ -206,6 +216,9 @@ function printCard(capabilities: UiCapabilities, options: CardOptions, variant: 
 }
 
 function printHero(capabilities: UiCapabilities, options: CardOptions): void {
+  if (isMachineContext()) {
+    return;
+  }
   const tone = options.tone ?? 'accent';
   const width = Math.max(40, Math.min(capabilities.width - 2, 96));
   const bullet = figures.pointerSmall;
@@ -235,6 +248,9 @@ function printHero(capabilities: UiCapabilities, options: CardOptions): void {
 }
 
 function printCelebration(capabilities: UiCapabilities, options: CardOptions): void {
+  if (isMachineContext()) {
+    return;
+  }
   const tone = options.tone ?? 'success';
   const width = Math.max(40, Math.min(capabilities.width - 2, 96));
   const rule = renderRule(capabilities, tone, Math.min(width, 42));
@@ -267,6 +283,9 @@ function printCelebration(capabilities: UiCapabilities, options: CardOptions): v
 }
 
 function printSection(capabilities: UiCapabilities, title: string, subtitle?: string): void {
+  if (isMachineContext()) {
+    return;
+  }
   const width = Math.max(44, Math.min(capabilities.width - 2, 106));
   const rule = capabilities.supportsUnicode ? '─'.repeat(Math.max(10, width - visibleLength(title) - 6)) : '-'.repeat(Math.max(10, width - visibleLength(title) - 6));
 
@@ -280,6 +299,9 @@ function printSection(capabilities: UiCapabilities, title: string, subtitle?: st
 }
 
 function printList(lines: string[], tone: Tone = 'muted'): void {
+  if (isMachineContext()) {
+    return;
+  }
   const accent = paletteForTone(tone).accent;
   for (const line of lines) {
     process.stdout.write(`${accent(figures.pointerSmall)} ${chalk.gray(line)}\n`);
@@ -287,6 +309,9 @@ function printList(lines: string[], tone: Tone = 'muted'): void {
 }
 
 function printKeyValues(capabilities: UiCapabilities, title: string, items: KeyValueItem[]): void {
+  if (isMachineContext()) {
+    return;
+  }
   const width = Math.max(44, Math.min(capabilities.width - 2, 106));
   const labelWidth = Math.min(24, Math.max(...items.map((item) => item.label.length), 12));
   printSection(capabilities, title);
@@ -305,6 +330,9 @@ function printKeyValues(capabilities: UiCapabilities, title: string, items: KeyV
 }
 
 function printStats(capabilities: UiCapabilities, title: string, items: MetricItem[]): void {
+  if (isMachineContext()) {
+    return;
+  }
   printSection(capabilities, title);
   const columns = capabilities.mode === 'interactive-rich' && capabilities.width >= 96 ? 3 : 2;
   const width = Math.max(44, Math.min(capabilities.width - 2, 106));
@@ -335,6 +363,9 @@ function printStats(capabilities: UiCapabilities, title: string, items: MetricIt
 }
 
 function printStepper(capabilities: UiCapabilities, title: string, steps: StepItem[]): void {
+  if (isMachineContext()) {
+    return;
+  }
   printSection(capabilities, title);
 
   for (const [index, step] of steps.entries()) {
@@ -351,6 +382,9 @@ function printStepper(capabilities: UiCapabilities, title: string, steps: StepIt
 }
 
 function printTimeline(capabilities: UiCapabilities, title: string, items: TimelineItem[]): void {
+  if (isMachineContext()) {
+    return;
+  }
   printSection(capabilities, title);
 
   for (const item of items) {
@@ -365,6 +399,9 @@ function printTimeline(capabilities: UiCapabilities, title: string, items: Timel
 }
 
 function printRecordList(capabilities: UiCapabilities, title: string, items: RecordItem[]): void {
+  if (isMachineContext()) {
+    return;
+  }
   printSection(capabilities, title);
 
   for (const item of items) {

--- a/src/infra/ui/live.ts
+++ b/src/infra/ui/live.ts
@@ -1,6 +1,7 @@
 import * as p from '@clack/prompts';
 import chalk from 'chalk';
 import figures from 'figures';
+import { isMachineContext } from '../execution-context.js';
 import type { TaskController, TaskOptions, Tone, UiCapabilities } from './types.js';
 
 function toneColor(tone: Tone): 'green' | 'yellow' | 'red' | 'magenta' | 'white' | 'cyan' {
@@ -52,6 +53,10 @@ export async function runTask<T>(
       // no-op by default; interactive mode replaces this with spinner.message(...)
     },
   };
+
+  if (isMachineContext()) {
+    return task(controller);
+  }
 
   if (!capabilities.isInteractive || capabilities.mode === 'plain') {
     process.stdout.write(`${renderInlineStatus(figures.pointerSmall, options.title, tone)}\n`);

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -68,6 +68,33 @@ export interface MachineScoutResult {
   nextActions: string[];
 }
 
+export interface MachineAgentResult {
+  issue: RankedIssue;
+  workspace: RepoWorkspaceContext;
+  patchDraft: PatchDraft;
+  prDraft: PullRequestDraft;
+  artifacts: ContributionAgentResult['artifacts'];
+  changedFiles: string[];
+  validationResults: TestResult[];
+  reviewRequired: boolean;
+  published: boolean;
+  prCreated: boolean;
+  repoMutated: boolean;
+  artifactsWritten: boolean;
+  executionOutcome: 'draft_only' | 'local_artifacts_written' | 'changes_applied' | 'pr_opened' | 'blocked';
+  executionPolicy: {
+    headless: boolean;
+    draftOnly: boolean;
+    runChecks: boolean;
+    dryRun: boolean;
+    refresh: boolean;
+  };
+  skipReasons: string[];
+  nextActions: string[];
+  pullRequestUrl?: string;
+  pullRequestNumber?: number;
+}
+
 interface TargetRepoContext {
   path: string;
   owner: string;
@@ -132,6 +159,223 @@ const AGENT_STAGES: Array<{ id: AgentStageId; label: string; description: string
 
 export class AgentOrchestrator {
   private octokit: Octokit | null = null;
+
+  async runMachine(options: AgentRunOptions = {}): Promise<MachineAgentResult> {
+    const config = await configService.get();
+    const headless = options.headless ?? true;
+    const schedulerRun = Boolean(options.schedulerRun);
+    const runChecks = typeof options.runChecks === 'boolean' ? options.runChecks : !headless;
+    const draftOnly = Boolean(options.draftOnly);
+    const refresh = Boolean(options.refresh);
+    const dryRun = Boolean(options.dryRun);
+    const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
+    const repoFullName = issueTarget?.repoFullName ?? (options.repo ? parseGitHubRepoFullName(options.repo) : undefined);
+
+    await this.validateConfig(config);
+
+    if (headless && !schedulerRun && !dryRun) {
+      await this.confirmManualHeadlessRun(config);
+    }
+
+    await this.initializeClients(config);
+
+    const rankedIssues = issueTarget
+      ? await issueRankingService.loadTargetIssue(config, issueTarget)
+      : await issueRankingService.loadRankedIssues(config, {
+        refresh,
+        repoFullName,
+      });
+
+    if (rankedIssues.length === 0) {
+      throw new Error(issueTarget
+        ? 'OpenMeta could not build a contribution target from the specified issue.'
+        : 'No issues met the current technical match threshold. Broaden your profile or try again later.');
+    }
+
+    const selectedIssue = issueTarget
+      ? rankedIssues[0]
+      : headless
+        ? issueRankingService.selectIssueForAutomation(rankedIssues, config.automation.minMatchScore)
+        : await this.promptForIssue(issueRankingService.diversifyScoutIssues(rankedIssues, 5));
+
+    if (!selectedIssue) {
+      throw new Error(issueTarget
+        ? 'OpenMeta could not select the specified target issue after scoring.'
+        : `Top opportunities were below ${config.automation.minMatchScore}/100. Lower the threshold or widen your profile.`);
+    }
+
+    const memoryBeforeRun = memoryService.load(selectedIssue.repoFullName);
+    const workspace = await workspaceService.prepareWorkspace(
+      selectedIssue,
+      memoryBeforeRun,
+      runChecks,
+      headless ? 'headless' : 'interactive',
+    );
+    const memory = memoryService.update(selectedIssue, workspace);
+
+    const patchDraftResult = await llmService.generatePatchDraft(selectedIssue, workspace, memory);
+    const patchDraft = patchDraftResult.data;
+    const implementationWorkspace = this.buildImplementationWorkspace(workspace, patchDraft);
+    const implementation = patchDraftResult.status === 'success'
+      ? await this.generateConcretePatch(selectedIssue, implementationWorkspace, patchDraft, runChecks, draftOnly)
+      : {
+        changedFiles: [],
+        validationResults: implementationWorkspace.testResults,
+        reviewRequired: true,
+      };
+
+    const workspaceForArtifacts: RepoWorkspaceContext = {
+      ...implementationWorkspace,
+      testResults: implementation.validationResults,
+    };
+
+    const prDraftResult = await llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts);
+    const prDraft = prDraftResult.data;
+    const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+
+    const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
+      config,
+      allowRealPr: patchDraftResult.status === 'success' && prDraftResult.status === 'success',
+      headless,
+      issue: selectedIssue,
+      prDraft,
+      workspace: workspaceForArtifacts,
+      changedFiles: implementation.changedFiles,
+      validationResults: implementation.validationResults,
+    });
+
+    const artifacts = this.prepareLocalArtifactPaths(selectedIssue);
+    const reviewRequired =
+      patchDraftResult.status !== 'success'
+      || implementation.reviewRequired
+      || prDraftResult.status !== 'success';
+    const skipReasons = [
+      ...(draftOnly ? ['draft_only'] : []),
+      ...(patchDraftResult.status !== 'success' ? ['patch_draft_requires_review'] : []),
+      ...(implementation.reviewRequired ? ['implementation_requires_review'] : []),
+      ...(prDraftResult.status !== 'success' ? ['pr_draft_requires_review'] : []),
+      ...(contributionPullRequest.url ? [] : implementation.changedFiles.length > 0 ? ['pr_not_created'] : ['no_changes_applied']),
+    ];
+
+    if (!dryRun) {
+      const inboxItem = {
+        id: `${selectedIssue.repoFullName}#${selectedIssue.number}`,
+        repoFullName: selectedIssue.repoFullName,
+        issueNumber: selectedIssue.number,
+        issueTitle: selectedIssue.title,
+        summary: selectedIssue.opportunity.summary,
+        overallScore: selectedIssue.opportunity.overallScore,
+        opportunityScore: selectedIssue.opportunity.score,
+        status: 'ready' as const,
+        artifactDir: artifacts.artifactDir,
+        generatedAt: new Date().toISOString(),
+      };
+      const inboxItems = inboxService.saveItem(inboxItem);
+      const proofRecord = {
+        id: `${selectedIssue.repoFullName}#${selectedIssue.number}@${Date.now()}`,
+        repoFullName: selectedIssue.repoFullName,
+        issueNumber: selectedIssue.number,
+        issueTitle: selectedIssue.title,
+        overallScore: selectedIssue.opportunity.overallScore,
+        opportunityScore: selectedIssue.opportunity.score,
+        branchName: workspace.branchName,
+        artifactDir: artifacts.artifactDir,
+        generatedAt: new Date().toISOString(),
+        published: false,
+        pullRequestUrl: contributionPullRequest.url,
+        pullRequestNumber: contributionPullRequest.number,
+      };
+      const dossier = contentService.formatContributionDossier(selectedIssue, workspaceForArtifacts, memory, patchDraft, prDraft);
+      const proofMarkdown = proofOfWorkService.renderMarkdown([
+        proofRecord,
+        ...proofOfWorkService.load().records,
+      ].slice(0, 100));
+
+      this.writeLocalArtifacts({
+        artifacts,
+        dossier,
+        patchDraftMarkdown,
+        prDraftMarkdown,
+        memoryMarkdown: memoryService.renderMarkdown(memory),
+        inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+        proofMarkdown,
+      });
+
+      const publishResult = await this.publishArtifactsIfNeeded({
+        config,
+        headless,
+        dryRun: options.dryRun,
+        issue: selectedIssue,
+        patchDraftMarkdown,
+        prDraftMarkdown,
+        dossier,
+        memoryMarkdown: memoryService.renderMarkdown(memory),
+        inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+        proofMarkdown,
+        changedFiles: implementation.changedFiles,
+        validationResults: implementation.validationResults,
+        pullRequestUrl: contributionPullRequest.url,
+      });
+
+      const finalProofRecord = {
+        ...proofRecord,
+        published: publishResult.published,
+      };
+      const finalMemory = memoryService.recordOutcome({
+        issue: selectedIssue,
+        workspace: workspaceForArtifacts,
+        changedFiles: implementation.changedFiles,
+        validationResults: implementation.validationResults,
+        published: publishResult.published,
+        pullRequestUrl: contributionPullRequest.url,
+        reviewRequired,
+      });
+      proofOfWorkService.record(finalProofRecord);
+      const finalProofMarkdown = proofOfWorkService.renderMarkdown(proofOfWorkService.load().records);
+      this.writeLocalArtifacts({
+        artifacts,
+        dossier,
+        patchDraftMarkdown,
+        prDraftMarkdown,
+        memoryMarkdown: memoryService.renderMarkdown(finalMemory),
+        inboxMarkdown: inboxService.renderMarkdown(inboxItems),
+        proofMarkdown: finalProofMarkdown,
+      });
+    }
+
+    return {
+      issue: selectedIssue,
+      workspace: workspaceForArtifacts,
+      patchDraft,
+      prDraft,
+      artifacts,
+      changedFiles: implementation.changedFiles,
+      validationResults: implementation.validationResults,
+      reviewRequired,
+      published: false,
+      prCreated: Boolean(contributionPullRequest.url),
+      repoMutated: implementation.changedFiles.length > 0,
+      artifactsWritten: !dryRun,
+      executionOutcome: this.resolveMachineExecutionOutcome({
+        draftOnly,
+        changedFiles: implementation.changedFiles,
+        prCreated: Boolean(contributionPullRequest.url),
+        reviewRequired,
+      }),
+      executionPolicy: {
+        headless,
+        draftOnly,
+        runChecks,
+        dryRun,
+        refresh,
+      },
+      skipReasons: [...new Set(skipReasons)],
+      nextActions: dryRun ? ['inspect_artifact_paths'] : contributionPullRequest.url ? ['review_pull_request'] : ['inspect_artifact_paths'],
+      pullRequestUrl: contributionPullRequest.url,
+      pullRequestNumber: contributionPullRequest.number,
+    };
+  }
 
   async run(options: AgentRunOptions = {}): Promise<void> {
     const config = await configService.get();
@@ -1538,6 +1782,31 @@ export class AgentOrchestrator {
 
   private hasBlockingValidationFailures(results: TestResult[]): boolean {
     return results.some((result) => !result.passed && !this.isInfrastructureValidationFailure(result));
+  }
+
+  private resolveMachineExecutionOutcome(input: {
+    draftOnly: boolean;
+    changedFiles: string[];
+    prCreated: boolean;
+    reviewRequired: boolean;
+  }): MachineAgentResult['executionOutcome'] {
+    if (input.reviewRequired && input.changedFiles.length === 0 && !input.prCreated) {
+      return 'blocked';
+    }
+
+    if (input.draftOnly) {
+      return 'draft_only';
+    }
+
+    if (input.prCreated) {
+      return 'pr_opened';
+    }
+
+    if (input.changedFiles.length > 0) {
+      return 'changes_applied';
+    }
+
+    return 'local_artifacts_written';
   }
 
   private isInfrastructureValidationFailure(result: TestResult): boolean {

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -477,8 +477,8 @@ export class AgentOrchestrator {
   }
 
   async showInbox(): Promise<void> {
-    const items = [...inboxService.load().items]
-      .sort((left, right) => right.generatedAt.localeCompare(left.generatedAt));
+    const result = await this.getInboxMachineResult();
+    const { items } = result;
 
     ui.hero({
       label: 'OpenMeta Inbox',
@@ -517,8 +517,8 @@ export class AgentOrchestrator {
   }
 
   async showProofOfWork(): Promise<void> {
-    const records = [...proofOfWorkService.load().records]
-      .sort((left, right) => right.generatedAt.localeCompare(left.generatedAt));
+    const result = await this.getProofOfWorkMachineResult();
+    const { records } = result;
 
     ui.hero({
       label: 'OpenMeta PoW',
@@ -555,6 +555,36 @@ export class AgentOrchestrator {
       ],
       tone: record.published ? 'success' : 'info',
     })));
+  }
+
+  async getInboxMachineResult(): Promise<{
+    items: ReturnType<typeof inboxService.load>['items'];
+    inboxPath: string;
+    nextActions: string[];
+  }> {
+    const items = [...inboxService.load().items]
+      .sort((left, right) => right.overallScore - left.overallScore);
+
+    return {
+      items,
+      inboxPath: inboxService.getPath(),
+      nextActions: items.length === 0 ? ['run_machine_scout'] : ['inspect_artifact_paths'],
+    };
+  }
+
+  async getProofOfWorkMachineResult(): Promise<{
+    records: ReturnType<typeof proofOfWorkService.load>['records'];
+    proofOfWorkPath: string;
+    nextActions: string[];
+  }> {
+    const records = [...proofOfWorkService.load().records]
+      .sort((left, right) => right.generatedAt.localeCompare(left.generatedAt));
+
+    return {
+      records,
+      proofOfWorkPath: proofOfWorkService.getPath(),
+      nextActions: records.length === 0 ? ['run_machine_agent'] : ['inspect_recent_publications'],
+    };
   }
 
   private renderAgentStage(

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -57,6 +57,17 @@ export interface ScoutRunOptions {
   localOnly?: boolean;
 }
 
+export interface MachineScoutResult {
+  opportunities: RankedIssue[];
+  mode: {
+    limit: number;
+    refresh: boolean;
+    repo?: string;
+    localOnly: boolean;
+  };
+  nextActions: string[];
+}
+
 interface TargetRepoContext {
   path: string;
   owner: string;
@@ -474,6 +485,34 @@ export class AgentOrchestrator {
       { label: 'Profile threshold', value: `${config.automation.minMatchScore}`, tone: 'info' },
     ]);
     this.renderOpportunityList('Ranked opportunities', issueRankingService.diversifyScoutIssues(rankedIssues, limit));
+  }
+
+  async scoutMachine(options: ScoutRunOptions = {}): Promise<MachineScoutResult> {
+    const limit = options.limit ?? 10;
+    const refresh = Boolean(options.refresh);
+    const repoFullName = options.repo ? parseGitHubRepoFullName(options.repo) : undefined;
+    const localOnly = Boolean(options.localOnly);
+    const config = await configService.get();
+
+    await this.validateConfig(config, { requireLlm: !localOnly });
+    await this.initializeClients(config, { validateLlm: !localOnly });
+
+    const rankedIssues = await issueRankingService.loadRankedIssues(config, {
+      refresh,
+      repoFullName,
+      localOnly,
+    });
+
+    return {
+      opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
+      mode: {
+        limit,
+        refresh,
+        repo: repoFullName,
+        localOnly,
+      },
+      nextActions: rankedIssues.length === 0 ? ['broaden_profile_filters'] : ['inspect_ranked_opportunities'],
+    };
   }
 
   async showInbox(): Promise<void> {

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -38,13 +38,20 @@ interface AnalyzeResult {
   repoFullName: string;
   workspace: RepoWorkspaceContext;
   selectedSuggestion: RepositoryImprovementSuggestion;
+  suggestions: RepositoryImprovementSuggestion[];
   patchDraft: PatchDraft;
   prDraft: PullRequestDraft;
   artifacts: AnalyzeArtifacts;
 }
 
 export class AnalyzeOrchestrator {
-  async run(options: AnalyzeRunOptions = {}): Promise<void> {
+  async runMachine(options: AnalyzeRunOptions = {}): Promise<AnalyzeResult & {
+    mode: {
+      headless: boolean;
+      runChecks: boolean;
+      dryRun: boolean;
+    };
+  }> {
     if (!options.repo) {
       throw new Error('Repository analysis requires --repo, for example: openmeta analyze --repo owner/name.');
     }
@@ -53,72 +60,29 @@ export class AnalyzeOrchestrator {
     const config = await configService.get();
     const headless = Boolean(options.headless);
     const runChecks = Boolean(options.runChecks);
-
-    ui.hero({
-      label: 'OpenMeta Analyze',
-      title: 'Find a contribution path even when the issue tracker is quiet',
-      subtitle: 'OpenMeta will inspect the repository, ask the model for grounded improvement ideas, and draft PR-ready artifacts for the strongest suggestion.',
-      lines: [
-        `Repository: ${repoFullName}`,
-        runChecks ? 'Detected validation commands may run during workspace preparation.' : 'This analysis will skip baseline validation commands.',
-        headless ? 'Headless mode will select the highest-scoring suggestion automatically.' : 'You can choose which suggestion should become the draft target.',
-      ],
-    });
+    const dryRun = Boolean(options.dryRun);
 
     await this.validateConfig(config);
     await this.initializeClients(config);
 
     const memory = memoryService.load(repoFullName);
-    const workspace = await ui.task({
-      title: `Preparing repository workspace for ${repoFullName}`,
-      doneMessage: 'Repository workspace prepared',
-      failedMessage: 'Repository workspace preparation failed',
-      tone: 'info',
-    }, async () => workspaceService.prepareRepositoryWorkspace(
+    const workspace = await workspaceService.prepareRepositoryWorkspace(
       repoFullName,
       memory,
       runChecks,
       headless ? 'headless' : 'interactive',
-    ));
+    );
 
-    this.showWorkspaceSummary(workspace);
-
-    const suggestionsResult = await ui.task({
-      title: 'Analyzing repository contribution paths',
-      doneMessage: 'Repository suggestions generated',
-      failedMessage: 'Repository analysis failed',
-      tone: 'info',
-    }, async () => llmService.analyzeRepository(repoFullName, workspace, memory));
+    const suggestionsResult = await llmService.analyzeRepository(repoFullName, workspace, memory);
     const suggestions = suggestionsResult.data;
-    if (suggestions.length === 0) {
-      ui.emptyState(
-        'OpenMeta Analyze',
-        'No repository suggestions generated',
-        'The model did not find a grounded contribution path from the current repository context.',
-      );
-      return;
-    }
-
-    this.showSuggestions(suggestions);
     const selectedSuggestion = headless
       ? this.selectTopSuggestion(suggestions)
       : await this.promptForSuggestion(suggestions);
     const syntheticIssue = this.buildSyntheticIssue(repoFullName, selectedSuggestion);
 
-    const patchDraftResult = await ui.task({
-      title: 'Generating patch strategy for selected suggestion',
-      doneMessage: 'Patch strategy generated',
-      failedMessage: 'Patch strategy generation failed',
-      tone: 'info',
-    }, async () => llmService.generatePatchDraft(syntheticIssue, workspace, memory));
+    const patchDraftResult = await llmService.generatePatchDraft(syntheticIssue, workspace, memory);
     const patchDraft = patchDraftResult.data;
-
-    const prDraftResult = await ui.task({
-      title: 'Generating PR narrative',
-      doneMessage: 'PR narrative generated',
-      failedMessage: 'PR narrative generation failed',
-      tone: 'info',
-    }, async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspace));
+    const prDraftResult = await llmService.generatePrDraft(syntheticIssue, patchDraft, workspace);
     const prDraft = prDraftResult.data;
 
     const artifacts = this.prepareArtifactPaths(repoFullName, selectedSuggestion.id);
@@ -131,7 +95,59 @@ export class AnalyzeOrchestrator {
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
     const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
 
-    if (options.dryRun) {
+    if (!dryRun) {
+      this.writeLocalArtifacts({
+        artifacts,
+        analysisMarkdown,
+        patchDraftMarkdown,
+        prDraftMarkdown,
+      });
+    }
+
+    return {
+      repoFullName,
+      workspace,
+      selectedSuggestion,
+      suggestions,
+      patchDraft,
+      prDraft,
+      artifacts,
+      mode: {
+        headless,
+        runChecks,
+        dryRun,
+      },
+    };
+  }
+
+  async run(options: AnalyzeRunOptions = {}): Promise<void> {
+    const result = await this.runMachine(options);
+    const { repoFullName, mode, workspace, suggestions, selectedSuggestion, patchDraft, prDraft, artifacts } = result;
+
+    ui.hero({
+      label: 'OpenMeta Analyze',
+      title: 'Find a contribution path even when the issue tracker is quiet',
+      subtitle: 'OpenMeta will inspect the repository, ask the model for grounded improvement ideas, and draft PR-ready artifacts for the strongest suggestion.',
+      lines: [
+        `Repository: ${repoFullName}`,
+        mode.runChecks ? 'Detected validation commands may run during workspace preparation.' : 'This analysis will skip baseline validation commands.',
+        mode.headless ? 'Headless mode will select the highest-scoring suggestion automatically.' : 'You can choose which suggestion should become the draft target.',
+      ],
+    });
+
+    this.showWorkspaceSummary(workspace);
+    if (suggestions.length === 0) {
+      ui.emptyState(
+        'OpenMeta Analyze',
+        'No repository suggestions generated',
+        'The model did not find a grounded contribution path from the current repository context.',
+      );
+      return;
+    }
+
+    this.showSuggestions(suggestions);
+
+    if (mode.dryRun) {
       ui.callout({
         label: 'OpenMeta Analyze',
         title: 'Dry-run artifact preview',
@@ -143,26 +159,13 @@ export class AnalyzeOrchestrator {
         ],
         tone: 'info',
       });
-    } else {
-      await ui.task({
-        title: 'Writing repository analysis artifacts',
-        doneMessage: 'Repository analysis artifacts written',
-        failedMessage: 'Repository analysis artifact write failed',
-        tone: 'info',
-      }, async () => {
-        this.writeLocalArtifacts({
-          artifacts,
-          analysisMarkdown,
-          patchDraftMarkdown,
-          prDraftMarkdown,
-        });
-      });
     }
 
     this.showResult({
       repoFullName,
       workspace,
       selectedSuggestion,
+      suggestions,
       patchDraft,
       prDraft,
       artifacts,

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -3,6 +3,36 @@ import { schedulerService, SCORING_PRESETS, getPreset, normalizeWeights, normali
 import type { AppConfig, ScoringWeights, OverallWeights } from '../types/index.js';
 
 export class ConfigOrchestrator {
+  async setMachineValue(key: string, value: string): Promise<{
+    updatedKey: string;
+    appliedValue: string;
+    snapshot: Awaited<ReturnType<ConfigOrchestrator['getMachineSnapshot']>>;
+    scheduler: {
+      status: 'unchanged' | 'synced' | 'failed';
+      detail: string;
+    };
+  }> {
+    const updated = await this.applyConfigValue(key, value);
+    const syncResult = key.startsWith('automation.')
+      ? await schedulerService.sync(updated)
+      : null;
+
+    return {
+      updatedKey: key,
+      appliedValue: this.describeUpdatedValue(key, updated),
+      snapshot: await this.getMachineSnapshot(),
+      scheduler: syncResult
+        ? {
+          status: syncResult.status === 'failed' ? 'failed' : 'synced',
+          detail: syncResult.detail,
+        }
+        : {
+          status: 'unchanged',
+          detail: 'Scheduler state unchanged.',
+        },
+    };
+  }
+
   async getMachineSnapshot(): Promise<{
     userProfile: AppConfig['userProfile'];
     github: { username: string; pat: string; targetRepoPath?: string };
@@ -18,6 +48,7 @@ export class ConfigOrchestrator {
       savedProfiles: string[];
     };
     automation: AppConfig['automation'];
+    scoring: AppConfig['scoring'];
     commitTemplate: string;
   }> {
     const config = await configService.get();
@@ -41,6 +72,7 @@ export class ConfigOrchestrator {
         savedProfiles: Object.keys(config.llm.profiles ?? {}).sort(),
       },
       automation: config.automation,
+      scoring: config.scoring,
       commitTemplate: config.commitTemplate,
     };
   }
@@ -152,141 +184,7 @@ export class ConfigOrchestrator {
   }
 
   async set(key: string, value: string): Promise<void> {
-    const config = await configService.get();
-    const validPaths = ['userProfile.techStack', 'userProfile.proficiency', 'userProfile.focusAreas',
-                       'github.username', 'github.pat', 'github.targetRepoPath', 'llm.provider', 'llm.apiBaseUrl', 'llm.apiKey', 'llm.modelName', 'llm.reasoningEffort', 'llm.stream',
-                       'automation.enabled', 'automation.scheduleTime', 'automation.contentType',
-                       'automation.minMatchScore', 'automation.skipIfAlreadyGeneratedToday',
-                       'scoring.weights.freshness', 'scoring.weights.onboardingClarity',
-                       'scoring.weights.mergePotential', 'scoring.weights.impact', 'scoring.weights.riskPenalty',
-                       'scoring.overallWeights.technicalMatch', 'scoring.overallWeights.opportunityScore',
-                       'scoring.preset',
-                       'commitTemplate'];
-
-    if (!validPaths.includes(key)) {
-      ui.callout({
-        label: 'OpenMeta Config',
-        title: 'Unknown configuration key',
-        subtitle: `OpenMeta does not recognize "${key}". Use one of the supported dotted paths below.`,
-        lines: validPaths,
-        tone: 'warning',
-      });
-      return;
-    }
-
-    let updated: AppConfig;
-
-    if (key === 'userProfile.techStack') {
-      updated = await configService.update({
-        userProfile: { ...config.userProfile, techStack: value.split(',').map(s => s.trim()).filter(Boolean) }
-      });
-    } else if (key === 'userProfile.focusAreas') {
-      updated = await configService.update({
-        userProfile: { ...config.userProfile, focusAreas: value.split(',').map(s => s.trim()).filter(Boolean) }
-      });
-    } else if (key === 'userProfile.proficiency') {
-      updated = await configService.update({
-        userProfile: { ...config.userProfile, proficiency: value as 'beginner' | 'intermediate' | 'advanced' }
-      });
-    } else if (key === 'github.username') {
-      updated = await configService.update({ github: { ...config.github, username: value } });
-    } else if (key === 'github.pat') {
-      updated = await configService.update({ github: { ...config.github, pat: this.parseRequiredSecret(value, key) } });
-    } else if (key === 'github.targetRepoPath') {
-      updated = await configService.update({ github: { ...config.github, targetRepoPath: value } });
-    } else if (key === 'llm.provider') {
-      if (!['openai', 'minimax', 'moonshot', 'zhipu', 'gemini', 'claude', 'custom'].includes(value)) {
-        throw new Error('llm.provider must be "openai", "minimax", "moonshot", "zhipu", "gemini", "claude", or "custom".');
-      }
-      updated = await configService.update({ llm: { ...config.llm, provider: value as AppConfig['llm']['provider'] } });
-    } else if (key === 'llm.apiBaseUrl') {
-      updated = await configService.update({ llm: { ...config.llm, apiBaseUrl: value } });
-    } else if (key === 'llm.apiKey') {
-      updated = await configService.update({ llm: { ...config.llm, apiKey: this.parseRequiredSecret(value, key) } });
-    } else if (key === 'llm.modelName') {
-      updated = await configService.update({ llm: { ...config.llm, modelName: value } });
-    } else if (key === 'llm.reasoningEffort') {
-      updated = await configService.update({ llm: { ...config.llm, reasoningEffort: parseLLMReasoningEffort(value) } });
-    } else if (key === 'llm.stream') {
-      updated = await configService.update({ llm: { ...config.llm, stream: this.parseBoolean(value, key) } });
-    } else if (key === 'automation.enabled') {
-      updated = await configService.update({
-        automation: {
-          ...config.automation,
-          enabled: this.parseBoolean(value, key),
-        },
-      });
-    } else if (key === 'automation.scheduleTime') {
-      if (!/^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
-        throw new Error('automation.scheduleTime must use HH:mm format.');
-      }
-      updated = await configService.update({
-        automation: {
-          ...config.automation,
-          scheduleTime: value,
-        },
-      });
-    } else if (key === 'automation.contentType') {
-      if (value !== 'research_note' && value !== 'development_diary') {
-        throw new Error('automation.contentType must be "research_note" or "development_diary".');
-      }
-      updated = await configService.update({
-        automation: {
-          ...config.automation,
-          contentType: value,
-        },
-      });
-    } else if (key === 'automation.minMatchScore') {
-      const minMatchScore = Number.parseInt(value, 10);
-      if (Number.isNaN(minMatchScore) || minMatchScore < 0 || minMatchScore > 100) {
-        throw new Error('automation.minMatchScore must be an integer between 0 and 100.');
-      }
-      updated = await configService.update({
-        automation: {
-          ...config.automation,
-          minMatchScore,
-        },
-      });
-    } else if (key === 'automation.skipIfAlreadyGeneratedToday') {
-      updated = await configService.update({
-        automation: {
-          ...config.automation,
-          skipIfAlreadyGeneratedToday: this.parseBoolean(value, key),
-        },
-      });
-    } else if (key.startsWith('scoring.weights.')) {
-      const weightKey = key.replace('scoring.weights.', '') as keyof ScoringWeights;
-      const numValue = Number.parseFloat(value);
-      if (Number.isNaN(numValue) || numValue < 0 || numValue > 1) {
-        throw new Error(`${key} must be a number between 0 and 1.`);
-      }
-      const newWeights = normalizeWeights({ ...config.scoring.weights, [weightKey]: numValue });
-      updated = await configService.update({
-        scoring: { ...config.scoring, weights: newWeights, preset: 'custom' },
-      });
-    } else if (key.startsWith('scoring.overallWeights.')) {
-      const weightKey = key.replace('scoring.overallWeights.', '') as keyof OverallWeights;
-      const numValue = Number.parseFloat(value);
-      if (Number.isNaN(numValue) || numValue < 0 || numValue > 1) {
-        throw new Error(`${key} must be a number between 0 and 1.`);
-      }
-      const newWeights = normalizeOverallWeights({ ...config.scoring.overallWeights, [weightKey]: numValue });
-      updated = await configService.update({
-        scoring: { ...config.scoring, overallWeights: newWeights, preset: 'custom' },
-      });
-    } else if (key === 'scoring.preset') {
-      const preset = getPreset(value);
-      if (!preset) {
-        throw new Error(`Unknown scoring preset "${value}". Available: ${SCORING_PRESETS.map(p => p.name).join(', ')}`);
-      }
-      updated = await configService.update({
-        scoring: { weights: preset.weights, overallWeights: preset.overallWeights, preset: preset.name },
-      });
-    } else if (key === 'commitTemplate') {
-      updated = await configService.update({ commitTemplate: value });
-    } else {
-      return;
-    }
+    const updated = await this.applyConfigValue(key, value);
 
     let schedulerDetail = 'Scheduler state unchanged.';
     let resultTone: 'success' | 'warning' = 'success';
@@ -497,6 +395,175 @@ export class ConfigOrchestrator {
       throw new Error(`${key} cannot be empty.`);
     }
     return trimmed;
+  }
+
+  private async applyConfigValue(key: string, value: string): Promise<AppConfig> {
+    const config = await configService.get();
+    const validPaths = ['userProfile.techStack', 'userProfile.proficiency', 'userProfile.focusAreas',
+                       'github.username', 'github.pat', 'github.targetRepoPath', 'llm.provider', 'llm.apiBaseUrl', 'llm.apiKey', 'llm.modelName', 'llm.reasoningEffort', 'llm.stream',
+                       'automation.enabled', 'automation.scheduleTime', 'automation.contentType',
+                       'automation.minMatchScore', 'automation.skipIfAlreadyGeneratedToday',
+                       'scoring.weights.freshness', 'scoring.weights.onboardingClarity',
+                       'scoring.weights.mergePotential', 'scoring.weights.impact', 'scoring.weights.riskPenalty',
+                       'scoring.overallWeights.technicalMatch', 'scoring.overallWeights.opportunityScore',
+                       'scoring.preset',
+                       'commitTemplate'];
+
+    if (!validPaths.includes(key)) {
+      throw new Error(`Unknown configuration key "${key}".`);
+    }
+
+    if (key === 'userProfile.techStack') {
+      return configService.update({
+        userProfile: { ...config.userProfile, techStack: value.split(',').map((item) => item.trim()).filter(Boolean) }
+      });
+    }
+
+    if (key === 'userProfile.focusAreas') {
+      return configService.update({
+        userProfile: { ...config.userProfile, focusAreas: value.split(',').map((item) => item.trim()).filter(Boolean) }
+      });
+    }
+
+    if (key === 'userProfile.proficiency') {
+      return configService.update({
+        userProfile: { ...config.userProfile, proficiency: value as 'beginner' | 'intermediate' | 'advanced' }
+      });
+    }
+
+    if (key === 'github.username') {
+      return configService.update({ github: { ...config.github, username: value } });
+    }
+
+    if (key === 'github.pat') {
+      return configService.update({ github: { ...config.github, pat: this.parseRequiredSecret(value, key) } });
+    }
+
+    if (key === 'github.targetRepoPath') {
+      return configService.update({ github: { ...config.github, targetRepoPath: value } });
+    }
+
+    if (key === 'llm.provider') {
+      if (!['openai', 'minimax', 'moonshot', 'zhipu', 'gemini', 'claude', 'custom'].includes(value)) {
+        throw new Error('llm.provider must be "openai", "minimax", "moonshot", "zhipu", "gemini", "claude", or "custom".');
+      }
+      return configService.update({ llm: { ...config.llm, provider: value as AppConfig['llm']['provider'] } });
+    }
+
+    if (key === 'llm.apiBaseUrl') {
+      return configService.update({ llm: { ...config.llm, apiBaseUrl: value } });
+    }
+
+    if (key === 'llm.apiKey') {
+      return configService.update({ llm: { ...config.llm, apiKey: this.parseRequiredSecret(value, key) } });
+    }
+
+    if (key === 'llm.modelName') {
+      return configService.update({ llm: { ...config.llm, modelName: value } });
+    }
+
+    if (key === 'llm.reasoningEffort') {
+      return configService.update({ llm: { ...config.llm, reasoningEffort: parseLLMReasoningEffort(value) } });
+    }
+
+    if (key === 'llm.stream') {
+      return configService.update({ llm: { ...config.llm, stream: this.parseBoolean(value, key) } });
+    }
+
+    if (key === 'automation.enabled') {
+      return configService.update({
+        automation: {
+          ...config.automation,
+          enabled: this.parseBoolean(value, key),
+        },
+      });
+    }
+
+    if (key === 'automation.scheduleTime') {
+      if (!/^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
+        throw new Error('automation.scheduleTime must use HH:mm format.');
+      }
+      return configService.update({
+        automation: {
+          ...config.automation,
+          scheduleTime: value,
+        },
+      });
+    }
+
+    if (key === 'automation.contentType') {
+      if (value !== 'research_note' && value !== 'development_diary') {
+        throw new Error('automation.contentType must be "research_note" or "development_diary".');
+      }
+      return configService.update({
+        automation: {
+          ...config.automation,
+          contentType: value,
+        },
+      });
+    }
+
+    if (key === 'automation.minMatchScore') {
+      const minMatchScore = Number.parseInt(value, 10);
+      if (Number.isNaN(minMatchScore) || minMatchScore < 0 || minMatchScore > 100) {
+        throw new Error('automation.minMatchScore must be an integer between 0 and 100.');
+      }
+      return configService.update({
+        automation: {
+          ...config.automation,
+          minMatchScore,
+        },
+      });
+    }
+
+    if (key === 'automation.skipIfAlreadyGeneratedToday') {
+      return configService.update({
+        automation: {
+          ...config.automation,
+          skipIfAlreadyGeneratedToday: this.parseBoolean(value, key),
+        },
+      });
+    }
+
+    if (key.startsWith('scoring.weights.')) {
+      const weightKey = key.replace('scoring.weights.', '') as keyof ScoringWeights;
+      const numValue = Number.parseFloat(value);
+      if (Number.isNaN(numValue) || numValue < 0 || numValue > 1) {
+        throw new Error(`${key} must be a number between 0 and 1.`);
+      }
+      const newWeights = normalizeWeights({ ...config.scoring.weights, [weightKey]: numValue });
+      return configService.update({
+        scoring: { ...config.scoring, weights: newWeights, preset: 'custom' },
+      });
+    }
+
+    if (key.startsWith('scoring.overallWeights.')) {
+      const weightKey = key.replace('scoring.overallWeights.', '') as keyof OverallWeights;
+      const numValue = Number.parseFloat(value);
+      if (Number.isNaN(numValue) || numValue < 0 || numValue > 1) {
+        throw new Error(`${key} must be a number between 0 and 1.`);
+      }
+      const newWeights = normalizeOverallWeights({ ...config.scoring.overallWeights, [weightKey]: numValue });
+      return configService.update({
+        scoring: { ...config.scoring, overallWeights: newWeights, preset: 'custom' },
+      });
+    }
+
+    if (key === 'scoring.preset') {
+      const preset = getPreset(value);
+      if (!preset) {
+        throw new Error(`Unknown scoring preset "${value}". Available: ${SCORING_PRESETS.map((p) => p.name).join(', ')}`);
+      }
+      return configService.update({
+        scoring: { weights: preset.weights, overallWeights: preset.overallWeights, preset: preset.name },
+      });
+    }
+
+    if (key === 'commitTemplate') {
+      return configService.update({ commitTemplate: value });
+    }
+
+    throw new Error(`Unknown configuration key "${key}".`);
   }
 
   private describeUpdatedValue(key: string, config: AppConfig): string {

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -3,6 +3,48 @@ import { schedulerService, SCORING_PRESETS, getPreset, normalizeWeights, normali
 import type { AppConfig, ScoringWeights, OverallWeights } from '../types/index.js';
 
 export class ConfigOrchestrator {
+  async getMachineSnapshot(): Promise<{
+    userProfile: AppConfig['userProfile'];
+    github: { username: string; pat: string; targetRepoPath?: string };
+    llm: {
+      provider: AppConfig['llm']['provider'];
+      apiBaseUrl: string;
+      apiKey: string;
+      modelName: string;
+      apiHeaders: Record<string, string>;
+      reasoningEffort?: AppConfig['llm']['reasoningEffort'];
+      stream?: boolean;
+      activeProfile?: string;
+      savedProfiles: string[];
+    };
+    automation: AppConfig['automation'];
+    commitTemplate: string;
+  }> {
+    const config = await configService.get();
+
+    return {
+      userProfile: config.userProfile,
+      github: {
+        username: config.github.username,
+        pat: ui.maskSecret(config.github.pat),
+        targetRepoPath: config.github.targetRepoPath,
+      },
+      llm: {
+        provider: config.llm.provider,
+        apiBaseUrl: config.llm.apiBaseUrl,
+        apiKey: ui.maskSecret(config.llm.apiKey),
+        modelName: config.llm.modelName,
+        apiHeaders: config.llm.apiHeaders ?? {},
+        reasoningEffort: config.llm.reasoningEffort,
+        stream: config.llm.stream,
+        activeProfile: config.llm.activeProfile,
+        savedProfiles: Object.keys(config.llm.profiles ?? {}).sort(),
+      },
+      automation: config.automation,
+      commitTemplate: config.commitTemplate,
+    };
+  }
+
   async view(): Promise<void> {
     const config = await configService.get();
     const missingRequired = [

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -7,3 +7,4 @@ export { providerOrchestrator, ProviderOrchestrator } from './provider.js';
 export { automationOrchestrator, AutomationOrchestrator } from './automation.js';
 export { doctorOrchestrator, DoctorOrchestrator } from './doctor.js';
 export { runsOrchestrator, RunsOrchestrator } from './runs.js';
+export * from './machine/index.js';

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -8,3 +8,4 @@ export { automationOrchestrator, AutomationOrchestrator } from './automation.js'
 export { doctorOrchestrator, DoctorOrchestrator } from './doctor.js';
 export { runsOrchestrator, RunsOrchestrator } from './runs.js';
 export * from './machine/index.js';
+export * from './skill/index.js';

--- a/src/orchestration/machine/agent.ts
+++ b/src/orchestration/machine/agent.ts
@@ -1,4 +1,5 @@
 import { agentOrchestrator } from '../index.js';
+import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
 import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
 
@@ -13,15 +14,15 @@ export class MachineAgentFlowOrchestrator {
     dryRun?: boolean;
   } = {}): Promise<void> {
     try {
-      const result = await agentOrchestrator.runMachine({
-        headless: options.headless,
+      const result = await runInMachineContext(() => agentOrchestrator.runMachine({
+        headless: options.headless ?? true,
         runChecks: options.runChecks,
         draftOnly: options.draftOnly,
         refresh: options.refresh,
         repo: options.repo,
         issue: options.issue,
         dryRun: options.dryRun,
-      });
+      }));
       writeMachinePayload(buildMachineEnvelope('machine agent', result));
     } catch (error) {
       const mapped = mapMachineError('machine agent', error);

--- a/src/orchestration/machine/agent.ts
+++ b/src/orchestration/machine/agent.ts
@@ -1,0 +1,34 @@
+import { agentOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineAgentFlowOrchestrator {
+  async execute(options: {
+    headless?: boolean;
+    runChecks?: boolean;
+    draftOnly?: boolean;
+    refresh?: boolean;
+    repo?: string;
+    issue?: string;
+    dryRun?: boolean;
+  } = {}): Promise<void> {
+    try {
+      const result = await agentOrchestrator.runMachine({
+        headless: options.headless,
+        runChecks: options.runChecks,
+        draftOnly: options.draftOnly,
+        refresh: options.refresh,
+        repo: options.repo,
+        issue: options.issue,
+        dryRun: options.dryRun,
+      });
+      writeMachinePayload(buildMachineEnvelope('machine agent', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine agent', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineAgentFlowOrchestrator = new MachineAgentFlowOrchestrator();

--- a/src/orchestration/machine/analyze.ts
+++ b/src/orchestration/machine/analyze.ts
@@ -1,4 +1,5 @@
 import { analyzeOrchestrator } from '../index.js';
+import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
 import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
 
@@ -10,12 +11,12 @@ export class MachineAnalyzeOrchestrator {
     dryRun?: boolean;
   } = {}): Promise<void> {
     try {
-      const result = await analyzeOrchestrator.runMachine({
+      const result = await runInMachineContext(() => analyzeOrchestrator.runMachine({
         repo: options.repo,
-        headless: options.headless,
+        headless: options.headless ?? true,
         runChecks: options.runChecks,
         dryRun: options.dryRun,
-      });
+      }));
       writeMachinePayload(buildMachineEnvelope('machine analyze', result));
     } catch (error) {
       const mapped = mapMachineError('machine analyze', error);

--- a/src/orchestration/machine/analyze.ts
+++ b/src/orchestration/machine/analyze.ts
@@ -1,0 +1,28 @@
+import { analyzeOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineAnalyzeOrchestrator {
+  async execute(options: {
+    repo?: string;
+    headless?: boolean;
+    runChecks?: boolean;
+    dryRun?: boolean;
+  } = {}): Promise<void> {
+    try {
+      const result = await analyzeOrchestrator.runMachine({
+        repo: options.repo,
+        headless: options.headless,
+        runChecks: options.runChecks,
+        dryRun: options.dryRun,
+      });
+      writeMachinePayload(buildMachineEnvelope('machine analyze', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine analyze', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineAnalyzeOrchestrator = new MachineAnalyzeOrchestrator();

--- a/src/orchestration/machine/config.ts
+++ b/src/orchestration/machine/config.ts
@@ -13,6 +13,17 @@ export class MachineConfigOrchestrator {
       process.exitCode = mapped.exitCode;
     }
   }
+
+  async set(key: string, value: string): Promise<void> {
+    try {
+      const result = await configOrchestrator.setMachineValue(key, value);
+      writeMachinePayload(buildMachineEnvelope('machine config set', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine config set', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
 }
 
 export const machineConfigOrchestrator = new MachineConfigOrchestrator();

--- a/src/orchestration/machine/config.ts
+++ b/src/orchestration/machine/config.ts
@@ -1,0 +1,18 @@
+import { configOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineConfigOrchestrator {
+  async get(): Promise<void> {
+    try {
+      const snapshot = await configOrchestrator.getMachineSnapshot();
+      writeMachinePayload(buildMachineEnvelope('machine config get', snapshot));
+    } catch (error) {
+      const mapped = mapMachineError('machine config get', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineConfigOrchestrator = new MachineConfigOrchestrator();

--- a/src/orchestration/machine/doctor.ts
+++ b/src/orchestration/machine/doctor.ts
@@ -1,0 +1,21 @@
+import { doctorOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineDoctorOrchestrator {
+  async execute(): Promise<void> {
+    try {
+      const report = await doctorOrchestrator.inspect();
+      writeMachinePayload(buildMachineEnvelope('machine doctor', {
+        ...report,
+        nextActions: report.ready ? [] : ['run_machine_config_set'],
+      }));
+    } catch (error) {
+      const mapped = mapMachineError('machine doctor', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineDoctorOrchestrator = new MachineDoctorOrchestrator();

--- a/src/orchestration/machine/errors.ts
+++ b/src/orchestration/machine/errors.ts
@@ -1,0 +1,36 @@
+import { getErrorMessage } from '../../infra/index.js';
+import { buildMachineErrorEnvelope } from './runtime.js';
+import type { MachineErrorEnvelope } from './types.js';
+
+export function mapMachineError(command: string, error: unknown): {
+  exitCode: number;
+  payload: MachineErrorEnvelope;
+} {
+  const message = getErrorMessage(error);
+
+  if (/must be|is required|does not exist|unknown configuration key|requires --repo|run not found/i.test(message)) {
+    return {
+      exitCode: 2,
+      payload: buildMachineErrorEnvelope(command, 'INVALID_ARGUMENT', message),
+    };
+  }
+
+  if (/configuration is incomplete|run "openmeta init"|missing github|missing llm/i.test(message)) {
+    return {
+      exitCode: 3,
+      payload: buildMachineErrorEnvelope(command, 'CONFIG_MISSING', message),
+    };
+  }
+
+  if (/validation failed|access failed|connection failed/i.test(message)) {
+    return {
+      exitCode: 4,
+      payload: buildMachineErrorEnvelope(command, 'VALIDATION_FAILED', message),
+    };
+  }
+
+  return {
+    exitCode: 5,
+    payload: buildMachineErrorEnvelope(command, 'INTERNAL_ERROR', message),
+  };
+}

--- a/src/orchestration/machine/inbox.ts
+++ b/src/orchestration/machine/inbox.ts
@@ -1,0 +1,18 @@
+import { agentOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineInboxOrchestrator {
+  async execute(): Promise<void> {
+    try {
+      const result = await agentOrchestrator.getInboxMachineResult();
+      writeMachinePayload(buildMachineEnvelope('machine inbox', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine inbox', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineInboxOrchestrator = new MachineInboxOrchestrator();

--- a/src/orchestration/machine/index.ts
+++ b/src/orchestration/machine/index.ts
@@ -1,0 +1,9 @@
+export * from './types.js';
+export * from './runtime.js';
+export * from './errors.js';
+export { machineDoctorOrchestrator, MachineDoctorOrchestrator } from './doctor.js';
+export { machineConfigOrchestrator, MachineConfigOrchestrator } from './config.js';
+export { machineProviderOrchestrator, MachineProviderOrchestrator } from './provider.js';
+export { machineRunsOrchestrator, MachineRunsOrchestrator } from './runs.js';
+export { machineInboxOrchestrator, MachineInboxOrchestrator } from './inbox.js';
+export { machineProofOfWorkOrchestrator, MachineProofOfWorkOrchestrator } from './pow.js';

--- a/src/orchestration/machine/index.ts
+++ b/src/orchestration/machine/index.ts
@@ -7,3 +7,6 @@ export { machineProviderOrchestrator, MachineProviderOrchestrator } from './prov
 export { machineRunsOrchestrator, MachineRunsOrchestrator } from './runs.js';
 export { machineInboxOrchestrator, MachineInboxOrchestrator } from './inbox.js';
 export { machineProofOfWorkOrchestrator, MachineProofOfWorkOrchestrator } from './pow.js';
+export { machineScoutOrchestrator, MachineScoutOrchestrator } from './scout.js';
+export { machineAnalyzeOrchestrator, MachineAnalyzeOrchestrator } from './analyze.js';
+export { machineAgentFlowOrchestrator, MachineAgentFlowOrchestrator } from './agent.js';

--- a/src/orchestration/machine/pow.ts
+++ b/src/orchestration/machine/pow.ts
@@ -1,0 +1,18 @@
+import { agentOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineProofOfWorkOrchestrator {
+  async execute(): Promise<void> {
+    try {
+      const result = await agentOrchestrator.getProofOfWorkMachineResult();
+      writeMachinePayload(buildMachineEnvelope('machine pow', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine pow', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineProofOfWorkOrchestrator = new MachineProofOfWorkOrchestrator();

--- a/src/orchestration/machine/provider.ts
+++ b/src/orchestration/machine/provider.ts
@@ -3,6 +3,25 @@ import { mapMachineError } from './errors.js';
 import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
 
 export class MachineProviderOrchestrator {
+  async add(name: string, options: {
+    provider?: string;
+    baseUrl?: string;
+    model?: string;
+    apiKey?: string;
+    reasoningEffort?: string;
+    stream?: string;
+    header?: string[];
+  }): Promise<void> {
+    try {
+      const result = await providerOrchestrator.addProfile(name, options);
+      writeMachinePayload(buildMachineEnvelope('machine provider add', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine provider add', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+
   async use(name: string): Promise<void> {
     try {
       const result = await providerOrchestrator.useProfile(name);

--- a/src/orchestration/machine/provider.ts
+++ b/src/orchestration/machine/provider.ts
@@ -1,0 +1,18 @@
+import { providerOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineProviderOrchestrator {
+  async use(name: string): Promise<void> {
+    try {
+      const result = await providerOrchestrator.useProfile(name);
+      writeMachinePayload(buildMachineEnvelope('machine provider use', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine provider use', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineProviderOrchestrator = new MachineProviderOrchestrator();

--- a/src/orchestration/machine/runs.ts
+++ b/src/orchestration/machine/runs.ts
@@ -1,0 +1,26 @@
+import { runsOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineRunsOrchestrator {
+  async show(id: string | undefined, options: { limit?: string } = {}): Promise<void> {
+    try {
+      if (id) {
+        const result = await runsOrchestrator.showMachine(id);
+        writeMachinePayload(buildMachineEnvelope('machine runs', result));
+        return;
+      }
+
+      const result = await runsOrchestrator.listMachine({
+        limit: Number.parseInt(options.limit || '10', 10) || 10,
+      });
+      writeMachinePayload(buildMachineEnvelope('machine runs', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine runs', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineRunsOrchestrator = new MachineRunsOrchestrator();

--- a/src/orchestration/machine/runtime.ts
+++ b/src/orchestration/machine/runtime.ts
@@ -1,0 +1,36 @@
+import type { MachineEnvelope, MachineErrorCode, MachineErrorEnvelope } from './types.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export function buildMachineEnvelope<T>(command: string, data: T): MachineEnvelope<T> {
+  return {
+    version: 1,
+    command,
+    timestamp: now(),
+    data,
+  };
+}
+
+export function buildMachineErrorEnvelope(
+  command: string,
+  code: MachineErrorCode,
+  message: string,
+  details?: unknown,
+): MachineErrorEnvelope {
+  return {
+    version: 1,
+    command,
+    timestamp: now(),
+    error: {
+      code,
+      message,
+      ...(details === undefined ? {} : { details }),
+    },
+  };
+}
+
+export function writeMachinePayload(payload: MachineEnvelope<unknown> | MachineErrorEnvelope): void {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}

--- a/src/orchestration/machine/scout.ts
+++ b/src/orchestration/machine/scout.ts
@@ -1,4 +1,5 @@
 import { agentOrchestrator } from '../index.js';
+import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
 import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
 
@@ -10,12 +11,12 @@ export class MachineScoutOrchestrator {
     local?: boolean;
   } = {}): Promise<void> {
     try {
-      const result = await agentOrchestrator.scoutMachine({
+      const result = await runInMachineContext(() => agentOrchestrator.scoutMachine({
         limit: Number.parseInt(options.limit || '10', 10) || 10,
         refresh: options.refresh,
         repo: options.repo,
         localOnly: options.local,
-      });
+      }));
       writeMachinePayload(buildMachineEnvelope('machine scout', result));
     } catch (error) {
       const mapped = mapMachineError('machine scout', error);

--- a/src/orchestration/machine/scout.ts
+++ b/src/orchestration/machine/scout.ts
@@ -1,0 +1,28 @@
+import { agentOrchestrator } from '../index.js';
+import { mapMachineError } from './errors.js';
+import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+
+export class MachineScoutOrchestrator {
+  async execute(options: {
+    limit?: string;
+    refresh?: boolean;
+    repo?: string;
+    local?: boolean;
+  } = {}): Promise<void> {
+    try {
+      const result = await agentOrchestrator.scoutMachine({
+        limit: Number.parseInt(options.limit || '10', 10) || 10,
+        refresh: options.refresh,
+        repo: options.repo,
+        localOnly: options.local,
+      });
+      writeMachinePayload(buildMachineEnvelope('machine scout', result));
+    } catch (error) {
+      const mapped = mapMachineError('machine scout', error);
+      writeMachinePayload(mapped.payload);
+      process.exitCode = mapped.exitCode;
+    }
+  }
+}
+
+export const machineScoutOrchestrator = new MachineScoutOrchestrator();

--- a/src/orchestration/machine/types.ts
+++ b/src/orchestration/machine/types.ts
@@ -1,0 +1,32 @@
+export type MachineErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'CONFIG_MISSING'
+  | 'CONFIG_INVALID'
+  | 'GITHUB_AUTH_FAILED'
+  | 'LLM_AUTH_FAILED'
+  | 'REPO_PREP_FAILED'
+  | 'VALIDATION_FAILED'
+  | 'DIRTY_WORKSPACE'
+  | 'PR_CREATION_SKIPPED'
+  | 'PR_CREATION_FAILED'
+  | 'SKILL_HOST_UNSUPPORTED'
+  | 'SKILL_INSTALL_FAILED'
+  | 'INTERNAL_ERROR';
+
+export interface MachineEnvelope<T> {
+  version: 1;
+  command: string;
+  timestamp: string;
+  data: T;
+}
+
+export interface MachineErrorEnvelope {
+  version: 1;
+  command: string;
+  timestamp: string;
+  error: {
+    code: MachineErrorCode;
+    message: string;
+    details?: unknown;
+  };
+}

--- a/src/orchestration/provider.ts
+++ b/src/orchestration/provider.ts
@@ -18,6 +18,20 @@ interface ProviderUseOptions {
   validate?: boolean;
 }
 
+interface ProviderUseResult {
+  profileName: string;
+  activeProfile: string;
+  provider: LLMProvider;
+  modelName: string;
+  apiBaseUrl: string;
+  apiKey: string;
+  apiHeaders: Record<string, string>;
+  reasoningEffort?: LLMReasoningEffort;
+  stream?: boolean;
+  validation: 'skipped' | 'passed' | 'failed';
+  validationMessage: string;
+}
+
 function parseHeaders(values: string[] = []): Record<string, string> {
   const headers: Record<string, string> = {};
 
@@ -354,6 +368,27 @@ export class ProviderOrchestrator {
   }
 
   async use(nameInput: string, options: ProviderUseOptions = {}): Promise<void> {
+    const result = await this.useProfile(nameInput, options);
+    const tone: 'success' | 'warning' = result.validation === 'failed' ? 'warning' : 'success';
+
+    ui.card({
+      label: 'OpenMeta Provider',
+      title: 'Active provider switched',
+      subtitle: 'OpenMeta will use this LLM backend for the next agent or scout run.',
+      lines: [
+        `Profile: ${result.profileName}`,
+        `Provider: ${result.provider}`,
+        `Model: ${result.modelName}`,
+        `Reasoning effort: ${result.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
+        `Streaming: ${result.stream ? 'yes' : 'no'}`,
+        `Endpoint: ${result.apiBaseUrl}`,
+        result.validationMessage,
+      ],
+      tone,
+    });
+  }
+
+  async useProfile(nameInput: string, options: ProviderUseOptions = {}): Promise<ProviderUseResult> {
     const name = this.normalizeProfileName(nameInput);
     const config = await configService.get();
     const profile = config.llm.profiles?.[name];
@@ -373,31 +408,29 @@ export class ProviderOrchestrator {
       },
     });
 
-    let validationDetail = 'Validation skipped.';
-    let tone: 'success' | 'warning' = 'success';
+    let validation: 'skipped' | 'passed' | 'failed' = 'skipped';
+    let validationMessage = 'Validation skipped.';
     if (options.validate) {
       const valid = await this.validateProfile(profile);
-      validationDetail = valid
+      validation = valid ? 'passed' : 'failed';
+      validationMessage = valid
         ? 'Provider validation succeeded.'
         : `Provider validation failed: ${llmService.getLastValidationError() || 'unknown reason'}`;
-      tone = valid ? 'success' : 'warning';
     }
 
-    ui.card({
-      label: 'OpenMeta Provider',
-      title: 'Active provider switched',
-      subtitle: 'OpenMeta will use this LLM backend for the next agent or scout run.',
-      lines: [
-        `Profile: ${name}`,
-        `Provider: ${updated.llm.provider}`,
-        `Model: ${updated.llm.modelName}`,
-        `Reasoning effort: ${updated.llm.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
-        `Streaming: ${updated.llm.stream ? 'yes' : 'no'}`,
-        `Endpoint: ${updated.llm.apiBaseUrl}`,
-        validationDetail,
-      ],
-      tone,
-    });
+    return {
+      profileName: name,
+      activeProfile: updated.llm.activeProfile || '',
+      provider: updated.llm.provider,
+      modelName: updated.llm.modelName,
+      apiBaseUrl: updated.llm.apiBaseUrl,
+      apiKey: ui.maskSecret(updated.llm.apiKey),
+      apiHeaders: updated.llm.apiHeaders ?? {},
+      reasoningEffort: updated.llm.reasoningEffort,
+      stream: updated.llm.stream,
+      validation,
+      validationMessage,
+    };
   }
 
   async remove(nameInput: string): Promise<void> {

--- a/src/orchestration/provider.ts
+++ b/src/orchestration/provider.ts
@@ -98,6 +98,37 @@ function parseBooleanOption(value: string | undefined, label: string): boolean {
 }
 
 export class ProviderOrchestrator {
+  async addProfile(nameInput: string, options: ProviderAddOptions): Promise<ProviderUseResult> {
+    const name = this.normalizeProfileName(nameInput);
+    const config = await configService.get();
+    const profile: LLMProviderProfile = {
+      provider: parseProvider(options.provider),
+      apiBaseUrl: requireValue(options.baseUrl, 'base URL'),
+      modelName: requireValue(options.model, 'model'),
+      apiKey: requireValue(options.apiKey, 'API key'),
+      apiHeaders: parseHeaders(options.header?.filter(Boolean) ?? []),
+      reasoningEffort: options.reasoningEffort
+        ? parseLLMReasoningEffort(options.reasoningEffort)
+        : DEFAULT_LLM_REASONING_EFFORT,
+      stream: parseBooleanOption(options.stream, 'stream'),
+    };
+    const updated = await this.saveProfile(config, name, profile, config.llm.activeProfile);
+
+    return {
+      profileName: name,
+      activeProfile: updated.llm.activeProfile || '',
+      provider: profile.provider,
+      modelName: profile.modelName,
+      apiBaseUrl: profile.apiBaseUrl,
+      apiKey: ui.maskSecret(profile.apiKey),
+      apiHeaders: profile.apiHeaders ?? {},
+      reasoningEffort: profile.reasoningEffort,
+      stream: profile.stream,
+      validation: 'skipped',
+      validationMessage: 'Validation skipped.',
+    };
+  }
+
   async list(): Promise<void> {
     const config = await configService.get();
     const profiles = config.llm.profiles || {};
@@ -164,33 +195,20 @@ export class ProviderOrchestrator {
   }
 
   async add(nameInput: string, options: ProviderAddOptions): Promise<void> {
-    const name = this.normalizeProfileName(nameInput);
-    const config = await configService.get();
-    const profile: LLMProviderProfile = {
-      provider: parseProvider(options.provider),
-      apiBaseUrl: requireValue(options.baseUrl, 'base URL'),
-      modelName: requireValue(options.model, 'model'),
-      apiKey: requireValue(options.apiKey, 'API key'),
-      apiHeaders: parseHeaders(options.header?.filter(Boolean) ?? []),
-      reasoningEffort: options.reasoningEffort
-        ? parseLLMReasoningEffort(options.reasoningEffort)
-        : DEFAULT_LLM_REASONING_EFFORT,
-      stream: parseBooleanOption(options.stream, 'stream'),
-    };
-    const updated = await this.saveProfile(config, name, profile, config.llm.activeProfile);
+    const result = await this.addProfile(nameInput, options);
 
     ui.card({
       label: 'OpenMeta Provider',
       title: 'Provider profile saved',
       subtitle: options.validate ? 'The profile was saved. Run provider use to activate and validate it.' : 'The profile is available for fast switching.',
       lines: [
-        `Profile: ${name}`,
-        `Provider: ${profile.provider}`,
-        `Model: ${profile.modelName}`,
-        `Reasoning effort: ${profile.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
-        `Streaming: ${profile.stream ? 'yes' : 'no'}`,
-        `Endpoint: ${profile.apiBaseUrl}`,
-        `Active profile: ${updated.llm.activeProfile || '(none)'}`,
+        `Profile: ${result.profileName}`,
+        `Provider: ${result.provider}`,
+        `Model: ${result.modelName}`,
+        `Reasoning effort: ${result.reasoningEffort || DEFAULT_LLM_REASONING_EFFORT}`,
+        `Streaming: ${result.stream ? 'yes' : 'no'}`,
+        `Endpoint: ${result.apiBaseUrl}`,
+        `Active profile: ${result.activeProfile || '(none)'}`,
       ],
       tone: 'success',
     });

--- a/src/orchestration/runs.ts
+++ b/src/orchestration/runs.ts
@@ -27,26 +27,56 @@ function statusTone(status: AgentRunStatus): 'success' | 'warning' | 'error' | '
 }
 
 export class RunsOrchestrator {
-  async list(options: RunsListOptions = {}): Promise<void> {
+  async listMachine(options: RunsListOptions = {}): Promise<{
+    records: ReturnType<typeof runHistoryService.load>['records'];
+    totals: Record<AgentRunStatus, number>;
+    ledgerPath: string;
+  }> {
     const limit = Math.max(1, options.limit ?? 10);
-    const records = runHistoryService.load().records.slice(0, limit);
+    const state = runHistoryService.load();
+    const records = state.records.slice(0, limit);
+    const totals = state.records.reduce<Record<AgentRunStatus, number>>((acc, record) => {
+      acc[record.status] += 1;
+      return acc;
+    }, { running: 0, success: 0, failed: 0, cancelled: 0 });
+
+    return {
+      records,
+      totals,
+      ledgerPath: runHistoryService.getPath(),
+    };
+  }
+
+  async showMachine(id: string): Promise<{
+    record: NonNullable<ReturnType<typeof runHistoryService.find>>;
+    ledgerPath: string;
+  }> {
+    const record = runHistoryService.find(id);
+
+    if (!record) {
+      throw new Error(`Run not found: ${id}`);
+    }
+
+    return {
+      record,
+      ledgerPath: runHistoryService.getPath(),
+    };
+  }
+
+  async list(options: RunsListOptions = {}): Promise<void> {
+    const { records, totals, ledgerPath } = await this.listMachine(options);
 
     if (options.json) {
       process.stdout.write(`${JSON.stringify(records, null, 2)}\n`);
       return;
     }
 
-    const totals = runHistoryService.load().records.reduce<Record<AgentRunStatus, number>>((acc, record) => {
-      acc[record.status] += 1;
-      return acc;
-    }, { running: 0, success: 0, failed: 0, cancelled: 0 });
-
     ui.hero({
       label: 'OpenMeta Runs',
       title: records.length > 0 ? 'The agent now leaves footprints you can inspect' : 'No run history has been recorded yet',
       subtitle: 'Recent command runs, durations, and failure reasons stay in a local ledger for debugging and follow-up.',
       lines: [
-        `Run history path: ${runHistoryService.getPath()}`,
+        `Run history path: ${ledgerPath}`,
         `Showing latest ${records.length} run(s).`,
       ],
       tone: records.some((record) => record.status === 'failed') ? 'warning' : 'accent',
@@ -80,11 +110,7 @@ export class RunsOrchestrator {
   }
 
   async show(id: string, options: { json?: boolean } = {}): Promise<void> {
-    const record = runHistoryService.find(id);
-
-    if (!record) {
-      throw new Error(`Run not found: ${id}`);
-    }
+    const { record, ledgerPath } = await this.showMachine(id);
 
     if (options.json) {
       process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
@@ -108,7 +134,7 @@ export class RunsOrchestrator {
       { label: 'Command', value: record.commandName, tone: 'info' },
       { label: 'Args', value: record.args.join(' ') || '(none)', tone: 'info' },
       { label: 'Error', value: record.error || '(none)', tone: record.error ? 'error' : 'muted' },
-      { label: 'Ledger', value: runHistoryService.getPath(), tone: 'muted' },
+      { label: 'Ledger', value: ledgerPath, tone: 'muted' },
     ]);
   }
 }

--- a/src/orchestration/skill/catalog.ts
+++ b/src/orchestration/skill/catalog.ts
@@ -1,8 +1,26 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-const SKILLS_ROOT = join(dirname(dirname(dirname(fileURLToPath(import.meta.url)))), '..', 'skills');
+function resolveSkillsRoot(): string {
+  const modulePath = fileURLToPath(import.meta.url);
+  const moduleDir = dirname(modulePath);
+  const candidates = [
+    join(moduleDir, '..', '..', '..', 'skills'),
+    join(moduleDir, '..', '..', '..', '..', 'skills'),
+    join(process.cwd(), 'skills'),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, 'core', 'openmeta.md'))) {
+      return candidate;
+    }
+  }
+
+  return candidates[0]!;
+}
+
+const SKILLS_ROOT = resolveSkillsRoot();
 
 export type SkillHost = 'claude-code' | 'openclaw';
 

--- a/src/orchestration/skill/catalog.ts
+++ b/src/orchestration/skill/catalog.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const SKILLS_ROOT = join(dirname(dirname(dirname(fileURLToPath(import.meta.url)))), '..', 'skills');
+
+export type SkillHost = 'claude-code' | 'openclaw';
+
+export function getSkillsRoot(): string {
+  return SKILLS_ROOT;
+}
+
+export function getSupportedSkillHosts(): SkillHost[] {
+  return ['claude-code', 'openclaw'];
+}
+
+export function loadCoreSkill(): string {
+  return readFileSync(join(SKILLS_ROOT, 'core', 'openmeta.md'), 'utf-8');
+}
+
+export function loadCapabilityCatalog(): string {
+  return readFileSync(join(SKILLS_ROOT, 'schema', 'capability-catalog.json'), 'utf-8');
+}
+
+export function loadHostTemplate(host: SkillHost): string {
+  return readFileSync(join(SKILLS_ROOT, 'templates', host, 'skill.md'), 'utf-8');
+}

--- a/src/orchestration/skill/doctor.ts
+++ b/src/orchestration/skill/doctor.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { getInstallTarget } from './installer.js';
+import type { SkillHost } from './catalog.js';
+
+export interface SkillDoctorResult {
+  host: SkillHost;
+  supported: boolean;
+  installPath?: string;
+  installPathExists: boolean;
+  openmetaOnPath: boolean;
+  nextActions: string[];
+}
+
+export async function doctorSkillBundle(host: SkillHost): Promise<SkillDoctorResult> {
+  const installPath = getInstallTarget(host);
+  const openmeta = spawnSync('openmeta', ['--version'], { encoding: 'utf-8' });
+  const installPathExists = Boolean(installPath && existsSync(installPath));
+
+  return {
+    host,
+    supported: Boolean(installPath),
+    installPath: installPath || undefined,
+    installPathExists,
+    openmetaOnPath: !openmeta.error && openmeta.status === 0,
+    nextActions: [
+      ...(installPathExists ? [] : ['run_openmeta_skill_install']),
+      ...(!openmeta.error && openmeta.status === 0 ? [] : ['ensure_openmeta_on_path']),
+    ],
+  };
+}

--- a/src/orchestration/skill/index.ts
+++ b/src/orchestration/skill/index.ts
@@ -1,0 +1,4 @@
+export { getSkillsRoot, getSupportedSkillHosts, type SkillHost } from './catalog.js';
+export { renderSkillBundle, type RenderedSkillBundle } from './renderer.js';
+export { installSkillBundle, getInstallTarget, type SkillInstallResult } from './installer.js';
+export { doctorSkillBundle, type SkillDoctorResult } from './doctor.js';

--- a/src/orchestration/skill/installer.ts
+++ b/src/orchestration/skill/installer.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { renderSkillBundle } from './renderer.js';
+import type { SkillHost } from './catalog.js';
+
+export interface SkillInstallResult {
+  host: SkillHost;
+  installed: boolean;
+  installPath?: string;
+  exportedFiles: string[];
+  manualInstructions?: string;
+}
+
+function resolveDefaultInstallPath(host: SkillHost): string | null {
+  if (host === 'claude-code') {
+    return join(homedir(), '.claude', 'skills', 'openmeta');
+  }
+
+  if (host === 'openclaw') {
+    return join(homedir(), '.openclaw', 'skills', 'openmeta');
+  }
+
+  return null;
+}
+
+export async function installSkillBundle(host: SkillHost): Promise<SkillInstallResult> {
+  const installPath = resolveDefaultInstallPath(host);
+  if (!installPath) {
+    return {
+      host,
+      installed: false,
+      exportedFiles: [],
+      manualInstructions: `Unsupported skill host: ${host}`,
+    };
+  }
+
+  mkdirSync(installPath, { recursive: true });
+  const rendered = await renderSkillBundle(host, installPath);
+
+  return {
+    host,
+    installed: existsSync(installPath),
+    installPath,
+    exportedFiles: rendered.files,
+  };
+}
+
+export function getInstallTarget(host: SkillHost): string | null {
+  return resolveDefaultInstallPath(host);
+}

--- a/src/orchestration/skill/renderer.ts
+++ b/src/orchestration/skill/renderer.ts
@@ -1,0 +1,26 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { getSkillsRoot, type SkillHost, loadCapabilityCatalog, loadCoreSkill, loadHostTemplate } from './catalog.js';
+
+export interface RenderedSkillBundle {
+  host: SkillHost;
+  files: string[];
+  sourceRoot: string;
+}
+
+export async function renderSkillBundle(host: SkillHost, outputDir: string): Promise<RenderedSkillBundle> {
+  const targetDir = join(outputDir, host);
+  mkdirSync(targetDir, { recursive: true });
+
+  const rendered = loadHostTemplate(host)
+    .replace('{{coreSkill}}', loadCoreSkill())
+    .replace('{{capabilityCatalog}}', loadCapabilityCatalog());
+  const skillPath = join(targetDir, 'skill.md');
+  writeFileSync(skillPath, rendered, 'utf-8');
+
+  return {
+    host,
+    files: [skillPath],
+    sourceRoot: getSkillsRoot(),
+  };
+}

--- a/test/config-orchestrator.test.ts
+++ b/test/config-orchestrator.test.ts
@@ -73,4 +73,18 @@ describe('ConfigOrchestrator', () => {
       'llm.stream must be a boolean value.',
     );
   });
+
+  test('returns a masked machine config snapshot', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('github.pat', 'ghp_new_secret');
+    await orchestrator.set('llm.apiKey', 'sk-new-secret');
+
+    const snapshot = await orchestrator.getMachineSnapshot();
+
+    expect(snapshot.github.pat).toBe('***cret');
+    expect(snapshot.llm.apiKey).toBe('***cret');
+    expect(snapshot.llm.modelName).toBe('gpt-4o-mini');
+    expect(snapshot.llm.savedProfiles).toEqual([]);
+  });
 });

--- a/test/config-orchestrator.test.ts
+++ b/test/config-orchestrator.test.ts
@@ -87,4 +87,15 @@ describe('ConfigOrchestrator', () => {
     expect(snapshot.llm.modelName).toBe('gpt-4o-mini');
     expect(snapshot.llm.savedProfiles).toEqual([]);
   });
+
+  test('returns machine config set results with masked secret values', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    const result = await orchestrator.setMachineValue('llm.apiKey', 'sk-machine-secret');
+
+    expect(result.updatedKey).toBe('llm.apiKey');
+    expect(result.appliedValue).toBe('***cret');
+    expect(result.snapshot.llm.apiKey).toBe('***cret');
+    expect(result.scheduler.status).toBe('unchanged');
+  });
 });

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import * as infra from '../src/infra/index.js';
+import { AgentOrchestrator } from '../src/orchestration/agent.js';
+import { AnalyzeOrchestrator } from '../src/orchestration/analyze.js';
+import { contentService, issueRankingService, llmService, memoryService, workspaceService } from '../src/services/index.js';
+import { createMemory, createPatchDraft, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
+
+function createConfig() {
+  return {
+    userProfile: {
+      techStack: ['typescript', 'react'],
+      proficiency: 'intermediate' as const,
+      focusAreas: ['frontend'],
+    },
+    github: {
+      pat: 'ghp_test_token',
+      username: 'octocat',
+    },
+    llm: {
+      provider: 'custom' as const,
+      apiBaseUrl: 'https://example.com/v1',
+      apiKey: 'sk-test',
+      modelName: 'test-model',
+      apiHeaders: {},
+    },
+    automation: {
+      enabled: true,
+      scheduleTime: '09:00',
+      timezone: 'UTC',
+      contentType: 'research_note' as const,
+      scheduler: 'manual' as const,
+      minMatchScore: 75,
+      skipIfAlreadyGeneratedToday: false,
+    },
+    commitTemplate: 'feat: {{title}}',
+  };
+}
+
+function muteUi(): void {
+  spyOn(infra.ui, 'hero').mockImplementation(() => {});
+  spyOn(infra.ui, 'stepper').mockImplementation(() => {});
+  spyOn(infra.ui, 'section').mockImplementation(() => {});
+  spyOn(infra.ui, 'recordList').mockImplementation(() => {});
+  spyOn(infra.ui, 'card').mockImplementation(() => {});
+  spyOn(infra.ui, 'stats').mockImplementation(() => {});
+  spyOn(infra.ui, 'keyValues').mockImplementation(() => {});
+  spyOn(infra.ui, 'callout').mockImplementation(() => {});
+  spyOn(infra.ui, 'emptyState').mockImplementation(() => {});
+  spyOn(infra.ui, 'banner').mockImplementation(() => {});
+  spyOn(infra.ui, 'timeline').mockImplementation(() => {});
+  spyOn(infra.ui, 'task').mockImplementation(async (_options, task) => task({
+    setMessage() {},
+  } as never));
+}
+
+beforeEach(() => {
+  muteUi();
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('machine flow result builders', () => {
+  test('machine scout returns ranked opportunities with mode metadata', async () => {
+    const config = createConfig();
+    const issue = createRankedIssue();
+    const orchestrator = new AgentOrchestrator();
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as AgentOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
+    spyOn(orchestrator as AgentOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
+    spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([issue]);
+
+    const result = await orchestrator.scoutMachine({ limit: 5, refresh: true, localOnly: true });
+
+    expect(result.mode.localOnly).toBe(true);
+    expect(result.mode.refresh).toBe(true);
+    expect(result.opportunities).toEqual([issue]);
+  });
+
+  test('machine analyze returns selected suggestion and artifact paths', async () => {
+    const config = createConfig();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-demo',
+      branchName: 'openmeta/analyze-acme-demo',
+      candidateFiles: ['README.md', 'src/index.ts'],
+    });
+    const memory = createMemory({ repoFullName: 'acme/demo' });
+    const suggestion = createRepositorySuggestion({
+      id: 'config-validation',
+      title: 'Add config validation tests',
+      summary: 'Cover malformed provider config normalization.',
+      targetFiles: [{ path: 'src/infra/config.ts', reason: 'Normalization logic' }],
+      prPotentialScore: 93,
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const orchestrator = new AnalyzeOrchestrator();
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as AnalyzeOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
+    spyOn(orchestrator as AnalyzeOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValue(memory);
+    spyOn(workspaceService, 'prepareRepositoryWorkspace').mockResolvedValue(workspace);
+    spyOn(llmService, 'analyzeRepository').mockResolvedValue({
+      version: '1',
+      kind: 'repository_suggestion_list',
+      status: 'success',
+      data: [suggestion],
+    });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatRepositoryAnalysisMarkdown').mockReturnValue('# Repository Analysis');
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+
+    const result = await orchestrator.runMachine({ repo: 'acme/demo', dryRun: true, headless: true });
+
+    expect(result.repoFullName).toBe('acme/demo');
+    expect(result.selectedSuggestion).toEqual(suggestion);
+    expect(result.artifacts.analysisPath).toContain('analysis');
+    expect(result.mode.dryRun).toBe(true);
+  });
+});

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:
 import * as infra from '../src/infra/index.js';
 import { AgentOrchestrator } from '../src/orchestration/agent.js';
 import { AnalyzeOrchestrator } from '../src/orchestration/analyze.js';
-import { contentService, issueRankingService, llmService, memoryService, workspaceService } from '../src/services/index.js';
-import { createMemory, createPatchDraft, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
+import { contentService, inboxService, issueRankingService, llmService, memoryService, proofOfWorkService, workspaceService } from '../src/services/index.js';
+import { createInboxItem, createMemory, createPatchDraft, createProofRecord, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
 
 function createConfig() {
   return {
@@ -33,6 +33,18 @@ function createConfig() {
       skipIfAlreadyGeneratedToday: false,
     },
     commitTemplate: 'feat: {{title}}',
+  };
+}
+
+function createArtifacts() {
+  return {
+    artifactDir: '/tmp/openmeta/artifacts',
+    dossierPath: '/tmp/openmeta/artifacts/dossier.md',
+    patchDraftPath: '/tmp/openmeta/artifacts/patch-draft.md',
+    prDraftPath: '/tmp/openmeta/artifacts/pr-draft.md',
+    memoryPath: '/tmp/openmeta/artifacts/repo-memory.md',
+    inboxPath: '/tmp/openmeta/artifacts/inbox.md',
+    proofOfWorkPath: '/tmp/openmeta/artifacts/proof-of-work.md',
   };
 }
 
@@ -131,5 +143,81 @@ describe('machine flow result builders', () => {
     expect(result.selectedSuggestion).toEqual(suggestion);
     expect(result.artifacts.analysisPath).toContain('analysis');
     expect(result.mode.dryRun).toBe(true);
+  });
+
+  test('machine agent draft-only flow returns explicit execution flags', async () => {
+    const config = createConfig();
+    const issue = createRankedIssue({ repoFullName: 'acme/demo', number: 42 });
+    const memory = createMemory();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-demo',
+      branchName: 'openmeta/42-accessibility',
+      testResults: [],
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const artifacts = createArtifacts();
+    const orchestrator = new AgentOrchestrator();
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as AgentOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
+    spyOn(orchestrator as AgentOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
+    spyOn(issueRankingService, 'loadTargetIssue').mockResolvedValue([issue]);
+    spyOn(memoryService, 'load').mockReturnValue(memory);
+    spyOn(workspaceService, 'prepareWorkspace').mockResolvedValue(workspace);
+    spyOn(memoryService, 'update').mockReturnValue(memory);
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(orchestrator as AgentOrchestrator, 'generateConcretePatch' as never).mockResolvedValue({
+      changedFiles: [],
+      validationResults: [],
+      reviewRequired: false,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+    spyOn(contentService, 'formatContributionDossier').mockReturnValue('# Dossier');
+    spyOn(orchestrator as AgentOrchestrator, 'submitContributionPullRequestIfPossible' as never).mockResolvedValue({
+      changedFiles: [],
+      validationResults: [],
+    });
+    spyOn(orchestrator as AgentOrchestrator, 'prepareLocalArtifactPaths' as never).mockReturnValue(artifacts);
+    const writeArtifactsSpy = spyOn(orchestrator as AgentOrchestrator, 'writeLocalArtifacts' as never).mockImplementation(() => {});
+    const publishSpy = spyOn(orchestrator as AgentOrchestrator, 'publishArtifactsIfNeeded' as never).mockResolvedValue({
+      published: false,
+    });
+    const saveInboxSpy = spyOn(inboxService, 'saveItem').mockReturnValue([createInboxItem()]);
+    spyOn(inboxService, 'renderMarkdown').mockReturnValue('# Inbox');
+    spyOn(proofOfWorkService, 'load').mockReturnValue({ records: [] });
+    spyOn(proofOfWorkService, 'renderMarkdown').mockReturnValue('# Proof');
+    const recordProofSpy = spyOn(proofOfWorkService, 'record').mockReturnValue([createProofRecord()]);
+    spyOn(memoryService, 'renderMarkdown').mockReturnValue('# Memory');
+    const recordOutcomeSpy = spyOn(memoryService, 'recordOutcome').mockReturnValue(memory);
+
+    const result = await orchestrator.runMachine({
+      issue: 'https://github.com/acme/demo/issues/42',
+      draftOnly: true,
+      dryRun: true,
+    });
+
+    expect(result.executionOutcome).toBe('draft_only');
+    expect(result.repoMutated).toBe(false);
+    expect(result.prCreated).toBe(false);
+    expect(result.artifactsWritten).toBe(false);
+    expect(result.executionPolicy.headless).toBe(true);
+    expect(writeArtifactsSpy).not.toHaveBeenCalled();
+    expect(publishSpy).not.toHaveBeenCalled();
+    expect(saveInboxSpy).not.toHaveBeenCalled();
+    expect(recordProofSpy).not.toHaveBeenCalled();
+    expect(recordOutcomeSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -3,7 +3,47 @@ import * as infra from '../src/infra/index.js';
 import { AgentOrchestrator } from '../src/orchestration/agent.js';
 import { AnalyzeOrchestrator } from '../src/orchestration/analyze.js';
 import { contentService, inboxService, issueRankingService, llmService, memoryService, proofOfWorkService, workspaceService } from '../src/services/index.js';
+import type { MachineAgentResult } from '../src/orchestration/agent.js';
 import { createInboxItem, createMemory, createPatchDraft, createProofRecord, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
+
+interface AgentMachineInternals {
+  validateConfig(config: unknown, options?: unknown): Promise<void>;
+  initializeClients(config: unknown, options?: unknown): Promise<void>;
+  generateConcretePatch(
+    issue: unknown,
+    workspace: unknown,
+    patchDraft: unknown,
+    runChecks: boolean,
+    draftOnly?: boolean,
+  ): Promise<{
+    changedFiles: string[];
+    validationResults: unknown[];
+    reviewRequired: boolean;
+  }>;
+  submitContributionPullRequestIfPossible(input: unknown): Promise<{
+    changedFiles: string[];
+    validationResults: unknown[];
+    url?: string;
+    number?: number;
+  }>;
+  prepareLocalArtifactPaths(issue: unknown): ReturnType<typeof createArtifacts>;
+  writeLocalArtifacts(input: unknown): void;
+  publishArtifactsIfNeeded(input: unknown): Promise<{ published: boolean }>;
+}
+
+interface AgentMachineRunShape {
+  runMachine(options?: {
+    headless?: boolean;
+    force?: boolean;
+    schedulerRun?: boolean;
+    runChecks?: boolean;
+    draftOnly?: boolean;
+    refresh?: boolean;
+    repo?: string;
+    issue?: string;
+    dryRun?: boolean;
+  }): Promise<MachineAgentResult>;
+}
 
 function createConfig() {
   return {
@@ -157,11 +197,12 @@ describe('machine flow result builders', () => {
     const patchDraft = createPatchDraft();
     const prDraft = createPullRequestDraft();
     const artifacts = createArtifacts();
-    const orchestrator = new AgentOrchestrator();
+    const orchestrator = new AgentOrchestrator() as unknown as AgentMachineRunShape;
+    const machineInternals = orchestrator as unknown as AgentMachineInternals;
 
     spyOn(infra.configService, 'get').mockResolvedValue(config);
-    spyOn(orchestrator as AgentOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
-    spyOn(orchestrator as AgentOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
+    spyOn(machineInternals, 'validateConfig').mockResolvedValue(undefined);
+    spyOn(machineInternals, 'initializeClients').mockResolvedValue(undefined);
     spyOn(issueRankingService, 'loadTargetIssue').mockResolvedValue([issue]);
     spyOn(memoryService, 'load').mockReturnValue(memory);
     spyOn(workspaceService, 'prepareWorkspace').mockResolvedValue(workspace);
@@ -172,7 +213,7 @@ describe('machine flow result builders', () => {
       status: 'success',
       data: patchDraft,
     });
-    spyOn(orchestrator as AgentOrchestrator, 'generateConcretePatch' as never).mockResolvedValue({
+    spyOn(machineInternals, 'generateConcretePatch').mockResolvedValue({
       changedFiles: [],
       validationResults: [],
       reviewRequired: false,
@@ -186,13 +227,13 @@ describe('machine flow result builders', () => {
     spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
     spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
     spyOn(contentService, 'formatContributionDossier').mockReturnValue('# Dossier');
-    spyOn(orchestrator as AgentOrchestrator, 'submitContributionPullRequestIfPossible' as never).mockResolvedValue({
+    spyOn(machineInternals, 'submitContributionPullRequestIfPossible').mockResolvedValue({
       changedFiles: [],
       validationResults: [],
     });
-    spyOn(orchestrator as AgentOrchestrator, 'prepareLocalArtifactPaths' as never).mockReturnValue(artifacts);
-    const writeArtifactsSpy = spyOn(orchestrator as AgentOrchestrator, 'writeLocalArtifacts' as never).mockImplementation(() => {});
-    const publishSpy = spyOn(orchestrator as AgentOrchestrator, 'publishArtifactsIfNeeded' as never).mockResolvedValue({
+    spyOn(machineInternals, 'prepareLocalArtifactPaths').mockReturnValue(artifacts);
+    const writeArtifactsSpy = spyOn(machineInternals, 'writeLocalArtifacts').mockImplementation(() => {});
+    const publishSpy = spyOn(machineInternals, 'publishArtifactsIfNeeded').mockResolvedValue({
       published: false,
     });
     const saveInboxSpy = spyOn(inboxService, 'saveItem').mockReturnValue([createInboxItem()]);

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -72,6 +72,20 @@ function createConfig() {
       minMatchScore: 75,
       skipIfAlreadyGeneratedToday: false,
     },
+    scoring: {
+      weights: {
+        freshness: 0.25,
+        onboardingClarity: 0.25,
+        mergePotential: 0.3,
+        impact: 0.2,
+        riskPenalty: 0.35,
+      },
+      overallWeights: {
+        technicalMatch: 0.45,
+        opportunityScore: 0.55,
+      },
+      preset: 'balanced',
+    },
     commitTemplate: 'feat: {{title}}',
   };
 }

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { registerMachineCommand } from '../src/commands/machine.js';
 import * as infra from '../src/infra/index.js';
 import { agentOrchestrator, analyzeOrchestrator, configOrchestrator, providerOrchestrator } from '../src/orchestration/index.js';
+import { githubService, issueRankingService } from '../src/services/index.js';
 import { createPatchDraft, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
 
 function captureStdout(): string[] {
@@ -311,5 +312,44 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine agent');
     expect(output.data.executionOutcome).toBe('draft_only');
     expect(output.data.repoMutated).toBe(false);
+  });
+
+  test('machine scout suppresses human task output during real machine execution', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+
+    spyOn(infra.configService, 'get').mockResolvedValue({
+      userProfile: { techStack: ['typescript'], proficiency: 'intermediate', focusAreas: ['cli'] },
+      github: { pat: 'ghp_test_token', username: 'octocat', targetRepoPath: '' },
+      llm: {
+        provider: 'custom',
+        apiBaseUrl: 'https://example.com/v1',
+        apiKey: 'sk-test',
+        modelName: 'test-model',
+        apiHeaders: {},
+        activeProfile: '',
+        profiles: {},
+      },
+      automation: {
+        enabled: false,
+        scheduleTime: '09:00',
+        timezone: 'UTC',
+        contentType: 'research_note',
+        scheduler: 'manual',
+        minMatchScore: 70,
+        skipIfAlreadyGeneratedToday: true,
+      },
+      commitTemplate: 'feat: {{title}}',
+    });
+    spyOn(githubService, 'validateCredentials').mockResolvedValue(true);
+    spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
+
+    await program.parseAsync(['machine', 'scout', '--local'], { from: 'user' });
+
+    const output = writes.join('');
+    expect(() => JSON.parse(output)).not.toThrow();
+    expect(output).not.toContain('Validating GitHub access');
+    expect(output).not.toContain('[success]');
   });
 });

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -15,6 +15,21 @@ function captureStdout(): string[] {
   return writes;
 }
 
+const DEFAULT_SCORING = {
+  weights: {
+    freshness: 0.25,
+    onboardingClarity: 0.25,
+    mergePotential: 0.3,
+    impact: 0.2,
+    riskPenalty: 0.35,
+  },
+  overallWeights: {
+    technicalMatch: 0.45,
+    opportunityScore: 0.55,
+  },
+  preset: 'balanced',
+} as const;
+
 describe('machine commands', () => {
   afterEach(() => {
     mock.restore();
@@ -63,6 +78,7 @@ describe('machine commands', () => {
         minMatchScore: 70,
         skipIfAlreadyGeneratedToday: true,
       },
+      scoring: DEFAULT_SCORING,
       commitTemplate: 'feat: {{title}}',
     });
 
@@ -99,6 +115,7 @@ describe('machine commands', () => {
         minMatchScore: 70,
         skipIfAlreadyGeneratedToday: true,
       },
+      scoring: DEFAULT_SCORING,
       commitTemplate: 'feat: {{title}}',
     });
 
@@ -138,6 +155,7 @@ describe('machine commands', () => {
           minMatchScore: 70,
           skipIfAlreadyGeneratedToday: true,
         },
+        scoring: DEFAULT_SCORING,
         commitTemplate: 'feat: {{title}}',
       },
       scheduler: {
@@ -340,6 +358,7 @@ describe('machine commands', () => {
         minMatchScore: 70,
         skipIfAlreadyGeneratedToday: true,
       },
+      scoring: DEFAULT_SCORING,
       commitTemplate: 'feat: {{title}}',
     });
     spyOn(githubService, 'validateCredentials').mockResolvedValue(true);

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { Command } from 'commander';
 import { registerMachineCommand } from '../src/commands/machine.js';
 import * as infra from '../src/infra/index.js';
-import { configOrchestrator, providerOrchestrator } from '../src/orchestration/index.js';
+import { agentOrchestrator, analyzeOrchestrator, configOrchestrator, providerOrchestrator } from '../src/orchestration/index.js';
+import { createPatchDraft, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
 
 function captureStdout(): string[] {
   const writes: string[] = [];
@@ -190,5 +191,125 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine provider add');
     expect(output.data.profileName).toBe('machine-add');
     expect(output.data.apiKey).toBe('***cret');
+  });
+
+  test('machine scout writes ranked opportunities as JSON only', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+    const issue = createRankedIssue();
+
+    spyOn(agentOrchestrator, 'scoutMachine').mockResolvedValue({
+      opportunities: [issue],
+      mode: {
+        limit: 10,
+        refresh: false,
+        repo: undefined,
+        localOnly: true,
+      },
+      nextActions: ['inspect_ranked_opportunities'],
+    });
+
+    await program.parseAsync(['machine', 'scout', '--local'], { from: 'user' });
+
+    const output = JSON.parse(writes.join(''));
+    expect(output.command).toBe('machine scout');
+    expect(output.data.opportunities[0].repoFullName).toBe(issue.repoFullName);
+  });
+
+  test('machine analyze writes repository analysis output as JSON only', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+    const suggestion = createRepositorySuggestion();
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-demo',
+      branchName: 'openmeta/analyze-acme-demo',
+    });
+
+    spyOn(analyzeOrchestrator, 'runMachine').mockResolvedValue({
+      repoFullName: 'acme/demo',
+      workspace,
+      selectedSuggestion: suggestion,
+      suggestions: [suggestion],
+      patchDraft,
+      prDraft,
+      artifacts: {
+        artifactDir: '/tmp/openmeta/artifacts/analyze',
+        analysisPath: '/tmp/openmeta/artifacts/analyze/repository-analysis.md',
+        patchDraftPath: '/tmp/openmeta/artifacts/analyze/patch-draft.md',
+        prDraftPath: '/tmp/openmeta/artifacts/analyze/pr-draft.md',
+      },
+      mode: {
+        headless: true,
+        runChecks: false,
+        dryRun: true,
+      },
+    });
+
+    await program.parseAsync(['machine', 'analyze', '--repo', 'acme/demo', '--headless', '--dry-run'], { from: 'user' });
+
+    const output = JSON.parse(writes.join(''));
+    expect(output.command).toBe('machine analyze');
+    expect(output.data.repoFullName).toBe('acme/demo');
+    expect(output.data.mode.dryRun).toBe(true);
+  });
+
+  test('machine agent writes execution outcome as JSON only', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+    const issue = createRankedIssue({ repoFullName: 'acme/demo', number: 42 });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-demo',
+      branchName: 'openmeta/42-accessibility',
+      testResults: [],
+    });
+
+    spyOn(agentOrchestrator, 'runMachine').mockResolvedValue({
+      issue,
+      workspace,
+      patchDraft,
+      prDraft,
+      artifacts: {
+        artifactDir: '/tmp/openmeta/artifacts',
+        dossierPath: '/tmp/openmeta/artifacts/dossier.md',
+        patchDraftPath: '/tmp/openmeta/artifacts/patch-draft.md',
+        prDraftPath: '/tmp/openmeta/artifacts/pr-draft.md',
+        memoryPath: '/tmp/openmeta/artifacts/repo-memory.md',
+        inboxPath: '/tmp/openmeta/artifacts/inbox.md',
+        proofOfWorkPath: '/tmp/openmeta/artifacts/proof-of-work.md',
+      },
+      changedFiles: [],
+      validationResults: [],
+      reviewRequired: false,
+      published: false,
+      prCreated: false,
+      repoMutated: false,
+      artifactsWritten: false,
+      executionOutcome: 'draft_only',
+      executionPolicy: {
+        headless: true,
+        draftOnly: true,
+        runChecks: false,
+        dryRun: true,
+        refresh: false,
+      },
+      skipReasons: ['draft_only'],
+      nextActions: ['inspect_artifact_paths'],
+      pullRequestUrl: undefined,
+      pullRequestNumber: undefined,
+    });
+
+    await program.parseAsync(['machine', 'agent', '--issue', 'https://github.com/acme/demo/issues/42', '--draft-only', '--dry-run'], { from: 'user' });
+
+    const output = JSON.parse(writes.join(''));
+    expect(output.command).toBe('machine agent');
+    expect(output.data.executionOutcome).toBe('draft_only');
+    expect(output.data.repoMutated).toBe(false);
   });
 });

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { Command } from 'commander';
 import { registerMachineCommand } from '../src/commands/machine.js';
 import * as infra from '../src/infra/index.js';
-import { configOrchestrator } from '../src/orchestration/index.js';
+import { configOrchestrator, providerOrchestrator } from '../src/orchestration/index.js';
 
 function captureStdout(): string[] {
   const writes: string[] = [];
@@ -30,6 +30,9 @@ describe('machine commands', () => {
     expect(help).toContain('config');
     expect(help).toContain('provider');
     expect(help).toContain('runs');
+    expect(help).toContain('scout');
+    expect(help).toContain('analyze');
+    expect(help).toContain('agent');
   });
 
   test('machine doctor writes only JSON to stdout', async () => {
@@ -102,5 +105,90 @@ describe('machine commands', () => {
     const output = JSON.parse(writes.join(''));
     expect(output.command).toBe('machine config get');
     expect(output.data.github.pat).toBe('***oken');
+  });
+
+  test('machine config set writes the updated key and masked snapshot', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+
+    spyOn(configOrchestrator, 'setMachineValue').mockResolvedValue({
+      updatedKey: 'llm.apiKey',
+      appliedValue: '***cret',
+      snapshot: {
+        userProfile: { techStack: [], proficiency: 'beginner', focusAreas: [] },
+        github: { username: 'octocat', pat: '***oken', targetRepoPath: '' },
+        llm: {
+          provider: 'openai',
+          apiBaseUrl: 'https://api.openai.com/v1',
+          apiKey: '***cret',
+          modelName: 'gpt-4o-mini',
+          apiHeaders: {},
+          activeProfile: '',
+          savedProfiles: [],
+        },
+        automation: {
+          enabled: false,
+          scheduleTime: '09:00',
+          timezone: 'UTC',
+          contentType: 'research_note',
+          scheduler: 'manual',
+          minMatchScore: 70,
+          skipIfAlreadyGeneratedToday: true,
+        },
+        commitTemplate: 'feat: {{title}}',
+      },
+      scheduler: {
+        status: 'unchanged',
+        detail: 'Scheduler state unchanged.',
+      },
+    });
+
+    await program.parseAsync(['machine', 'config', 'set', 'llm.apiKey', 'sk-secret'], { from: 'user' });
+
+    const output = JSON.parse(writes.join(''));
+    expect(output.command).toBe('machine config set');
+    expect(output.data.updatedKey).toBe('llm.apiKey');
+    expect(output.data.appliedValue).toBe('***cret');
+  });
+
+  test('machine provider add writes the saved profile result', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+
+    spyOn(providerOrchestrator, 'addProfile').mockResolvedValue({
+      profileName: 'machine-add',
+      activeProfile: '',
+      provider: 'custom',
+      modelName: 'example-model',
+      apiBaseUrl: 'https://example.com/v1',
+      apiKey: '***cret',
+      apiHeaders: { 'X-Test': 'yes' },
+      reasoningEffort: 'medium',
+      stream: true,
+      validation: 'skipped',
+      validationMessage: 'Validation skipped.',
+    });
+
+    await program.parseAsync([
+      'machine',
+      'provider',
+      'add',
+      'machine-add',
+      '--base-url',
+      'https://example.com/v1',
+      '--model',
+      'example-model',
+      '--api-key',
+      'sk-secret',
+      '--header',
+      'X-Test=yes',
+    ], { from: 'user' });
+
+    const output = JSON.parse(writes.join(''));
+    expect(output.command).toBe('machine provider add');
+    expect(output.data.profileName).toBe('machine-add');
+    expect(output.data.apiKey).toBe('***cret');
   });
 });

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { Command } from 'commander';
+import { registerMachineCommand } from '../src/commands/machine.js';
+import * as infra from '../src/infra/index.js';
+import { configOrchestrator } from '../src/orchestration/index.js';
+
+function captureStdout(): string[] {
+  const writes: string[] = [];
+  spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  return writes;
+}
+
+describe('machine commands', () => {
+  afterEach(() => {
+    mock.restore();
+    process.exitCode = 0;
+  });
+
+  test('registers machine doctor and config commands', () => {
+    const program = new Command();
+    registerMachineCommand(program);
+
+    const machineCommand = program.commands.find((command) => command.name() === 'machine');
+    const help = machineCommand?.helpInformation() ?? '';
+
+    expect(help).toContain('doctor');
+    expect(help).toContain('config');
+    expect(help).toContain('provider');
+    expect(help).toContain('runs');
+  });
+
+  test('machine doctor writes only JSON to stdout', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+
+    spyOn(infra.configService, 'get').mockResolvedValue({
+      userProfile: { techStack: [], proficiency: 'beginner', focusAreas: [] },
+      github: { pat: '', username: '', targetRepoPath: '' },
+      llm: {
+        provider: 'openai',
+        apiBaseUrl: 'https://api.openai.com/v1',
+        apiKey: '',
+        modelName: 'gpt-4o-mini',
+        apiHeaders: {},
+        activeProfile: '',
+        profiles: {},
+      },
+      automation: {
+        enabled: false,
+        scheduleTime: '09:00',
+        timezone: 'UTC',
+        contentType: 'research_note',
+        scheduler: 'manual',
+        minMatchScore: 70,
+        skipIfAlreadyGeneratedToday: true,
+      },
+      commitTemplate: 'feat: {{title}}',
+    });
+
+    await program.parseAsync(['machine', 'doctor'], { from: 'user' });
+
+    const output = writes.join('');
+    expect(() => JSON.parse(output)).not.toThrow();
+    expect(output).not.toContain('OpenMeta Doctor');
+  });
+
+  test('machine config get writes a masked JSON snapshot', async () => {
+    const writes = captureStdout();
+    const program = new Command();
+    registerMachineCommand(program);
+
+    spyOn(configOrchestrator, 'getMachineSnapshot').mockResolvedValue({
+      userProfile: { techStack: [], proficiency: 'beginner', focusAreas: [] },
+      github: { username: 'octocat', pat: '***oken', targetRepoPath: '' },
+      llm: {
+        provider: 'openai',
+        apiBaseUrl: 'https://api.openai.com/v1',
+        apiKey: '***-key',
+        modelName: 'gpt-4o-mini',
+        apiHeaders: {},
+        activeProfile: '',
+        savedProfiles: [],
+      },
+      automation: {
+        enabled: false,
+        scheduleTime: '09:00',
+        timezone: 'UTC',
+        contentType: 'research_note',
+        scheduler: 'manual',
+        minMatchScore: 70,
+        skipIfAlreadyGeneratedToday: true,
+      },
+      commitTemplate: 'feat: {{title}}',
+    });
+
+    await program.parseAsync(['machine', 'config', 'get'], { from: 'user' });
+
+    const output = JSON.parse(writes.join(''));
+    expect(output.command).toBe('machine config get');
+    expect(output.data.github.pat).toBe('***oken');
+  });
+});

--- a/test/machine-runtime.test.ts
+++ b/test/machine-runtime.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { buildMachineEnvelope, mapMachineError } from '../src/orchestration/machine/index.js';
+
+describe('machine runtime', () => {
+  test('builds a success envelope with command, version, timestamp, and data', () => {
+    const envelope = buildMachineEnvelope('machine doctor', { ready: true });
+
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe('machine doctor');
+    expect(envelope.timestamp).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(envelope.data).toEqual({ ready: true });
+  });
+
+  test('maps invalid argument failures to exit code 2 and INVALID_ARGUMENT', () => {
+    const mapped = mapMachineError('machine config set', new Error('llm.stream must be a boolean value.'));
+
+    expect(mapped.exitCode).toBe(2);
+    expect(mapped.payload.error.code).toBe('INVALID_ARGUMENT');
+  });
+});

--- a/test/machine-state-commands.test.ts
+++ b/test/machine-state-commands.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { AgentOrchestrator } from '../src/orchestration/agent.js';
+import { RunsOrchestrator } from '../src/orchestration/runs.js';
+import { inboxService, proofOfWorkService, runHistoryService } from '../src/services/index.js';
+import { createInboxItem, createProofRecord } from './helpers/factories.js';
+
+let tempRoot = '';
+
+describe('machine state result builders', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'openmeta-machine-state-'));
+    process.env['OPENMETA_CONFIG_DIR'] = join(tempRoot, '.config', 'openmeta');
+    process.env['OPENMETA_HOME'] = join(tempRoot, '.openmeta');
+  });
+
+  afterEach(() => {
+    mock.restore();
+    delete process.env['OPENMETA_CONFIG_DIR'];
+    delete process.env['OPENMETA_HOME'];
+
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = '';
+    }
+  });
+
+  test('returns run history list data with totals', async () => {
+    runHistoryService.start({
+      commandName: 'OpenMeta Doctor',
+      args: ['doctor'],
+    });
+
+    const result = await new RunsOrchestrator().listMachine({ limit: 10 });
+
+    expect(result.records).toBeArray();
+    expect(result.records.length).toBe(1);
+    expect(result.totals.running).toBe(1);
+    expect(result.ledgerPath).toContain('runs.json');
+  });
+
+  test('returns inbox items ordered by score', async () => {
+    inboxService.saveItem(createInboxItem({ id: 'low', overallScore: 55 }));
+    inboxService.saveItem(createInboxItem({ id: 'high', overallScore: 88 }));
+
+    const result = await new AgentOrchestrator().getInboxMachineResult();
+
+    expect(result.items).toBeArray();
+    expect(result.items[0]?.id).toBe('high');
+    expect(result.inboxPath).toContain('inbox.json');
+  });
+
+  test('returns proof-of-work records with publication metadata', async () => {
+    proofOfWorkService.record(createProofRecord({ id: 'proof-1', published: true }));
+
+    const result = await new AgentOrchestrator().getProofOfWorkMachineResult();
+
+    expect(result.records).toBeArray();
+    expect(result.records[0]?.id).toBe('proof-1');
+    expect(result.records[0]?.published).toBe(true);
+    expect(result.proofOfWorkPath).toContain('proof-of-work.json');
+  });
+});

--- a/test/provider-orchestrator.test.ts
+++ b/test/provider-orchestrator.test.ts
@@ -188,4 +188,24 @@ describe('ProviderOrchestrator', () => {
     expect(result.apiKey).toBe('***cret');
     expect(result.validation).toBe('skipped');
   });
+
+  test('returns provider result data when adding a profile for machine flows', async () => {
+    const orchestrator = new ProviderOrchestrator();
+
+    const result = await orchestrator.addProfile('machine-add', {
+      provider: 'custom',
+      baseUrl: 'https://example.com/v1',
+      model: 'example-model',
+      apiKey: 'sk-machine-add-secret',
+      reasoningEffort: 'medium',
+      stream: 'true',
+      header: ['X-Test=yes'],
+    });
+
+    expect(result.profileName).toBe('machine-add');
+    expect(result.activeProfile).toBe('');
+    expect(result.apiKey).toBe('***cret');
+    expect(result.apiHeaders).toEqual({ 'X-Test': 'yes' });
+    expect(result.stream).toBe(true);
+  });
 });

--- a/test/provider-orchestrator.test.ts
+++ b/test/provider-orchestrator.test.ts
@@ -170,4 +170,22 @@ describe('ProviderOrchestrator', () => {
     expect(loaded.llm.activeProfile).toBe('');
     expect(loaded.llm.modelName).toBe('temporary-model');
   });
+
+  test('returns provider result data when switching profiles', async () => {
+    const orchestrator = new ProviderOrchestrator();
+
+    await orchestrator.add('machine-profile', {
+      provider: 'custom',
+      baseUrl: 'https://example.com/v1',
+      model: 'example-model',
+      apiKey: 'sk-machine-secret',
+    });
+
+    const result = await orchestrator.useProfile('machine-profile');
+
+    expect(result.profileName).toBe('machine-profile');
+    expect(result.activeProfile).toBe('machine-profile');
+    expect(result.apiKey).toBe('***cret');
+    expect(result.validation).toBe('skipped');
+  });
 });

--- a/test/skill-bundle.test.ts
+++ b/test/skill-bundle.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
 import packageJson from '../package.json';
 import { getSupportedSkillHosts, renderSkillBundle } from '../src/orchestration/skill/index.js';
 
@@ -29,6 +30,39 @@ describe('skill bundle rendering', () => {
     expect(readFileSync(claude.files[0]!, 'utf-8')).toContain('openmeta machine agent');
     expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
     expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine agent');
+  });
+
+  test('export works from the packed CLI with runtime-resolved skill assets', () => {
+    const packedRoot = mkdtempSync(join(tmpdir(), 'openmeta-pack-runtime-'));
+    const exportRoot = join(packedRoot, 'exported');
+
+    execFileSync('bun', ['run', 'build'], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'inherit'],
+      encoding: 'utf-8',
+    });
+    const packed = JSON.parse(execFileSync('npm', ['pack', '--json', '--pack-destination', packedRoot], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'inherit'],
+      encoding: 'utf-8',
+    })) as Array<{ filename: string }>;
+    execFileSync('tar', ['-xzf', join(packedRoot, packed[0]!.filename), '-C', packedRoot]);
+    execFileSync('bun', [
+      join(packedRoot, 'package', 'bin', 'openmeta.js'),
+      'skill',
+      'export',
+      '--host',
+      'claude-code',
+      '--output',
+      exportRoot,
+    ], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'inherit'],
+      encoding: 'utf-8',
+    });
+
+    expect(existsSync(join(exportRoot, 'claude-code', 'skill.md'))).toBe(true);
+    expect(readFileSync(join(exportRoot, 'claude-code', 'skill.md'), 'utf-8')).toContain('openmeta machine doctor');
   });
 });
 

--- a/test/skill-bundle.test.ts
+++ b/test/skill-bundle.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import packageJson from '../package.json';
+import { getSupportedSkillHosts, renderSkillBundle } from '../src/orchestration/skill/index.js';
+
+let tempRoot = '';
+
+describe('skill bundle rendering', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'openmeta-skill-bundle-'));
+  });
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = '';
+    }
+  });
+
+  test('renders claude-code and openclaw bundles from one canonical spec', async () => {
+    expect(getSupportedSkillHosts()).toEqual(['claude-code', 'openclaw']);
+
+    const claude = await renderSkillBundle('claude-code', tempRoot);
+    const openclaw = await renderSkillBundle('openclaw', tempRoot);
+
+    expect(readFileSync(claude.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
+    expect(readFileSync(claude.files[0]!, 'utf-8')).toContain('openmeta machine agent');
+    expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
+    expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine agent');
+  });
+});
+
+describe('package files', () => {
+  test('publishes skill assets with the CLI binary', () => {
+    expect(packageJson.files).toContain('bin/openmeta.js');
+    expect(packageJson.files).toContain('skills');
+  });
+});

--- a/test/skill-bundle.test.ts
+++ b/test/skill-bundle.test.ts
@@ -26,10 +26,20 @@ describe('skill bundle rendering', () => {
     const claude = await renderSkillBundle('claude-code', tempRoot);
     const openclaw = await renderSkillBundle('openclaw', tempRoot);
 
-    expect(readFileSync(claude.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
-    expect(readFileSync(claude.files[0]!, 'utf-8')).toContain('openmeta machine agent');
-    expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine doctor');
-    expect(readFileSync(openclaw.files[0]!, 'utf-8')).toContain('openmeta machine agent');
+    const claudeSkill = readFileSync(claude.files[0]!, 'utf-8');
+    const openclawSkill = readFileSync(openclaw.files[0]!, 'utf-8');
+
+    expect(claudeSkill).toContain('Install target: `~/.claude/skills/openmeta`');
+    expect(claudeSkill).toContain('## Config Keys For `machine config set`');
+    expect(claudeSkill).toContain('`executionOutcome`');
+    expect(claudeSkill).toContain('"errorCodes"');
+    expect(claudeSkill).toContain('openmeta machine agent');
+
+    expect(openclawSkill).toContain('Install target: `~/.openclaw/skills/openmeta`');
+    expect(openclawSkill).toContain('## Recovery Playbook');
+    expect(openclawSkill).toContain('`reviewRequired`');
+    expect(openclawSkill).toContain('"openmeta machine pow"');
+    expect(openclawSkill).toContain('openmeta machine doctor');
   });
 
   test('export works from the packed CLI with runtime-resolved skill assets', () => {
@@ -62,7 +72,11 @@ describe('skill bundle rendering', () => {
     });
 
     expect(existsSync(join(exportRoot, 'claude-code', 'skill.md'))).toBe(true);
-    expect(readFileSync(join(exportRoot, 'claude-code', 'skill.md'), 'utf-8')).toContain('openmeta machine doctor');
+    const exportedSkill = readFileSync(join(exportRoot, 'claude-code', 'skill.md'), 'utf-8');
+    expect(exportedSkill).toContain('Install target: `~/.claude/skills/openmeta`');
+    expect(exportedSkill).toContain('## Result Interpretation');
+    expect(exportedSkill).toContain('"inspectFields"');
+    expect(exportedSkill).toContain('openmeta machine doctor');
   });
 });
 

--- a/test/skill-command.test.ts
+++ b/test/skill-command.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { Command } from 'commander';
+import { registerSkillCommand } from '../src/commands/skill.js';
+
+describe('registerSkillCommand', () => {
+  test('registers skill bundle management commands', () => {
+    const program = new Command();
+    registerSkillCommand(program);
+
+    const skillCommand = program.commands.find((command) => command.name() === 'skill');
+    const help = skillCommand?.helpInformation() ?? '';
+
+    expect(help).toContain('list');
+    expect(help).toContain('export');
+    expect(help).toContain('install');
+    expect(help).toContain('doctor');
+  });
+});


### PR DESCRIPTION
## Summary
- add a thin `openmeta machine` surface for JSON-first agent integration across doctor, config, provider, scout, analyze, agent, runs, inbox, and proof-of-work flows
- add a package-shipped skill bundle system with export, install, and doctor commands plus generated bundles for Claude Code and OpenClaw
- harden machine-mode runtime behavior so stdout stays JSON-only and packaged skill assets resolve correctly after install
- expand the skill bundle guidance so host agents get install paths, workflow rules, config keys, outcome semantics, and recovery playbooks

## Why
OpenMeta needed a stable automation surface that external agents can actually drive without scraping human CLI output. This PR turns the machine layer into the supported integration contract and ships host-ready skill bundles with the package so Claude Code, OpenClaw, and similar agents can bootstrap and operate OpenMeta locally.

## Validation
- `bun run typecheck`
- `bun test`
- `bun run build`
- `npm pack --dry-run --json`
