### PR TITLE
[codex] improve machine progress feedback

### DIFF
--- a/src/infra/ui/live.ts
+++ b/src/infra/ui/live.ts
@@ -4,6 +4,26 @@ import figures from 'figures';
 import { isMachineContext } from '../execution-context.js';
 import type { TaskController, TaskOptions, Tone, UiCapabilities } from './types.js';
 
+function renderStepLabel(options: TaskOptions): string {
+  if (!options.step) {
+    return options.title;
+  }
+
+  return `Step ${options.step.index}/${options.step.total} ${options.title}`;
+}
+
+function resolveHeartbeatMessage(options: TaskOptions, elapsedMs: number): string | null {
+  if (!options.heartbeat) {
+    return null;
+  }
+
+  const message = typeof options.heartbeat.message === 'function'
+    ? options.heartbeat.message({ elapsedMs })
+    : options.heartbeat.message;
+
+  return message ? renderStepLabel({ ...options, title: message }) : null;
+}
+
 function toneColor(tone: Tone): 'green' | 'yellow' | 'red' | 'magenta' | 'white' | 'cyan' {
   switch (tone) {
     case 'success':
@@ -52,36 +72,72 @@ export async function runTask<T>(
   task: (controller: TaskController) => Promise<T>,
 ): Promise<T> {
   const tone = options.tone ?? 'info';
+  const title = renderStepLabel(options);
+  const doneMessage = options.doneMessage ? renderStepLabel({ ...options, title: options.doneMessage }) : title;
+  const failedMessage = options.failedMessage ? renderStepLabel({ ...options, title: options.failedMessage }) : title;
   const controller: TaskController = {
     setMessage(_message: string): void {
       // no-op by default; interactive mode replaces this with spinner.message(...)
     },
   };
+  const startedAt = Date.now();
+  const heartbeatIntervalMs = Math.max(10, options.heartbeat?.intervalMs ?? 10_000);
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let lastHeartbeatMessage = '';
+
+  const startHeartbeat = (emit: (message: string) => void): void => {
+    if (!options.heartbeat) {
+      return;
+    }
+
+    heartbeatTimer = setInterval(() => {
+      const message = resolveHeartbeatMessage(options, Date.now() - startedAt);
+      if (!message || message === lastHeartbeatMessage) {
+        return;
+      }
+
+      lastHeartbeatMessage = message;
+      emit(message);
+    }, heartbeatIntervalMs);
+  };
+
+  const stopHeartbeat = (): void => {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+  };
 
   if (isMachineContext()) {
-    writeMachineStatus(figures.pointerSmall, options.title, tone);
+    writeMachineStatus(figures.pointerSmall, title, tone);
     controller.setMessage = (message: string) => {
-      writeMachineStatus(figures.ellipsis, message, tone);
+      writeMachineStatus(figures.ellipsis, renderStepLabel({ ...options, title: message }), tone);
     };
+    startHeartbeat((message) => writeMachineStatus(figures.ellipsis, message, tone));
 
     try {
       const result = await task(controller);
-      writeMachineStatus(figures.tick, `[success] ${options.doneMessage || options.title}`, 'success');
+      stopHeartbeat();
+      writeMachineStatus(figures.tick, `[success] ${doneMessage}`, 'success');
       return result;
     } catch (error) {
-      writeMachineStatus(figures.cross, options.failedMessage || options.title, 'error');
+      stopHeartbeat();
+      writeMachineStatus(figures.cross, failedMessage, 'error');
       throw error;
     }
   }
 
   if (!capabilities.isInteractive || capabilities.mode === 'plain') {
-    process.stdout.write(`${renderInlineStatus(figures.pointerSmall, options.title, tone)}\n`);
+    process.stdout.write(`${renderInlineStatus(figures.pointerSmall, title, tone)}\n`);
+    startHeartbeat((message) => process.stdout.write(`${renderInlineStatus(figures.ellipsis, message, tone)}\n`));
     try {
       const result = await task(controller);
-      process.stdout.write(`${renderInlineStatus(figures.tick, `[success] ${options.doneMessage || options.title}`, 'success')}\n`);
+      stopHeartbeat();
+      process.stdout.write(`${renderInlineStatus(figures.tick, `[success] ${doneMessage}`, 'success')}\n`);
       return result;
     } catch (error) {
-      process.stdout.write(`${renderInlineStatus(figures.cross, options.failedMessage || options.title, 'error')}\n`);
+      stopHeartbeat();
+      process.stdout.write(`${renderInlineStatus(figures.cross, failedMessage, 'error')}\n`);
       throw error;
     }
   }
@@ -89,17 +145,20 @@ export async function runTask<T>(
   const spinner = p.spinner({
     indicator: capabilities.supportsUnicode ? 'dots' : 'timer',
   });
-  spinner.start(options.title);
+  spinner.start(title);
   controller.setMessage = (message: string) => {
-    spinner.message(message);
+    spinner.message(renderStepLabel({ ...options, title: message }));
   };
+  startHeartbeat((message) => spinner.message(message));
 
   try {
     const result = await task(controller);
-    spinner.stop(`${figures.tick} [success] ${options.doneMessage || options.title}`);
+    stopHeartbeat();
+    spinner.stop(`${figures.tick} [success] ${doneMessage}`);
     return result;
   } catch (error) {
-    spinner.error(`${figures.cross} [error] ${options.failedMessage || options.title}`);
+    stopHeartbeat();
+    spinner.error(`${figures.cross} [error] ${failedMessage}`);
     throw error;
   }
 }

--- a/src/infra/ui/types.ts
+++ b/src/infra/ui/types.ts
@@ -49,6 +49,14 @@ export interface TaskOptions {
   doneMessage?: string;
   failedMessage?: string;
   tone?: Tone;
+  step?: {
+    index: number;
+    total: number;
+  };
+  heartbeat?: {
+    intervalMs?: number;
+    message: string | ((context: { elapsedMs: number }) => string);
+  };
 }
 
 export interface TaskController {

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -162,6 +162,7 @@ export class AgentOrchestrator {
   private octokit: Octokit | null = null;
 
   async runMachine(options: AgentRunOptions = {}): Promise<MachineAgentResult> {
+    const totalSteps = 8;
     const config = await configService.get();
     const headless = options.headless ?? true;
     const schedulerRun = Boolean(options.schedulerRun);
@@ -179,15 +180,38 @@ export class AgentOrchestrator {
       await this.confirmManualHeadlessRun(config);
     }
 
-    await this.initializeClients(config);
+    await this.initializeClients(config, {
+      validateGithub: true,
+      validateLlm: true,
+      taskSteps: {
+        github: { index: 1, total: totalSteps },
+        llm: { index: 2, total: totalSteps },
+      },
+    });
     this.showLocalRepositoryHint(repoPath);
 
     const rankedIssues = issueTarget
-      ? await issueRankingService.loadTargetIssue(config, issueTarget)
-      : await issueRankingService.loadRankedIssues(config, {
+      ? await ui.task({
+        title: 'Loading target issue',
+        doneMessage: 'Target issue loaded',
+        failedMessage: 'Target issue loading failed',
+        tone: 'info',
+        step: { index: 3, total: totalSteps },
+      }, async () => issueRankingService.loadTargetIssue(config, issueTarget))
+      : await ui.task({
+        title: 'Ranking contribution opportunities',
+        doneMessage: 'Contribution opportunities ranked',
+        failedMessage: 'Contribution opportunity ranking failed',
+        tone: 'info',
+        step: { index: 3, total: totalSteps },
+        heartbeat: {
+          message: 'Still ranking contribution opportunities',
+        },
+      }, async (task) => issueRankingService.loadRankedIssues(config, {
         refresh,
         repoFullName,
-      });
+        onStatus: (message) => task.setMessage(message),
+      }));
 
     if (rankedIssues.length === 0) {
       throw new Error(issueTarget
@@ -208,16 +232,34 @@ export class AgentOrchestrator {
     }
 
     const memoryBeforeRun = memoryService.load(selectedIssue.repoFullName);
-    const workspace = await workspaceService.prepareWorkspace(
+    const workspace = await ui.task({
+      title: `Preparing workspace for ${selectedIssue.repoFullName}`,
+      doneMessage: 'Workspace prepared',
+      failedMessage: 'Workspace preparation failed',
+      tone: 'info',
+      step: { index: 4, total: totalSteps },
+      heartbeat: {
+        message: 'Still preparing repository workspace',
+      },
+    }, async () => workspaceService.prepareWorkspace(
       selectedIssue,
       memoryBeforeRun,
       runChecks,
       headless ? 'headless' : 'interactive',
       repoPath,
-    );
+    ));
     const memory = memoryService.update(selectedIssue, workspace);
 
-    const patchDraftResult = await llmService.generatePatchDraft(selectedIssue, workspace, memory);
+    const patchDraftResult = await ui.task({
+      title: 'Generating patch strategy',
+      doneMessage: 'Patch strategy generated',
+      failedMessage: 'Patch strategy generation failed',
+      tone: 'info',
+      step: { index: 5, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting patch strategy',
+      },
+    }, async () => llmService.generatePatchDraft(selectedIssue, workspace, memory));
     const patchDraft = patchDraftResult.data;
     const implementationWorkspace = this.buildImplementationWorkspace(workspace, patchDraft);
     const implementation = patchDraftResult.status === 'success'
@@ -233,12 +275,27 @@ export class AgentOrchestrator {
       testResults: implementation.validationResults,
     };
 
-    const prDraftResult = await llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts);
+    const prDraftResult = await ui.task({
+      title: 'Generating PR narrative',
+      doneMessage: 'PR narrative generated',
+      failedMessage: 'PR narrative generation failed',
+      tone: 'info',
+      step: { index: 6, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting PR narrative',
+      },
+    }, async () => llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts));
     const prDraft = prDraftResult.data;
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
     const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
 
-    const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
+    const contributionPullRequest = await ui.task({
+      title: 'Evaluating draft PR creation',
+      doneMessage: 'Draft PR evaluation complete',
+      failedMessage: 'Draft PR evaluation failed',
+      tone: 'info',
+      step: { index: 7, total: totalSteps },
+    }, async () => this.submitContributionPullRequestIfPossible({
       config,
       allowRealPr: patchDraftResult.status === 'success' && prDraftResult.status === 'success',
       headless,
@@ -247,7 +304,7 @@ export class AgentOrchestrator {
       workspace: workspaceForArtifacts,
       changedFiles: implementation.changedFiles,
       validationResults: implementation.validationResults,
-    });
+    }));
 
     const artifacts = this.prepareLocalArtifactPaths(selectedIssue);
     const reviewRequired =
@@ -306,7 +363,13 @@ export class AgentOrchestrator {
         proofMarkdown,
       });
 
-      const publishResult = await this.publishArtifactsIfNeeded({
+      const publishResult = await ui.task({
+        title: dryRun ? 'Previewing artifact publication' : 'Publishing contribution artifacts',
+        doneMessage: dryRun ? 'Artifact publication preview complete' : 'Contribution artifacts published',
+        failedMessage: dryRun ? 'Artifact publication preview failed' : 'Contribution artifact publication failed',
+        tone: 'info',
+        step: { index: 8, total: totalSteps },
+      }, async () => this.publishArtifactsIfNeeded({
         config,
         headless,
         dryRun: options.dryRun,
@@ -320,7 +383,7 @@ export class AgentOrchestrator {
         changedFiles: implementation.changedFiles,
         validationResults: implementation.validationResults,
         pullRequestUrl: contributionPullRequest.url,
-      });
+      }));
 
       const finalProofRecord = {
         ...proofRecord,
@@ -744,6 +807,7 @@ export class AgentOrchestrator {
   }
 
   async scoutMachine(options: ScoutRunOptions = {}): Promise<MachineScoutResult> {
+    const totalSteps = 3;
     const limit = options.limit ?? 10;
     const refresh = Boolean(options.refresh);
     const repoFullName = options.repo ? parseGitHubRepoFullName(options.repo) : undefined;
@@ -752,14 +816,31 @@ export class AgentOrchestrator {
 
     await this.validateConfig(config, { requireGithub: !localOnly, requireLlm: !localOnly });
     if (!localOnly || repoFullName) {
-      await this.initializeClients(config, { validateGithub: true, validateLlm: !localOnly });
+      await this.initializeClients(config, {
+        validateGithub: true,
+        validateLlm: !localOnly,
+        taskSteps: {
+          github: { index: 1, total: totalSteps },
+          ...(localOnly ? {} : { llm: { index: 2, total: totalSteps } }),
+        },
+      });
     }
 
-    const rankedIssues = await issueRankingService.loadRankedIssues(config, {
+    const rankedIssues = await ui.task({
+      title: 'Scoring contribution opportunities',
+      doneMessage: 'Contribution opportunities scored',
+      failedMessage: 'Contribution opportunity scoring failed',
+      tone: 'info',
+      step: { index: localOnly ? 2 : 3, total: totalSteps },
+      heartbeat: {
+        message: 'Still scoring contribution opportunities',
+      },
+    }, async (task) => issueRankingService.loadRankedIssues(config, {
       refresh,
       repoFullName,
       localOnly,
-    });
+      onStatus: (message) => task.setMessage(message),
+    }));
 
     return {
       opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
@@ -1105,7 +1186,14 @@ export class AgentOrchestrator {
 
   private async initializeClients(
     config: AppConfig,
-    options: { validateGithub?: boolean; validateLlm?: boolean } = {},
+    options: {
+      validateGithub?: boolean;
+      validateLlm?: boolean;
+      taskSteps?: {
+        github?: { index: number; total: number };
+        llm?: { index: number; total: number };
+      };
+    } = {},
   ): Promise<void> {
     const validateGithub = options.validateGithub ?? true;
     const validateLlm = options.validateLlm ?? true;
@@ -1117,6 +1205,7 @@ export class AgentOrchestrator {
         doneMessage: 'GitHub access verified',
         failedMessage: 'GitHub access failed',
         tone: 'info',
+        step: options.taskSteps?.github,
       }, async () => {
         const valid = await githubService.validateCredentials();
         if (!valid) {
@@ -1149,6 +1238,7 @@ export class AgentOrchestrator {
       doneMessage: 'LLM provider verified',
       failedMessage: 'LLM provider failed',
       tone: 'info',
+      step: options.taskSteps?.llm,
     }, async () => {
       const valid = await llmService.validateConnection();
       if (!valid) {

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -68,20 +68,34 @@ export class AnalyzeOrchestrator {
     await this.initializeClients(config);
     this.showLocalRepositoryHint(repoPath);
 
+    const totalSteps = 7;
     const memory = memoryService.load(repoFullName);
-    const workspace = await workspaceService.prepareRepositoryWorkspace(
+    const workspace = await ui.task({
+      title: 'Preparing repository workspace',
+      doneMessage: 'Repository workspace prepared',
+      failedMessage: 'Repository workspace preparation failed',
+      tone: 'info',
+      step: { index: 3, total: totalSteps },
+      heartbeat: {
+        message: 'Still preparing repository workspace',
+      },
+    }, async () => workspaceService.prepareRepositoryWorkspace(
       repoFullName,
       memory,
       runChecks,
       headless ? 'headless' : 'interactive',
       repoPath,
-    );
+    ));
 
     const suggestionsResult = await ui.task({
       title: 'Inspecting repository for grounded contribution ideas',
       doneMessage: 'Repository suggestions generated',
       failedMessage: 'Repository suggestion analysis failed',
       tone: 'info',
+      step: { index: 4, total: totalSteps },
+      heartbeat: {
+        message: 'Still inspecting repository context',
+      },
     }, async () => llmService.analyzeRepository(repoFullName, workspace, memory));
     const suggestions = suggestionsResult.data;
     const selectedSuggestion = headless
@@ -94,6 +108,7 @@ export class AnalyzeOrchestrator {
       doneMessage: 'Repository suggestion selected',
       failedMessage: 'Repository suggestion selection failed',
       tone: 'info',
+      step: { index: 5, total: totalSteps },
     }, async () => selectedSuggestion);
 
     const patchDraftResult = await ui.task({
@@ -101,6 +116,10 @@ export class AnalyzeOrchestrator {
       doneMessage: 'Patch strategy drafted',
       failedMessage: 'Patch strategy drafting failed',
       tone: 'info',
+      step: { index: 6, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting patch strategy',
+      },
     }, async () => llmService.generatePatchDraft(syntheticIssue, workspace, memory));
     const patchDraft = patchDraftResult.data;
     const prDraftResult = await ui.task({
@@ -108,6 +127,10 @@ export class AnalyzeOrchestrator {
       doneMessage: 'Pull request narrative drafted',
       failedMessage: 'Pull request narrative drafting failed',
       tone: 'info',
+      step: { index: 7, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting pull request narrative',
+      },
     }, async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspace));
     const prDraft = prDraftResult.data;
 
@@ -239,6 +262,7 @@ export class AnalyzeOrchestrator {
       doneMessage: 'GitHub access verified',
       failedMessage: 'GitHub access failed',
       tone: 'info',
+      step: { index: 1, total: 7 },
     }, async () => {
       const valid = await githubService.validateCredentials();
       if (!valid) {
@@ -263,6 +287,7 @@ export class AnalyzeOrchestrator {
       doneMessage: 'LLM provider verified',
       failedMessage: 'LLM provider failed',
       tone: 'info',
+      step: { index: 2, total: 7 },
     }, async () => {
       const valid = await llmService.validateConnection();
       if (!valid) {

--- a/src/orchestration/machine/agent.ts
+++ b/src/orchestration/machine/agent.ts
@@ -1,7 +1,7 @@
 import { agentOrchestrator } from '../index.js';
 import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
-import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineAgentFlowOrchestrator {
   async execute(options: {
@@ -15,6 +15,15 @@ export class MachineAgentFlowOrchestrator {
     dryRun?: boolean;
   } = {}): Promise<void> {
     try {
+      writeMachinePlan('machine agent', [
+        'Validate GitHub access',
+        'Validate LLM provider',
+        'Scout or load the target issue',
+        'Prepare repository workspace',
+        'Draft patch and PR artifacts without mutating the repository unless allowed',
+        'Optionally apply changes or open a draft PR depending on execution flags',
+        'Return execution outcome with artifact paths and next actions',
+      ]);
       const result = await runInMachineContext(() => agentOrchestrator.runMachine({
         headless: options.headless ?? true,
         runChecks: options.runChecks,

--- a/src/orchestration/machine/analyze.ts
+++ b/src/orchestration/machine/analyze.ts
@@ -1,7 +1,7 @@
 import { analyzeOrchestrator } from '../index.js';
 import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
-import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineAnalyzeOrchestrator {
   async execute(options: {
@@ -12,6 +12,15 @@ export class MachineAnalyzeOrchestrator {
     dryRun?: boolean;
   } = {}): Promise<void> {
     try {
+      writeMachinePlan('machine analyze', [
+        'Validate GitHub access',
+        'Validate LLM provider',
+        'Prepare repository workspace',
+        'Inspect repository for grounded contribution ideas',
+        'Select the strongest repository suggestion',
+        'Draft patch strategy for the selected suggestion',
+        'Draft pull request narrative for the selected suggestion',
+      ]);
       const result = await runInMachineContext(() => analyzeOrchestrator.runMachine({
         repo: options.repo,
         repoPath: options.repoPath,

--- a/src/orchestration/machine/runtime.ts
+++ b/src/orchestration/machine/runtime.ts
@@ -34,3 +34,18 @@ export function buildMachineErrorEnvelope(
 export function writeMachinePayload(payload: MachineEnvelope<unknown> | MachineErrorEnvelope): void {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
+
+export function writeMachinePlan(command: string, steps: string[]): void {
+  if (steps.length === 0) {
+    return;
+  }
+
+  const lines = [
+    `Machine execution plan for ${command}:`,
+    ...steps.map((step, index) => `${index + 1}. ${step}`),
+  ];
+
+  for (const line of lines) {
+    process.stderr.write(`${line}\n`);
+  }
+}

--- a/src/orchestration/machine/scout.ts
+++ b/src/orchestration/machine/scout.ts
@@ -1,7 +1,7 @@
 import { agentOrchestrator } from '../index.js';
 import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
-import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineScoutOrchestrator {
   async execute(options: {
@@ -11,6 +11,12 @@ export class MachineScoutOrchestrator {
     local?: boolean;
   } = {}): Promise<void> {
     try {
+      writeMachinePlan('machine scout', [
+        'Validate GitHub access when remote scouting is enabled',
+        'Validate LLM provider when model scoring is enabled',
+        'Fetch and score contribution opportunities',
+        'Return ranked opportunities with mode metadata',
+      ]);
       const result = await runInMachineContext(() => agentOrchestrator.scoutMachine({
         limit: Number.parseInt(options.limit || '10', 10) || 10,
         refresh: options.refresh,

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -189,6 +189,8 @@ describe('machine flow result builders', () => {
 
     const combined = stderrWrites.join('');
     expect(combined).toContain('--repo-path <local-path>');
+    expect(combined).toContain('Step 3/7 Preparing repository workspace');
+    expect(combined).toContain('Step 4/7 Inspecting repository for grounded contribution ideas');
     expect(combined).toContain('Inspecting repository for grounded contribution ideas');
     expect(combined).toContain('Selecting the strongest repository suggestion');
     expect(combined).toContain('Drafting patch strategy for the selected suggestion');

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -316,11 +316,14 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine analyze');
     expect(output.data.repoFullName).toBe('acme/demo');
     expect(output.data.mode.dryRun).toBe(true);
+    expect(stderrWrites.join('')).toContain('Machine execution plan for machine analyze');
+    expect(stderrWrites.join('')).toContain('Prepare repository workspace');
     expect(stderrWrites.join('')).toContain('Inspecting repository for grounded contribution ideas');
   });
 
   test('machine agent writes execution outcome as JSON only', async () => {
     const writes = captureStdout();
+    const stderrWrites = captureStderr();
     const program = new Command();
     registerMachineCommand(program);
     const issue = createRankedIssue({ repoFullName: 'acme/demo', number: 42 });
@@ -373,6 +376,8 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine agent');
     expect(output.data.executionOutcome).toBe('draft_only');
     expect(output.data.repoMutated).toBe(false);
+    expect(stderrWrites.join('')).toContain('Machine execution plan for machine agent');
+    expect(stderrWrites.join('')).toContain('Draft patch and PR artifacts without mutating the repository');
   });
 
   test('machine scout suppresses human task output during real machine execution', async () => {

--- a/test/ui-task.test.ts
+++ b/test/ui-task.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { runInMachineContext } from '../src/infra/execution-context.js';
+import { runTask } from '../src/infra/ui/live.js';
+import type { UiCapabilities } from '../src/infra/ui/types.js';
+
+const capabilities: UiCapabilities = {
+  width: 100,
+  isInteractive: false,
+  supportsColor: false,
+  supportsUnicode: true,
+  mode: 'plain',
+};
+
+describe('ui task progress', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('machine task prefixes step progress and emits heartbeat updates after quiet periods', async () => {
+    const stderrWrites: string[] = [];
+
+    spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runInMachineContext(() => runTask(
+      capabilities,
+      {
+        title: 'Waiting for repository analysis',
+        doneMessage: 'Repository analysis finished',
+        step: { index: 2, total: 4 },
+        heartbeat: {
+          intervalMs: 5,
+          message: ({ elapsedMs }) => `Still working after ${elapsedMs}ms`,
+        },
+      },
+      async (task) => {
+        task.setMessage('Captured repository context');
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return true;
+      },
+    ));
+
+    const combined = stderrWrites.join('');
+    expect(combined).toContain('Step 2/4 Waiting for repository analysis');
+    expect(combined).toContain('Step 2/4 Captured repository context');
+    expect(combined).toContain('Step 2/4 Still working after');
+    expect(combined).toContain('[success] Step 2/4 Repository analysis finished');
+  });
+});


### PR DESCRIPTION
## Summary
- add step-based progress labels and heartbeat messages for long-running machine tasks
- emit machine execution plans for scout, analyze, and agent flows before work starts
- improve Claude Code and `claude -p` visibility during repository prep, ranking, drafting, and publish stages

## Why
Long-running `/openmeta` machine flows could appear stalled in interactive TUI contexts because they produced little or no intermediate feedback. This change makes the active phase visible, adds periodic heartbeat output during quiet stretches, and shows the overall machine plan up front so users know what is happening.

## Validation
- `bun test test/ui-task.test.ts test/machine-agent.test.ts test/machine-commands.test.ts`
- `bun run typecheck`
- `bun run build`
