### PR TITLE
[codex] harden doctor and workspace diagnostics

### DIFF
--- a/skills/core/openmeta.md
+++ b/skills/core/openmeta.md
@@ -11,6 +11,15 @@ This skill lets an external agent treat OpenMeta as a stable execution substrate
 - Treat stderr as optional diagnostics only.
 - Escalate to `openmeta machine agent` only when the user explicitly asks for execution.
 
+## What OpenMeta Can Do
+
+OpenMeta is built for contribution-oriented open source work.
+
+- Discover and rank worthwhile issues across one repository or a broader issue stream.
+- Analyze a repository and draft a grounded patch plan plus PR narrative before writing code.
+- Execute a fuller contribution flow when the user explicitly wants OpenMeta to mutate files or open a PR.
+- Inspect prior runs, saved opportunity backlog, and proof-of-work records to understand what already happened.
+
 ## Installation Expectations
 
 - Install the OpenMeta CLI and ensure `openmeta` is on `PATH`.

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -12,10 +12,11 @@ export function registerAgentCommand(program: Command): void {
     .option('--draft-only', 'Generate dossier and PR draft artifacts without applying file edits or opening a PR')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
+    .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
     .option('--dry-run', 'Preview artifacts without writing to git')
     .addOption(new Option('--scheduler-run', 'Internal flag for scheduled automation').hideHelp())
-    .action((options: { headless?: boolean; force?: boolean; runChecks?: boolean; draftOnly?: boolean; refresh?: boolean; repo?: string; issue?: string; dryRun?: boolean; schedulerRun?: boolean }) => runCommand(
+    .action((options: { headless?: boolean; force?: boolean; runChecks?: boolean; draftOnly?: boolean; refresh?: boolean; repo?: string; repoPath?: string; issue?: string; dryRun?: boolean; schedulerRun?: boolean }) => runCommand(
       'OpenMeta Agent',
       () => agentOrchestrator.run({
         headless: options.headless,
@@ -24,6 +25,7 @@ export function registerAgentCommand(program: Command): void {
         draftOnly: options.draftOnly,
         refresh: options.refresh,
         repo: options.repo,
+        repoPath: options.repoPath,
         issue: options.issue,
         dryRun: options.dryRun,
         schedulerRun: options.schedulerRun,

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -7,13 +7,15 @@ export function registerAnalyzeCommand(program: Command): void {
     .command('analyze')
     .description('Analyze a repository and draft contribution suggestions without relying on existing issues')
     .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name to analyze')
+    .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--headless', 'Select the highest-scoring suggestion without prompting')
     .option('--run-checks', 'Execute detected baseline validation commands during workspace preparation')
     .option('--dry-run', 'Preview artifact paths without writing local analysis files')
-    .action((options: { repo?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) => runCommand(
+    .action((options: { repo?: string; repoPath?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) => runCommand(
       'OpenMeta Analyze',
       () => analyzeOrchestrator.run({
         repo: options.repo,
+        repoPath: options.repoPath,
         headless: options.headless,
         runChecks: options.runChecks,
         dryRun: options.dryRun,

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -93,10 +93,11 @@ export function registerMachineCommand(program: Command): void {
     .command('analyze')
     .description('Machine-safe repository-first analysis')
     .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name to analyze')
+    .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--headless', 'Select the highest-scoring suggestion without prompting')
     .option('--run-checks', 'Execute detected baseline validation commands during workspace preparation')
     .option('--dry-run', 'Preview artifact paths without writing local analysis files')
-    .action((options: { repo?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) => machineAnalyzeOrchestrator.execute(options));
+    .action((options: { repo?: string; repoPath?: string; headless?: boolean; runChecks?: boolean; dryRun?: boolean }) => machineAnalyzeOrchestrator.execute(options));
 
   machine
     .command('agent')
@@ -106,6 +107,7 @@ export function registerMachineCommand(program: Command): void {
     .option('--draft-only', 'Generate artifacts without applying file edits or opening a PR')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one repository')
+    .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
     .option('--dry-run', 'Preview artifacts without publishing them')
     .action((options: {
@@ -114,6 +116,7 @@ export function registerMachineCommand(program: Command): void {
       draftOnly?: boolean;
       refresh?: boolean;
       repo?: string;
+      repoPath?: string;
       issue?: string;
       dryRun?: boolean;
     }) => machineAgentFlowOrchestrator.execute(options));

--- a/src/infra/ui/live.ts
+++ b/src/infra/ui/live.ts
@@ -4,6 +4,26 @@ import figures from 'figures';
 import { isMachineContext } from '../execution-context.js';
 import type { TaskController, TaskOptions, Tone, UiCapabilities } from './types.js';
 
+function renderStepLabel(options: TaskOptions): string {
+  if (!options.step) {
+    return options.title;
+  }
+
+  return `Step ${options.step.index}/${options.step.total} ${options.title}`;
+}
+
+function resolveHeartbeatMessage(options: TaskOptions, elapsedMs: number): string | null {
+  if (!options.heartbeat) {
+    return null;
+  }
+
+  const message = typeof options.heartbeat.message === 'function'
+    ? options.heartbeat.message({ elapsedMs })
+    : options.heartbeat.message;
+
+  return message ? renderStepLabel({ ...options, title: message }) : null;
+}
+
 function toneColor(tone: Tone): 'green' | 'yellow' | 'red' | 'magenta' | 'white' | 'cyan' {
   switch (tone) {
     case 'success':
@@ -52,36 +72,72 @@ export async function runTask<T>(
   task: (controller: TaskController) => Promise<T>,
 ): Promise<T> {
   const tone = options.tone ?? 'info';
+  const title = renderStepLabel(options);
+  const doneMessage = options.doneMessage ? renderStepLabel({ ...options, title: options.doneMessage }) : title;
+  const failedMessage = options.failedMessage ? renderStepLabel({ ...options, title: options.failedMessage }) : title;
   const controller: TaskController = {
     setMessage(_message: string): void {
       // no-op by default; interactive mode replaces this with spinner.message(...)
     },
   };
+  const startedAt = Date.now();
+  const heartbeatIntervalMs = Math.max(10, options.heartbeat?.intervalMs ?? 10_000);
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let lastHeartbeatMessage = '';
+
+  const startHeartbeat = (emit: (message: string) => void): void => {
+    if (!options.heartbeat) {
+      return;
+    }
+
+    heartbeatTimer = setInterval(() => {
+      const message = resolveHeartbeatMessage(options, Date.now() - startedAt);
+      if (!message || message === lastHeartbeatMessage) {
+        return;
+      }
+
+      lastHeartbeatMessage = message;
+      emit(message);
+    }, heartbeatIntervalMs);
+  };
+
+  const stopHeartbeat = (): void => {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+  };
 
   if (isMachineContext()) {
-    writeMachineStatus(figures.pointerSmall, options.title, tone);
+    writeMachineStatus(figures.pointerSmall, title, tone);
     controller.setMessage = (message: string) => {
-      writeMachineStatus(figures.ellipsis, message, tone);
+      writeMachineStatus(figures.ellipsis, renderStepLabel({ ...options, title: message }), tone);
     };
+    startHeartbeat((message) => writeMachineStatus(figures.ellipsis, message, tone));
 
     try {
       const result = await task(controller);
-      writeMachineStatus(figures.tick, `[success] ${options.doneMessage || options.title}`, 'success');
+      stopHeartbeat();
+      writeMachineStatus(figures.tick, `[success] ${doneMessage}`, 'success');
       return result;
     } catch (error) {
-      writeMachineStatus(figures.cross, options.failedMessage || options.title, 'error');
+      stopHeartbeat();
+      writeMachineStatus(figures.cross, failedMessage, 'error');
       throw error;
     }
   }
 
   if (!capabilities.isInteractive || capabilities.mode === 'plain') {
-    process.stdout.write(`${renderInlineStatus(figures.pointerSmall, options.title, tone)}\n`);
+    process.stdout.write(`${renderInlineStatus(figures.pointerSmall, title, tone)}\n`);
+    startHeartbeat((message) => process.stdout.write(`${renderInlineStatus(figures.ellipsis, message, tone)}\n`));
     try {
       const result = await task(controller);
-      process.stdout.write(`${renderInlineStatus(figures.tick, `[success] ${options.doneMessage || options.title}`, 'success')}\n`);
+      stopHeartbeat();
+      process.stdout.write(`${renderInlineStatus(figures.tick, `[success] ${doneMessage}`, 'success')}\n`);
       return result;
     } catch (error) {
-      process.stdout.write(`${renderInlineStatus(figures.cross, options.failedMessage || options.title, 'error')}\n`);
+      stopHeartbeat();
+      process.stdout.write(`${renderInlineStatus(figures.cross, failedMessage, 'error')}\n`);
       throw error;
     }
   }
@@ -89,17 +145,20 @@ export async function runTask<T>(
   const spinner = p.spinner({
     indicator: capabilities.supportsUnicode ? 'dots' : 'timer',
   });
-  spinner.start(options.title);
+  spinner.start(title);
   controller.setMessage = (message: string) => {
-    spinner.message(message);
+    spinner.message(renderStepLabel({ ...options, title: message }));
   };
+  startHeartbeat((message) => spinner.message(message));
 
   try {
     const result = await task(controller);
-    spinner.stop(`${figures.tick} [success] ${options.doneMessage || options.title}`);
+    stopHeartbeat();
+    spinner.stop(`${figures.tick} [success] ${doneMessage}`);
     return result;
   } catch (error) {
-    spinner.error(`${figures.cross} [error] ${options.failedMessage || options.title}`);
+    stopHeartbeat();
+    spinner.error(`${figures.cross} [error] ${failedMessage}`);
     throw error;
   }
 }

--- a/src/infra/ui/live.ts
+++ b/src/infra/ui/live.ts
@@ -42,6 +42,10 @@ function renderInlineStatus(symbol: string, text: string, tone: Tone): string {
   }
 }
 
+function writeMachineStatus(symbol: string, text: string, tone: Tone): void {
+  process.stderr.write(`${renderInlineStatus(symbol, text, tone)}\n`);
+}
+
 export async function runTask<T>(
   capabilities: UiCapabilities,
   options: TaskOptions,
@@ -55,7 +59,19 @@ export async function runTask<T>(
   };
 
   if (isMachineContext()) {
-    return task(controller);
+    writeMachineStatus(figures.pointerSmall, options.title, tone);
+    controller.setMessage = (message: string) => {
+      writeMachineStatus(figures.ellipsis, message, tone);
+    };
+
+    try {
+      const result = await task(controller);
+      writeMachineStatus(figures.tick, `[success] ${options.doneMessage || options.title}`, 'success');
+      return result;
+    } catch (error) {
+      writeMachineStatus(figures.cross, options.failedMessage || options.title, 'error');
+      throw error;
+    }
   }
 
   if (!capabilities.isInteractive || capabilities.mode === 'plain') {

--- a/src/infra/ui/types.ts
+++ b/src/infra/ui/types.ts
@@ -49,6 +49,14 @@ export interface TaskOptions {
   doneMessage?: string;
   failedMessage?: string;
   tone?: Tone;
+  step?: {
+    index: number;
+    total: number;
+  };
+  heartbeat?: {
+    intervalMs?: number;
+    message: string | ((context: { elapsedMs: number }) => string);
+  };
 }
 
 export interface TaskController {

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -66,6 +66,11 @@ export interface MachineScoutResult {
     repo?: string;
     localOnly: boolean;
   };
+  emptyExplanation?: {
+    title: string;
+    detail: string;
+    suggestions: string[];
+  };
   nextActions: string[];
 }
 
@@ -160,6 +165,25 @@ const AGENT_STAGES: Array<{ id: AgentStageId; label: string; description: string
 
 export class AgentOrchestrator {
   private octokit: Octokit | null = null;
+
+  private buildScoutEmptyExplanation(
+    config: AppConfig,
+    options: { repoFullName?: string; localOnly: boolean; refresh: boolean },
+  ): { title: string; detail: string; suggestions: string[] } {
+    const scopeLine = options.repoFullName
+      ? `This run was limited to ${options.repoFullName}.`
+      : 'This run searched the broader GitHub issue stream.';
+
+    return {
+      title: 'No issues cleared the current filters',
+      detail: `${scopeLine} OpenMeta did not find any opportunities that survived the current profile weighting and ${config.automation.minMatchScore}/100 threshold.`,
+      suggestions: [
+        `Lower automation.minMatchScore below ${config.automation.minMatchScore}.`,
+        options.repoFullName ? 'Try a different repository or remove the repo filter.' : 'Broaden your tech stack or focus areas in the saved profile.',
+        options.localOnly ? 'Run scout without --local after the LLM provider is healthy to widen scoring coverage.' : options.refresh ? 'Try again later after new issues appear.' : 'Rerun with --refresh to ignore the local issue cache.',
+      ],
+    };
+  }
 
   async runMachine(options: AgentRunOptions = {}): Promise<MachineAgentResult> {
     const totalSteps = 8;
@@ -793,7 +817,8 @@ export class AgentOrchestrator {
       onStatus: (message) => task.setMessage(message),
     }));
     if (rankedIssues.length === 0) {
-      ui.emptyState('OpenMeta Scout', 'No issues found', 'No issues met the current scoring thresholds.');
+      const emptyExplanation = this.buildScoutEmptyExplanation(config, { repoFullName, localOnly, refresh });
+      ui.emptyState('OpenMeta Scout', emptyExplanation.title, `${emptyExplanation.detail} Next: ${emptyExplanation.suggestions.join(' ')}`);
       return;
     }
 
@@ -841,6 +866,9 @@ export class AgentOrchestrator {
       localOnly,
       onStatus: (message) => task.setMessage(message),
     }));
+    const emptyExplanation = rankedIssues.length === 0
+      ? this.buildScoutEmptyExplanation(config, { repoFullName, localOnly, refresh })
+      : undefined;
 
     return {
       opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
@@ -850,6 +878,7 @@ export class AgentOrchestrator {
         repo: repoFullName,
         localOnly,
       },
+      ...(emptyExplanation ? { emptyExplanation } : {}),
       nextActions: rankedIssues.length === 0 ? ['broaden_profile_filters'] : ['inspect_ranked_opportunities'],
     };
   }

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -46,6 +46,7 @@ export interface AgentRunOptions {
   draftOnly?: boolean;
   refresh?: boolean;
   repo?: string;
+  repoPath?: string;
   issue?: string;
   dryRun?: boolean;
 }
@@ -168,6 +169,7 @@ export class AgentOrchestrator {
     const draftOnly = Boolean(options.draftOnly);
     const refresh = Boolean(options.refresh);
     const dryRun = Boolean(options.dryRun);
+    const repoPath = options.repoPath?.trim() || undefined;
     const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
     const repoFullName = issueTarget?.repoFullName ?? (options.repo ? parseGitHubRepoFullName(options.repo) : undefined);
 
@@ -178,6 +180,7 @@ export class AgentOrchestrator {
     }
 
     await this.initializeClients(config);
+    this.showLocalRepositoryHint(repoPath);
 
     const rankedIssues = issueTarget
       ? await issueRankingService.loadTargetIssue(config, issueTarget)
@@ -210,6 +213,7 @@ export class AgentOrchestrator {
       memoryBeforeRun,
       runChecks,
       headless ? 'headless' : 'interactive',
+      repoPath,
     );
     const memory = memoryService.update(selectedIssue, workspace);
 
@@ -384,6 +388,7 @@ export class AgentOrchestrator {
     const runChecks = typeof options.runChecks === 'boolean' ? options.runChecks : !headless;
     const draftOnly = Boolean(options.draftOnly);
     const refresh = Boolean(options.refresh);
+    const repoPath = options.repoPath?.trim() || undefined;
     const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
     const repoFullName = issueTarget?.repoFullName ?? (options.repo ? parseGitHubRepoFullName(options.repo) : undefined);
     const completedStages = new Set<AgentStageId>();
@@ -407,6 +412,9 @@ export class AgentOrchestrator {
           : repoFullName
             ? `Issue discovery is limited to ${repoFullName}.`
             : 'Issue discovery will scan the broader GitHub issue stream.',
+        repoPath
+          ? `Local repository reuse is enabled via ${repoPath}. OpenMeta will create an isolated worktree and a fresh branch before opening a PR.`
+          : 'If the repository already exists locally, pass --repo-path <local-path> so OpenMeta can reuse it via an isolated worktree and open the PR from a fresh branch.',
         headless ? `Unattended selection honors the saved threshold at ${config.automation.minMatchScore}/100.` : 'You stay in control at each decision gate before anything is published.',
       ],
     });
@@ -421,6 +429,7 @@ export class AgentOrchestrator {
       ? `Verifying provider access and loading ${issueTarget.repoFullName}#${issueTarget.issueNumber}.`
       : 'Verifying provider access and loading ranked opportunities.');
     await this.initializeClients(config);
+    this.showLocalRepositoryHint(repoPath);
 
     const rankedIssues = await ui.task({
       title: issueTarget ? 'Loading target issue' : 'Ranking contribution opportunities',
@@ -486,6 +495,7 @@ export class AgentOrchestrator {
       memoryBeforeRun,
       runChecks,
       headless ? 'headless' : 'interactive',
+      repoPath,
     ));
     const memory = memoryService.update(selectedIssue, workspace);
     completedStages.add('prepare');
@@ -2158,6 +2168,28 @@ export class AgentOrchestrator {
       subtitle: input.subtitle,
       lines: input.lines,
       tone: 'warning',
+    });
+  }
+
+  private showLocalRepositoryHint(repoPath?: string): void {
+    if (repoPath) {
+      logger.info(`Using local repository path via isolated worktree: ${repoPath}`);
+      ui.callout({
+        label: 'OpenMeta Agent',
+        title: 'Local repository reuse enabled',
+        subtitle: 'OpenMeta will reuse the provided local repository through an isolated worktree, create a fresh branch, and keep PR work off your existing checkout.',
+        lines: [`Path: ${repoPath}`],
+        tone: 'info',
+      });
+      return;
+    }
+
+    logger.info('Tip: if this repository already exists locally, pass --repo-path <local-path>. OpenMeta will reuse it via an isolated worktree, create a fresh branch, and open the PR from that branch.');
+    ui.callout({
+      label: 'OpenMeta Agent',
+      title: 'Faster local reuse available',
+      subtitle: 'If the repository is already on disk, pass --repo-path <local-path>. OpenMeta will reuse it via an isolated worktree, create a fresh branch, and avoid another full local checkout.',
+      tone: 'info',
     });
   }
 

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -162,6 +162,7 @@ export class AgentOrchestrator {
   private octokit: Octokit | null = null;
 
   async runMachine(options: AgentRunOptions = {}): Promise<MachineAgentResult> {
+    const totalSteps = 8;
     const config = await configService.get();
     const headless = options.headless ?? true;
     const schedulerRun = Boolean(options.schedulerRun);
@@ -179,15 +180,38 @@ export class AgentOrchestrator {
       await this.confirmManualHeadlessRun(config);
     }
 
-    await this.initializeClients(config);
+    await this.initializeClients(config, {
+      validateGithub: true,
+      validateLlm: true,
+      taskSteps: {
+        github: { index: 1, total: totalSteps },
+        llm: { index: 2, total: totalSteps },
+      },
+    });
     this.showLocalRepositoryHint(repoPath);
 
     const rankedIssues = issueTarget
-      ? await issueRankingService.loadTargetIssue(config, issueTarget)
-      : await issueRankingService.loadRankedIssues(config, {
+      ? await ui.task({
+        title: 'Loading target issue',
+        doneMessage: 'Target issue loaded',
+        failedMessage: 'Target issue loading failed',
+        tone: 'info',
+        step: { index: 3, total: totalSteps },
+      }, async () => issueRankingService.loadTargetIssue(config, issueTarget))
+      : await ui.task({
+        title: 'Ranking contribution opportunities',
+        doneMessage: 'Contribution opportunities ranked',
+        failedMessage: 'Contribution opportunity ranking failed',
+        tone: 'info',
+        step: { index: 3, total: totalSteps },
+        heartbeat: {
+          message: 'Still ranking contribution opportunities',
+        },
+      }, async (task) => issueRankingService.loadRankedIssues(config, {
         refresh,
         repoFullName,
-      });
+        onStatus: (message) => task.setMessage(message),
+      }));
 
     if (rankedIssues.length === 0) {
       throw new Error(issueTarget
@@ -208,16 +232,34 @@ export class AgentOrchestrator {
     }
 
     const memoryBeforeRun = memoryService.load(selectedIssue.repoFullName);
-    const workspace = await workspaceService.prepareWorkspace(
+    const workspace = await ui.task({
+      title: `Preparing workspace for ${selectedIssue.repoFullName}`,
+      doneMessage: 'Workspace prepared',
+      failedMessage: 'Workspace preparation failed',
+      tone: 'info',
+      step: { index: 4, total: totalSteps },
+      heartbeat: {
+        message: 'Still preparing repository workspace',
+      },
+    }, async () => workspaceService.prepareWorkspace(
       selectedIssue,
       memoryBeforeRun,
       runChecks,
       headless ? 'headless' : 'interactive',
       repoPath,
-    );
+    ));
     const memory = memoryService.update(selectedIssue, workspace);
 
-    const patchDraftResult = await llmService.generatePatchDraft(selectedIssue, workspace, memory);
+    const patchDraftResult = await ui.task({
+      title: 'Generating patch strategy',
+      doneMessage: 'Patch strategy generated',
+      failedMessage: 'Patch strategy generation failed',
+      tone: 'info',
+      step: { index: 5, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting patch strategy',
+      },
+    }, async () => llmService.generatePatchDraft(selectedIssue, workspace, memory));
     const patchDraft = patchDraftResult.data;
     const implementationWorkspace = this.buildImplementationWorkspace(workspace, patchDraft);
     const implementation = patchDraftResult.status === 'success'
@@ -233,12 +275,27 @@ export class AgentOrchestrator {
       testResults: implementation.validationResults,
     };
 
-    const prDraftResult = await llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts);
+    const prDraftResult = await ui.task({
+      title: 'Generating PR narrative',
+      doneMessage: 'PR narrative generated',
+      failedMessage: 'PR narrative generation failed',
+      tone: 'info',
+      step: { index: 6, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting PR narrative',
+      },
+    }, async () => llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts));
     const prDraft = prDraftResult.data;
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
     const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
 
-    const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
+    const contributionPullRequest = await ui.task({
+      title: 'Evaluating draft PR creation',
+      doneMessage: 'Draft PR evaluation complete',
+      failedMessage: 'Draft PR evaluation failed',
+      tone: 'info',
+      step: { index: 7, total: totalSteps },
+    }, async () => this.submitContributionPullRequestIfPossible({
       config,
       allowRealPr: patchDraftResult.status === 'success' && prDraftResult.status === 'success',
       headless,
@@ -247,7 +304,7 @@ export class AgentOrchestrator {
       workspace: workspaceForArtifacts,
       changedFiles: implementation.changedFiles,
       validationResults: implementation.validationResults,
-    });
+    }));
 
     const artifacts = this.prepareLocalArtifactPaths(selectedIssue);
     const reviewRequired =
@@ -306,7 +363,13 @@ export class AgentOrchestrator {
         proofMarkdown,
       });
 
-      const publishResult = await this.publishArtifactsIfNeeded({
+      const publishResult = await ui.task({
+        title: dryRun ? 'Previewing artifact publication' : 'Publishing contribution artifacts',
+        doneMessage: dryRun ? 'Artifact publication preview complete' : 'Contribution artifacts published',
+        failedMessage: dryRun ? 'Artifact publication preview failed' : 'Contribution artifact publication failed',
+        tone: 'info',
+        step: { index: 8, total: totalSteps },
+      }, async () => this.publishArtifactsIfNeeded({
         config,
         headless,
         dryRun: options.dryRun,
@@ -320,7 +383,7 @@ export class AgentOrchestrator {
         changedFiles: implementation.changedFiles,
         validationResults: implementation.validationResults,
         pullRequestUrl: contributionPullRequest.url,
-      });
+      }));
 
       const finalProofRecord = {
         ...proofRecord,
@@ -744,6 +807,7 @@ export class AgentOrchestrator {
   }
 
   async scoutMachine(options: ScoutRunOptions = {}): Promise<MachineScoutResult> {
+    const totalSteps = 3;
     const limit = options.limit ?? 10;
     const refresh = Boolean(options.refresh);
     const repoFullName = options.repo ? parseGitHubRepoFullName(options.repo) : undefined;
@@ -752,14 +816,31 @@ export class AgentOrchestrator {
 
     await this.validateConfig(config, { requireGithub: !localOnly, requireLlm: !localOnly });
     if (!localOnly || repoFullName) {
-      await this.initializeClients(config, { validateGithub: true, validateLlm: !localOnly });
+      await this.initializeClients(config, {
+        validateGithub: true,
+        validateLlm: !localOnly,
+        taskSteps: {
+          github: { index: 1, total: totalSteps },
+          ...(localOnly ? {} : { llm: { index: 2, total: totalSteps } }),
+        },
+      });
     }
 
-    const rankedIssues = await issueRankingService.loadRankedIssues(config, {
+    const rankedIssues = await ui.task({
+      title: 'Scoring contribution opportunities',
+      doneMessage: 'Contribution opportunities scored',
+      failedMessage: 'Contribution opportunity scoring failed',
+      tone: 'info',
+      step: { index: localOnly ? 2 : 3, total: totalSteps },
+      heartbeat: {
+        message: 'Still scoring contribution opportunities',
+      },
+    }, async (task) => issueRankingService.loadRankedIssues(config, {
       refresh,
       repoFullName,
       localOnly,
-    });
+      onStatus: (message) => task.setMessage(message),
+    }));
 
     return {
       opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
@@ -1105,7 +1186,14 @@ export class AgentOrchestrator {
 
   private async initializeClients(
     config: AppConfig,
-    options: { validateGithub?: boolean; validateLlm?: boolean } = {},
+    options: {
+      validateGithub?: boolean;
+      validateLlm?: boolean;
+      taskSteps?: {
+        github?: { index: number; total: number };
+        llm?: { index: number; total: number };
+      };
+    } = {},
   ): Promise<void> {
     const validateGithub = options.validateGithub ?? true;
     const validateLlm = options.validateLlm ?? true;
@@ -1117,6 +1205,7 @@ export class AgentOrchestrator {
         doneMessage: 'GitHub access verified',
         failedMessage: 'GitHub access failed',
         tone: 'info',
+        step: options.taskSteps?.github,
       }, async () => {
         const valid = await githubService.validateCredentials();
         if (!valid) {
@@ -1149,6 +1238,7 @@ export class AgentOrchestrator {
       doneMessage: 'LLM provider verified',
       failedMessage: 'LLM provider failed',
       tone: 'info',
+      step: options.taskSteps?.llm,
     }, async () => {
       const valid = await llmService.validateConnection();
       if (!valid) {

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -22,6 +22,7 @@ import {
 
 export interface AnalyzeRunOptions {
   repo?: string;
+  repoPath?: string;
   headless?: boolean;
   runChecks?: boolean;
   dryRun?: boolean;
@@ -61,9 +62,11 @@ export class AnalyzeOrchestrator {
     const headless = Boolean(options.headless);
     const runChecks = Boolean(options.runChecks);
     const dryRun = Boolean(options.dryRun);
+    const repoPath = options.repoPath?.trim() || undefined;
 
     await this.validateConfig(config);
     await this.initializeClients(config);
+    this.showLocalRepositoryHint(repoPath);
 
     const memory = memoryService.load(repoFullName);
     const workspace = await workspaceService.prepareRepositoryWorkspace(
@@ -71,6 +74,7 @@ export class AnalyzeOrchestrator {
       memory,
       runChecks,
       headless ? 'headless' : 'interactive',
+      repoPath,
     );
 
     const suggestionsResult = await ui.task({
@@ -191,6 +195,30 @@ export class AnalyzeOrchestrator {
       patchDraft,
       prDraft,
       artifacts,
+    });
+  }
+
+  private showLocalRepositoryHint(repoPath?: string): void {
+    if (repoPath) {
+      const message = `Using local repository path via isolated worktree: ${repoPath}`;
+      logger.info(message);
+      ui.callout({
+        label: 'OpenMeta Analyze',
+        title: 'Local repository reuse enabled',
+        subtitle: 'OpenMeta will reuse the provided local repository through an isolated worktree, create a fresh branch, and keep PR work off your existing checkout.',
+        lines: [`Path: ${repoPath}`],
+        tone: 'info',
+      });
+      return;
+    }
+
+    const message = 'Tip: if this repository already exists locally, pass --repo-path <local-path>. OpenMeta will reuse it via an isolated worktree, create a fresh branch, and open the PR from that branch.';
+    logger.info(message);
+    ui.callout({
+      label: 'OpenMeta Analyze',
+      title: 'Faster local reuse available',
+      subtitle: 'If the repository is already on disk, pass --repo-path <local-path>. OpenMeta will reuse it via an isolated worktree, create a fresh branch, and avoid another full local checkout.',
+      tone: 'info',
     });
   }
 

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -68,20 +68,34 @@ export class AnalyzeOrchestrator {
     await this.initializeClients(config);
     this.showLocalRepositoryHint(repoPath);
 
+    const totalSteps = 7;
     const memory = memoryService.load(repoFullName);
-    const workspace = await workspaceService.prepareRepositoryWorkspace(
+    const workspace = await ui.task({
+      title: 'Preparing repository workspace',
+      doneMessage: 'Repository workspace prepared',
+      failedMessage: 'Repository workspace preparation failed',
+      tone: 'info',
+      step: { index: 3, total: totalSteps },
+      heartbeat: {
+        message: 'Still preparing repository workspace',
+      },
+    }, async () => workspaceService.prepareRepositoryWorkspace(
       repoFullName,
       memory,
       runChecks,
       headless ? 'headless' : 'interactive',
       repoPath,
-    );
+    ));
 
     const suggestionsResult = await ui.task({
       title: 'Inspecting repository for grounded contribution ideas',
       doneMessage: 'Repository suggestions generated',
       failedMessage: 'Repository suggestion analysis failed',
       tone: 'info',
+      step: { index: 4, total: totalSteps },
+      heartbeat: {
+        message: 'Still inspecting repository context',
+      },
     }, async () => llmService.analyzeRepository(repoFullName, workspace, memory));
     const suggestions = suggestionsResult.data;
     const selectedSuggestion = headless
@@ -94,6 +108,7 @@ export class AnalyzeOrchestrator {
       doneMessage: 'Repository suggestion selected',
       failedMessage: 'Repository suggestion selection failed',
       tone: 'info',
+      step: { index: 5, total: totalSteps },
     }, async () => selectedSuggestion);
 
     const patchDraftResult = await ui.task({
@@ -101,6 +116,10 @@ export class AnalyzeOrchestrator {
       doneMessage: 'Patch strategy drafted',
       failedMessage: 'Patch strategy drafting failed',
       tone: 'info',
+      step: { index: 6, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting patch strategy',
+      },
     }, async () => llmService.generatePatchDraft(syntheticIssue, workspace, memory));
     const patchDraft = patchDraftResult.data;
     const prDraftResult = await ui.task({
@@ -108,6 +127,10 @@ export class AnalyzeOrchestrator {
       doneMessage: 'Pull request narrative drafted',
       failedMessage: 'Pull request narrative drafting failed',
       tone: 'info',
+      step: { index: 7, total: totalSteps },
+      heartbeat: {
+        message: 'Still drafting pull request narrative',
+      },
     }, async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspace));
     const prDraft = prDraftResult.data;
 
@@ -239,6 +262,7 @@ export class AnalyzeOrchestrator {
       doneMessage: 'GitHub access verified',
       failedMessage: 'GitHub access failed',
       tone: 'info',
+      step: { index: 1, total: 7 },
     }, async () => {
       const valid = await githubService.validateCredentials();
       if (!valid) {
@@ -263,6 +287,7 @@ export class AnalyzeOrchestrator {
       doneMessage: 'LLM provider verified',
       failedMessage: 'LLM provider failed',
       tone: 'info',
+      step: { index: 2, total: 7 },
     }, async () => {
       const valid = await llmService.validateConnection();
       if (!valid) {

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -73,16 +73,38 @@ export class AnalyzeOrchestrator {
       headless ? 'headless' : 'interactive',
     );
 
-    const suggestionsResult = await llmService.analyzeRepository(repoFullName, workspace, memory);
+    const suggestionsResult = await ui.task({
+      title: 'Inspecting repository for grounded contribution ideas',
+      doneMessage: 'Repository suggestions generated',
+      failedMessage: 'Repository suggestion analysis failed',
+      tone: 'info',
+    }, async () => llmService.analyzeRepository(repoFullName, workspace, memory));
     const suggestions = suggestionsResult.data;
     const selectedSuggestion = headless
       ? this.selectTopSuggestion(suggestions)
       : await this.promptForSuggestion(suggestions);
     const syntheticIssue = this.buildSyntheticIssue(repoFullName, selectedSuggestion);
 
-    const patchDraftResult = await llmService.generatePatchDraft(syntheticIssue, workspace, memory);
+    await ui.task({
+      title: 'Selecting the strongest repository suggestion',
+      doneMessage: 'Repository suggestion selected',
+      failedMessage: 'Repository suggestion selection failed',
+      tone: 'info',
+    }, async () => selectedSuggestion);
+
+    const patchDraftResult = await ui.task({
+      title: 'Drafting patch strategy for the selected suggestion',
+      doneMessage: 'Patch strategy drafted',
+      failedMessage: 'Patch strategy drafting failed',
+      tone: 'info',
+    }, async () => llmService.generatePatchDraft(syntheticIssue, workspace, memory));
     const patchDraft = patchDraftResult.data;
-    const prDraftResult = await llmService.generatePrDraft(syntheticIssue, patchDraft, workspace);
+    const prDraftResult = await ui.task({
+      title: 'Drafting pull request narrative for the selected suggestion',
+      doneMessage: 'Pull request narrative drafted',
+      failedMessage: 'Pull request narrative drafting failed',
+      tone: 'info',
+    }, async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspace));
     const prDraft = prDraftResult.data;
 
     const artifacts = this.prepareArtifactPaths(repoFullName, selectedSuggestion.id);

--- a/src/orchestration/doctor.ts
+++ b/src/orchestration/doctor.ts
@@ -9,7 +9,7 @@ import {
   getOpenMetaWorkspaceRoot,
   ui,
 } from '../infra/index.js';
-import { schedulerService } from '../services/index.js';
+import { inspectBinaryOnPath, schedulerService, type BinaryResolution } from '../services/index.js';
 import type { AppConfig } from '../types/index.js';
 
 export type DoctorCheckStatus = 'pass' | 'warn' | 'fail';
@@ -26,6 +26,7 @@ export interface DoctorCheck {
 export interface DoctorReport {
   configPath: string;
   homePath: string;
+  openmetaBinary: BinaryResolution;
   checks: DoctorCheck[];
   totals: Record<DoctorCheckStatus, number>;
   ready: boolean;
@@ -73,12 +74,14 @@ export class DoctorOrchestrator {
     const resolvedConfig = config ?? await configService.get();
     const configPath = configService.getConfigPath();
     const homePath = getOpenMetaHomePath();
+    const openmetaBinary = inspectBinaryOnPath('openmeta');
     const checks = [
       this.checkConfigFile(configPath),
       this.checkDirectory('state-dir', 'State directory', dirname(configPath), 'Run "openmeta init" to create and save local configuration.'),
       this.checkDirectory('openmeta-home', 'OpenMeta home', homePath, 'Run "openmeta agent" or create the directory manually with write permissions.'),
       this.checkDirectory('workspace-root', 'Workspace root', getOpenMetaWorkspaceRoot(), 'Run "openmeta agent" after configuration is complete.'),
       this.checkDirectory('artifact-root', 'Artifact root', getOpenMetaArtifactRoot(), 'Run "openmeta agent" after configuration is complete.'),
+      this.checkOpenMetaBinary(openmetaBinary),
       this.checkBunRuntime(),
       this.checkCommand('runtime-git', 'Git runtime', 'git', ['--version'], 'Install Git and ensure it is available on PATH.'),
       this.checkGitHubConfig(resolvedConfig),
@@ -92,6 +95,7 @@ export class DoctorOrchestrator {
     return {
       configPath,
       homePath,
+      openmetaBinary,
       checks,
       totals,
       ready: totals.fail === 0,
@@ -211,6 +215,35 @@ export class DoctorOrchestrator {
       status: 'pass',
       summary: `${command} is available.`,
       detail: (result.stdout || result.stderr || '').trim().split(/\r?\n/)[0],
+    };
+  }
+
+  private checkOpenMetaBinary(binary: BinaryResolution): DoctorCheck {
+    if (!binary.onPath) {
+      return {
+        id: 'runtime-openmeta',
+        label: 'OpenMeta binary',
+        status: 'warn',
+        summary: 'openmeta is not available on PATH from this shell context.',
+        detail: binary.error,
+        remediation: 'Re-link or reinstall OpenMeta so `openmeta` resolves on PATH, then rerun the doctor.',
+      };
+    }
+
+    const detailParts = [
+      binary.version ? `Version: ${binary.version}` : '',
+      binary.invokedPath ? `PATH entry: ${binary.invokedPath}` : '',
+      binary.resolvedPath && binary.resolvedPath !== binary.invokedPath ? `Resolved path: ${binary.resolvedPath}` : '',
+      binary.symlinkTarget ? `Symlink target: ${binary.symlinkTarget}` : '',
+      `Source: ${binary.source}`,
+    ].filter(Boolean);
+
+    return {
+      id: 'runtime-openmeta',
+      label: 'OpenMeta binary',
+      status: 'pass',
+      summary: `openmeta resolves on PATH (${binary.source}).`,
+      detail: detailParts.join(' | '),
     };
   }
 

--- a/src/orchestration/machine/agent.ts
+++ b/src/orchestration/machine/agent.ts
@@ -10,6 +10,7 @@ export class MachineAgentFlowOrchestrator {
     draftOnly?: boolean;
     refresh?: boolean;
     repo?: string;
+    repoPath?: string;
     issue?: string;
     dryRun?: boolean;
   } = {}): Promise<void> {
@@ -20,6 +21,7 @@ export class MachineAgentFlowOrchestrator {
         draftOnly: options.draftOnly,
         refresh: options.refresh,
         repo: options.repo,
+        repoPath: options.repoPath,
         issue: options.issue,
         dryRun: options.dryRun,
       }));

--- a/src/orchestration/machine/agent.ts
+++ b/src/orchestration/machine/agent.ts
@@ -1,7 +1,7 @@
 import { agentOrchestrator } from '../index.js';
 import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
-import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineAgentFlowOrchestrator {
   async execute(options: {
@@ -15,6 +15,15 @@ export class MachineAgentFlowOrchestrator {
     dryRun?: boolean;
   } = {}): Promise<void> {
     try {
+      writeMachinePlan('machine agent', [
+        'Validate GitHub access',
+        'Validate LLM provider',
+        'Scout or load the target issue',
+        'Prepare repository workspace',
+        'Draft patch and PR artifacts without mutating the repository unless allowed',
+        'Optionally apply changes or open a draft PR depending on execution flags',
+        'Return execution outcome with artifact paths and next actions',
+      ]);
       const result = await runInMachineContext(() => agentOrchestrator.runMachine({
         headless: options.headless ?? true,
         runChecks: options.runChecks,

--- a/src/orchestration/machine/analyze.ts
+++ b/src/orchestration/machine/analyze.ts
@@ -6,6 +6,7 @@ import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
 export class MachineAnalyzeOrchestrator {
   async execute(options: {
     repo?: string;
+    repoPath?: string;
     headless?: boolean;
     runChecks?: boolean;
     dryRun?: boolean;
@@ -13,6 +14,7 @@ export class MachineAnalyzeOrchestrator {
     try {
       const result = await runInMachineContext(() => analyzeOrchestrator.runMachine({
         repo: options.repo,
+        repoPath: options.repoPath,
         headless: options.headless ?? true,
         runChecks: options.runChecks,
         dryRun: options.dryRun,

--- a/src/orchestration/machine/analyze.ts
+++ b/src/orchestration/machine/analyze.ts
@@ -1,7 +1,7 @@
 import { analyzeOrchestrator } from '../index.js';
 import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
-import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineAnalyzeOrchestrator {
   async execute(options: {
@@ -12,6 +12,15 @@ export class MachineAnalyzeOrchestrator {
     dryRun?: boolean;
   } = {}): Promise<void> {
     try {
+      writeMachinePlan('machine analyze', [
+        'Validate GitHub access',
+        'Validate LLM provider',
+        'Prepare repository workspace',
+        'Inspect repository for grounded contribution ideas',
+        'Select the strongest repository suggestion',
+        'Draft patch strategy for the selected suggestion',
+        'Draft pull request narrative for the selected suggestion',
+      ]);
       const result = await runInMachineContext(() => analyzeOrchestrator.runMachine({
         repo: options.repo,
         repoPath: options.repoPath,

--- a/src/orchestration/machine/runtime.ts
+++ b/src/orchestration/machine/runtime.ts
@@ -34,3 +34,18 @@ export function buildMachineErrorEnvelope(
 export function writeMachinePayload(payload: MachineEnvelope<unknown> | MachineErrorEnvelope): void {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
+
+export function writeMachinePlan(command: string, steps: string[]): void {
+  if (steps.length === 0) {
+    return;
+  }
+
+  const lines = [
+    `Machine execution plan for ${command}:`,
+    ...steps.map((step, index) => `${index + 1}. ${step}`),
+  ];
+
+  for (const line of lines) {
+    process.stderr.write(`${line}\n`);
+  }
+}

--- a/src/orchestration/machine/scout.ts
+++ b/src/orchestration/machine/scout.ts
@@ -1,7 +1,7 @@
 import { agentOrchestrator } from '../index.js';
 import { runInMachineContext } from '../../infra/index.js';
 import { mapMachineError } from './errors.js';
-import { buildMachineEnvelope, writeMachinePayload } from './runtime.js';
+import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineScoutOrchestrator {
   async execute(options: {
@@ -11,6 +11,12 @@ export class MachineScoutOrchestrator {
     local?: boolean;
   } = {}): Promise<void> {
     try {
+      writeMachinePlan('machine scout', [
+        'Validate GitHub access when remote scouting is enabled',
+        'Validate LLM provider when model scoring is enabled',
+        'Fetch and score contribution opportunities',
+        'Return ranked opportunities with mode metadata',
+      ]);
       const result = await runInMachineContext(() => agentOrchestrator.scoutMachine({
         limit: Number.parseInt(options.limit || '10', 10) || 10,
         refresh: options.refresh,

--- a/src/orchestration/skill/doctor.ts
+++ b/src/orchestration/skill/doctor.ts
@@ -1,9 +1,9 @@
 import { existsSync } from 'fs';
-import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { getInstallTarget } from './installer.js';
 import { getInstalledSkillFileName } from './renderer.js';
 import type { SkillHost } from './catalog.js';
+import { inspectBinaryOnPath, type BinaryResolution } from '../../services/index.js';
 
 export interface SkillDoctorResult {
   host: SkillHost;
@@ -11,13 +11,14 @@ export interface SkillDoctorResult {
   installPath?: string;
   installPathExists: boolean;
   openmetaOnPath: boolean;
+  openmetaBinary: BinaryResolution;
   skillFileExists: boolean;
   nextActions: string[];
 }
 
 export async function doctorSkillBundle(host: SkillHost): Promise<SkillDoctorResult> {
   const installPath = getInstallTarget(host);
-  const openmeta = spawnSync('openmeta', ['--version'], { encoding: 'utf-8' });
+  const openmetaBinary = inspectBinaryOnPath('openmeta');
   const installPathExists = Boolean(installPath && existsSync(installPath));
   const skillFileExists = Boolean(installPath && existsSync(join(installPath, getInstalledSkillFileName(host))));
 
@@ -26,11 +27,12 @@ export async function doctorSkillBundle(host: SkillHost): Promise<SkillDoctorRes
     supported: Boolean(installPath),
     installPath: installPath || undefined,
     installPathExists,
-    openmetaOnPath: !openmeta.error && openmeta.status === 0,
+    openmetaOnPath: openmetaBinary.onPath,
+    openmetaBinary,
     skillFileExists,
     nextActions: [
       ...(installPathExists && skillFileExists ? [] : ['run_openmeta_skill_install']),
-      ...(!openmeta.error && openmeta.status === 0 ? [] : ['ensure_openmeta_on_path']),
+      ...(openmetaBinary.onPath ? [] : ['ensure_openmeta_on_path']),
     ],
   };
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -11,6 +11,7 @@ export { inboxService, InboxService } from './inbox.js';
 export { proofOfWorkService, ProofOfWorkService } from './proof-of-work.js';
 export { workspaceService, WorkspaceService } from './workspace.js';
 export { runHistoryService, RunHistoryService } from './run-history.js';
+export { inspectBinaryOnPath, type BinaryResolution } from './runtime-diagnostics.js';
 export { LLM_PROVIDER_PRESETS, findLLMProviderPreset, type LLMProviderPreset } from './llm.providers.js';
 export { SCORING_PRESETS, DEFAULT_SCORING, getPreset, normalizeWeights, normalizeOverallWeights } from './scoring-presets.js';
 export type { SchedulerSyncResult } from './scheduler.js';

--- a/src/services/runtime-diagnostics.ts
+++ b/src/services/runtime-diagnostics.ts
@@ -1,0 +1,122 @@
+import { existsSync, lstatSync, readlinkSync, realpathSync } from 'fs';
+import { dirname, isAbsolute, join, normalize, resolve } from 'path';
+import { spawnSync } from 'child_process';
+
+export interface BinaryResolution {
+  onPath: boolean;
+  command: string;
+  version?: string;
+  invokedPath?: string;
+  resolvedPath?: string;
+  symlinkTarget?: string;
+  source: 'bun-link' | 'npm-global' | 'workspace' | 'system' | 'unknown' | 'missing';
+  error?: string;
+}
+
+function classifyBinarySource(
+  invokedPath?: string,
+  resolvedPath?: string,
+  symlinkTarget?: string,
+): BinaryResolution['source'] {
+  if (!invokedPath && !resolvedPath && !symlinkTarget) {
+    return 'missing';
+  }
+
+  const normalizedInvokedPath = invokedPath ? normalize(invokedPath) : '';
+  const normalizedResolvedPath = resolvedPath ? normalize(resolvedPath) : '';
+  const normalizedSymlinkTarget = symlinkTarget ? normalize(resolve(symlinkTarget)) : '';
+  const workspaceRoot = normalize(resolve(process.cwd()));
+  const homeDir = process.env['HOME'] ? normalize(resolve(process.env['HOME'])) : '';
+
+  if (homeDir && normalizedInvokedPath.startsWith(normalize(join(homeDir, '.bun', 'bin')))) {
+    return 'bun-link';
+  }
+
+  if (homeDir && normalizedSymlinkTarget.startsWith(normalize(join(homeDir, '.bun', 'install', 'global', 'node_modules')))) {
+    return 'bun-link';
+  }
+
+  if (normalizedResolvedPath === workspaceRoot || normalizedResolvedPath.startsWith(`${workspaceRoot}/`)) {
+    return 'workspace';
+  }
+
+  if (homeDir && normalizedResolvedPath.startsWith(normalize(join(homeDir, '.bun', 'install', 'global', 'node_modules')))) {
+    return 'bun-link';
+  }
+
+  if (/[/\\](?:lib|node_modules)[/\\].+[/\\]bin[/\\][^/\\]+(?:\.[cm]?js)?$/.test(normalizedResolvedPath)) {
+    return 'npm-global';
+  }
+
+  if (normalizedResolvedPath.startsWith('/usr/') || normalizedResolvedPath.startsWith('/opt/')) {
+    return 'system';
+  }
+
+  return 'unknown';
+}
+
+function resolveVersion(stdout: string, stderr: string): string | undefined {
+  return (stdout || stderr)
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+}
+
+function resolveLinkedTarget(linkPath: string): string | undefined {
+  try {
+    const target = readlinkSync(linkPath);
+    return isAbsolute(target) ? target : resolve(dirname(linkPath), target);
+  } catch {
+    return undefined;
+  }
+}
+
+export function inspectBinaryOnPath(command: string): BinaryResolution {
+  const lookup = spawnSync('command', ['-v', command], {
+    encoding: 'utf-8',
+    shell: true,
+  });
+
+  if (lookup.error || lookup.status !== 0) {
+    return {
+      onPath: false,
+      command,
+      source: 'missing',
+      error: lookup.error?.message || (lookup.stderr || lookup.stdout || '').trim() || `${command} is not available on PATH.`,
+    };
+  }
+
+  const invokedPath = lookup.stdout.trim().split(/\r?\n/).find(Boolean);
+  const versionResult = spawnSync(command, ['--version'], { encoding: 'utf-8' });
+
+  let symlinkTarget: string | undefined;
+  let resolvedPath = invokedPath;
+
+  if (invokedPath && existsSync(invokedPath)) {
+    try {
+      const stat = lstatSync(invokedPath);
+      if (stat.isSymbolicLink()) {
+        symlinkTarget = resolveLinkedTarget(invokedPath);
+      }
+      resolvedPath = realpathSync(invokedPath);
+    } catch {
+      resolvedPath = invokedPath;
+    }
+  }
+
+  return {
+    onPath: !versionResult.error && versionResult.status === 0,
+    command,
+    version: resolveVersion(versionResult.stdout, versionResult.stderr),
+    invokedPath,
+    resolvedPath,
+    symlinkTarget,
+    source: classifyBinarySource(invokedPath, resolvedPath, symlinkTarget),
+    ...(versionResult.error
+      ? { error: versionResult.error.message }
+      : versionResult.status === 0
+        ? {}
+        : { error: (versionResult.stderr || versionResult.stdout || '').trim() || `${command} --version failed.` }),
+  };
+}

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -31,6 +31,13 @@ const MAX_GENERATED_FILES = 6;
 const MAX_GENERATED_FILE_CHARS = 60_000;
 type ExecutionMode = 'interactive' | 'headless';
 
+interface PreparedWorkspaceState {
+  workspacePath: string;
+  defaultBranch: string;
+  workspaceDirty: boolean;
+  branchName?: string;
+}
+
 function sanitizeRepoName(repoFullName: string): string {
   return repoFullName.replace(/\//g, '__');
 }
@@ -48,26 +55,30 @@ export class WorkspaceService {
     return join(ensureDirectory(getOpenMetaWorkspaceRoot()), sanitizeRepoName(repoFullName));
   }
 
+  private getWorktreeRoot(): string {
+    return join(ensureDirectory(getOpenMetaWorkspaceRoot()), '..', 'worktrees');
+  }
+
   async prepareWorkspace(
     issue: RankedIssue,
     memory: RepoMemory,
     runChecks: boolean,
     executionMode: ExecutionMode = 'interactive',
+    repoPath?: string,
   ): Promise<RepoWorkspaceContext> {
-    const workspacePath = this.getWorkspacePath(issue.repoFullName);
     const workspaceState = await this.prepareGitWorkspace(
       issue.repoFullName,
-      workspacePath,
       (git) => this.createWorkspaceBranchName(git, issue),
+      repoPath,
     );
     const candidateFiles = this.rankCandidateFiles(
       issue,
       memory,
-      this.discoverFiles(workspacePath),
+      this.discoverFiles(workspaceState.workspacePath),
     ).slice(0, 8);
 
     return this.buildWorkspaceContext({
-      workspacePath,
+      workspacePath: workspaceState.workspacePath,
       workspaceDirty: workspaceState.workspaceDirty,
       defaultBranch: workspaceState.defaultBranch,
       branchName: workspaceState.branchName,
@@ -82,20 +93,20 @@ export class WorkspaceService {
     memory: RepoMemory,
     runChecks: boolean,
     executionMode: ExecutionMode = 'interactive',
+    repoPath?: string,
   ): Promise<RepoWorkspaceContext> {
-    const workspacePath = this.getWorkspacePath(repoFullName);
     const workspaceState = await this.prepareGitWorkspace(
       repoFullName,
-      workspacePath,
       (git) => this.createRepositoryAnalysisBranchName(git, repoFullName),
+      repoPath,
     );
     const candidateFiles = this.rankRepositoryAnalysisFiles(
       memory,
-      this.discoverFiles(workspacePath),
+      this.discoverFiles(workspaceState.workspacePath),
     ).slice(0, 12);
 
     return this.buildWorkspaceContext({
-      workspacePath,
+      workspacePath: workspaceState.workspacePath,
       candidateFiles,
       workspaceDirty: workspaceState.workspaceDirty,
       defaultBranch: workspaceState.defaultBranch,
@@ -228,28 +239,116 @@ export class WorkspaceService {
 
   private async prepareGitWorkspace(
     repoFullName: string,
-    workspacePath: string,
     createBranchName: (git: SimpleGit) => Promise<string>,
-  ): Promise<{ defaultBranch: string; workspaceDirty: boolean; branchName?: string }> {
+    repoPath?: string,
+  ): Promise<PreparedWorkspaceState> {
+    if (repoPath) {
+      return this.prepareExternalWorkspace(repoFullName, repoPath, createBranchName);
+    }
+
+    return this.prepareManagedWorkspace(repoFullName, createBranchName);
+  }
+
+  private async prepareManagedWorkspace(
+    repoFullName: string,
+    createBranchName: (git: SimpleGit) => Promise<string>,
+  ): Promise<PreparedWorkspaceState> {
+    const workspacePath = this.getWorkspacePath(repoFullName);
     const repoUrl = this.buildRepoUrl(repoFullName);
+    const defaultBranch = await this.detectRemoteDefaultBranch(repoUrl);
 
     if (!existsSync(workspacePath)) {
       mkdirSync(dirname(workspacePath), { recursive: true });
-      await simpleGit().clone(repoUrl, workspacePath);
+      await simpleGit().clone(repoUrl, workspacePath, ['--depth', '1', '--single-branch', '--branch', defaultBranch]);
     }
 
     const git = simpleGit(workspacePath);
-    await git.fetch('origin');
+    await this.syncManagedWorkspace(git);
 
-    const defaultBranch = await this.detectDefaultBranch(git);
+    if (!existsSync(join(workspacePath, '.git', 'shallow'))) {
+      try {
+        await git.fetch('origin', defaultBranch, { '--depth': '1', '--prune': null });
+      } catch (error) {
+        logger.debug(`Unable to re-fetch ${repoFullName} as a shallow workspace`, error);
+      }
+    }
+
+    return this.finalizeWorkspaceBranch(git, workspacePath, defaultBranch, createBranchName);
+  }
+
+  private async prepareExternalWorkspace(
+    repoFullName: string,
+    repoPath: string,
+    createBranchName: (git: SimpleGit) => Promise<string>,
+  ): Promise<PreparedWorkspaceState> {
+    const sourcePath = resolve(repoPath);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Configured local repository path does not exist: ${repoPath}`);
+    }
+
+    const sourceGit = simpleGit(sourcePath);
+    const isRepo = await sourceGit.checkIsRepo();
+    if (!isRepo) {
+      throw new Error(`Configured local repository path is not a git repository: ${repoPath}`);
+    }
+
+    await this.assertRepositoryReadyForWorktree(sourceGit, sourcePath);
+
+    const defaultBranch = await this.detectDefaultBranch(sourceGit);
+    try {
+      await sourceGit.fetch('origin', defaultBranch, { '--depth': '1', '--prune': null });
+    } catch (error) {
+      logger.debug(`Unable to refresh external repository ${sourcePath} from origin/${defaultBranch}`, error);
+    }
+
+    const branchName = await createBranchName(sourceGit);
+    const worktreePath = this.getExecutionWorktreePath(repoFullName, branchName);
+    const parentDir = dirname(worktreePath);
+    mkdirSync(parentDir, { recursive: true });
+
+    if (existsSync(worktreePath)) {
+      const worktreeGit = simpleGit(worktreePath);
+      try {
+        await worktreeGit.raw(['worktree', 'remove', '--force', worktreePath]);
+      } catch (error) {
+        logger.debug(`Unable to remove stale worktree at ${worktreePath}`, error);
+      }
+    }
+
+    const baseRef = `origin/${defaultBranch}`;
+    try {
+      await sourceGit.raw(['worktree', 'add', '-b', branchName, worktreePath, baseRef]);
+    } catch {
+      await sourceGit.raw(['worktree', 'add', '-b', branchName, worktreePath, defaultBranch]);
+    }
+
+    const worktreeGit = simpleGit(worktreePath);
+    return this.finalizeWorkspaceBranch(worktreeGit, worktreePath, defaultBranch, async () => branchName, true);
+  }
+
+  private async syncManagedWorkspace(git: SimpleGit): Promise<void> {
+    try {
+      await git.fetch('origin');
+    } catch (error) {
+      logger.debug('Unable to fetch managed workspace before preparing branch', error);
+    }
+  }
+
+  private async finalizeWorkspaceBranch(
+    git: SimpleGit,
+    workspacePath: string,
+    defaultBranch: string,
+    createBranchName: (git: SimpleGit) => Promise<string>,
+    branchAlreadyCreated: boolean = false,
+  ): Promise<PreparedWorkspaceState> {
     const status = await git.status();
     const workspaceDirty = status.files.length > 0;
     const branchName = workspaceDirty ? undefined : await createBranchName(git);
 
-    if (!workspaceDirty && branchName) {
+    if (!workspaceDirty && branchName && !branchAlreadyCreated) {
       await git.checkout(defaultBranch);
       try {
-        await git.pull('origin', defaultBranch);
+        await git.pull('origin', defaultBranch, { '--ff-only': null });
       } catch (error) {
         logger.debug('Unable to fast-forward workspace before branch creation', error);
       }
@@ -258,10 +357,47 @@ export class WorkspaceService {
     }
 
     return {
+      workspacePath,
       defaultBranch,
       workspaceDirty,
       branchName,
     };
+  }
+
+  private getExecutionWorktreePath(repoFullName: string, branchName: string): string {
+    return join(
+      ensureDirectory(this.getWorktreeRoot()),
+      sanitizeRepoName(repoFullName),
+      branchName.replace(/\//g, '__'),
+    );
+  }
+
+  private async assertRepositoryReadyForWorktree(git: SimpleGit, sourcePath: string): Promise<void> {
+    const gitDir = await git.revparse(['--git-dir']);
+    const absoluteGitDir = resolve(sourcePath, gitDir.trim());
+    const conflictMarkers = ['MERGE_HEAD', 'REBASE_HEAD', 'CHERRY_PICK_HEAD', 'BISECT_LOG']
+      .map((marker) => join(absoluteGitDir, marker))
+      .filter((filePath) => existsSync(filePath));
+
+    if (conflictMarkers.length > 0) {
+      throw new Error(`Local repository is mid-operation and cannot be reused safely: ${sourcePath}`);
+    }
+    await git.status();
+  }
+
+  private async detectRemoteDefaultBranch(repoUrl: string): Promise<string> {
+    const lsRemote = spawnSync('git', ['ls-remote', '--symref', repoUrl, 'HEAD'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+
+    const firstLine = lsRemote.stdout.split('\n').find((line) => line.startsWith('ref:'));
+    const match = firstLine?.match(/^ref:\s+refs\/heads\/(.+)\s+HEAD$/);
+    if (match?.[1]) {
+      return match[1];
+    }
+
+    return 'main';
   }
 
   private buildWorkspaceContext(input: {

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { basename, dirname, join, relative, resolve, sep } from 'path';
 import { simpleGit, type SimpleGit } from 'simple-git';
@@ -257,23 +257,42 @@ export class WorkspaceService {
     const repoUrl = this.buildRepoUrl(repoFullName);
     const defaultBranch = await this.detectRemoteDefaultBranch(repoUrl);
 
-    if (!existsSync(workspacePath)) {
-      mkdirSync(dirname(workspacePath), { recursive: true });
-      await simpleGit().clone(repoUrl, workspacePath, ['--depth', '1', '--single-branch', '--branch', defaultBranch]);
-    }
+    try {
+      if (!existsSync(workspacePath)) {
+        await this.cloneManagedWorkspace(repoUrl, workspacePath, defaultBranch);
+      }
 
-    const git = simpleGit(workspacePath);
-    await this.syncManagedWorkspace(git);
+      const git = simpleGit(workspacePath);
+      await this.syncManagedWorkspace(git);
 
-    if (!existsSync(join(workspacePath, '.git', 'shallow'))) {
+      if (!existsSync(join(workspacePath, '.git', 'shallow'))) {
+        try {
+          await git.fetch('origin', defaultBranch, { '--depth': '1', '--prune': null });
+        } catch (error) {
+          logger.debug(`Unable to re-fetch ${repoFullName} as a shallow workspace`, error);
+        }
+      }
+
+      return await this.finalizeWorkspaceBranch(git, workspacePath, defaultBranch, createBranchName);
+    } catch (error) {
+      if (!this.isRecoverableManagedWorkspaceError(error)) {
+        throw error;
+      }
+
+      logger.warn(`Managed workspace cache for ${repoFullName} is invalid. Rebuilding the shallow clone.`, error);
+      rmSync(workspacePath, { recursive: true, force: true });
+      await this.cloneManagedWorkspace(repoUrl, workspacePath, defaultBranch);
+      const recoveredGit = simpleGit(workspacePath);
+      await this.syncManagedWorkspace(recoveredGit);
+
       try {
-        await git.fetch('origin', defaultBranch, { '--depth': '1', '--prune': null });
+        await recoveredGit.fetch('origin', defaultBranch, { '--depth': '1', '--prune': null });
       } catch (error) {
         logger.debug(`Unable to re-fetch ${repoFullName} as a shallow workspace`, error);
       }
-    }
 
-    return this.finalizeWorkspaceBranch(git, workspacePath, defaultBranch, createBranchName);
+      return await this.finalizeWorkspaceBranch(recoveredGit, workspacePath, defaultBranch, createBranchName);
+    }
   }
 
   private async prepareExternalWorkspace(
@@ -362,6 +381,16 @@ export class WorkspaceService {
       workspaceDirty,
       branchName,
     };
+  }
+
+  private async cloneManagedWorkspace(repoUrl: string, workspacePath: string, defaultBranch: string): Promise<void> {
+    mkdirSync(dirname(workspacePath), { recursive: true });
+    await simpleGit().clone(repoUrl, workspacePath, ['--depth', '1', '--single-branch', '--branch', defaultBranch]);
+  }
+
+  private isRecoverableManagedWorkspaceError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /\binvalid HEAD\b|\bbad object HEAD\b|\bambiguous argument 'HEAD'\b|\bNeeded a single revision\b|\bunable to read tree\b/i.test(message);
   }
 
   private getExecutionWorktreePath(repoFullName: string, branchName: string): string {

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -750,9 +750,10 @@ describe('AgentOrchestrator support behavior', () => {
 
     expect(emptyStateSpy).toHaveBeenCalledWith(
       'OpenMeta Scout',
-      'No issues found',
-      'No issues met the current scoring thresholds.',
+      'No issues cleared the current filters',
+      expect.stringContaining('75/100 threshold'),
     );
+    expect(emptyStateSpy.mock.calls[0]?.[2]).toContain('Broaden your tech stack or focus areas');
   });
 
   test('collects confirmations for headless and publish prompts', async () => {

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -15,6 +15,7 @@ interface AgentRunInternals {
     draftOnly?: boolean;
     refresh?: boolean;
     repo?: string;
+    repoPath?: string;
     issue?: string;
     dryRun?: boolean;
   }): Promise<void>;
@@ -49,12 +50,14 @@ interface AgentRunInternals {
 interface AnalyzeRunInternals {
   run(options: {
     repo?: string;
+    repoPath?: string;
     headless?: boolean;
     runChecks?: boolean;
     dryRun?: boolean;
   }): Promise<void>;
   runMachine(options: {
     repo?: string;
+    repoPath?: string;
     headless?: boolean;
     runChecks?: boolean;
     dryRun?: boolean;
@@ -480,7 +483,7 @@ describe('AnalyzeOrchestrator run flow', () => {
     await orchestrator.run({ repo: 'https://github.com/acme/demo', headless: true });
 
     expect(promptForSuggestionSpy).not.toHaveBeenCalled();
-    expect(workspaceService.prepareRepositoryWorkspace).toHaveBeenCalledWith('acme/demo', memory, false, 'headless');
+    expect(workspaceService.prepareRepositoryWorkspace).toHaveBeenCalledWith('acme/demo', memory, false, 'headless', undefined);
     expect(llmService.generatePatchDraft).toHaveBeenCalledWith(
       expect.objectContaining({
         repoFullName: 'acme/demo',
@@ -504,5 +507,67 @@ describe('AnalyzeOrchestrator run flow', () => {
       selectedSuggestion: topSuggestion,
       artifacts,
     }));
+  });
+
+  test('passes repoPath through repository analysis workflow', async () => {
+    const orchestrator = new AnalyzeOrchestrator() as unknown as AnalyzeRunInternals;
+    const config = createConfig();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-analysis-worktree',
+      branchName: 'openmeta/analyze-acme-demo',
+    });
+    const memory = createMemory({ repoFullName: 'acme/demo' });
+    const suggestion = createRepositorySuggestion({
+      id: 'config-validation',
+      title: 'Add config validation tests',
+      prPotentialScore: 93,
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as object as { initializeClients: AnalyzeRunInternals['initializeClients'] }, 'initializeClients').mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValue(memory);
+    const prepareSpy = spyOn(workspaceService, 'prepareRepositoryWorkspace').mockResolvedValue(workspace);
+    spyOn(llmService, 'analyzeRepository').mockResolvedValue({
+      version: '1',
+      kind: 'repository_suggestion_list',
+      status: 'success',
+      data: [suggestion],
+    });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatRepositoryAnalysisMarkdown').mockReturnValue('# Repository Analysis');
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+    spyOn(orchestrator as object as { prepareArtifactPaths: AnalyzeRunInternals['prepareArtifactPaths'] }, 'prepareArtifactPaths')
+      .mockReturnValue({
+        artifactDir: '/tmp/openmeta/artifacts/analyze',
+        analysisPath: '/tmp/openmeta/artifacts/analyze/repository-analysis.md',
+        patchDraftPath: '/tmp/openmeta/artifacts/analyze/patch-draft.md',
+        prDraftPath: '/tmp/openmeta/artifacts/analyze/pr-draft.md',
+      });
+    spyOn(orchestrator as object as { writeLocalArtifacts: AnalyzeRunInternals['writeLocalArtifacts'] }, 'writeLocalArtifacts')
+      .mockImplementation(() => {});
+    spyOn(orchestrator as object as { showResult: AnalyzeRunInternals['showResult'] }, 'showResult')
+      .mockImplementation(() => {});
+
+    await orchestrator.run({
+      repo: 'acme/demo',
+      repoPath: '/Users/example/src/demo',
+      headless: true,
+    });
+
+    expect(prepareSpy).toHaveBeenCalledWith('acme/demo', memory, false, 'headless', '/Users/example/src/demo');
   });
 });

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -53,6 +53,12 @@ interface AnalyzeRunInternals {
     runChecks?: boolean;
     dryRun?: boolean;
   }): Promise<void>;
+  runMachine(options: {
+    repo?: string;
+    headless?: boolean;
+    runChecks?: boolean;
+    dryRun?: boolean;
+  }): Promise<unknown>;
   initializeClients(config: AppConfig): Promise<void>;
   promptForSuggestion<T>(suggestions: T[]): Promise<T>;
   prepareArtifactPaths(repoFullName: string, suggestionId: string): {

--- a/test/analyze-command.test.ts
+++ b/test/analyze-command.test.ts
@@ -12,6 +12,7 @@ describe('registerAnalyzeCommand', () => {
 
     expect(help).toContain('analyze');
     expect(help).toContain('--repo <repository>');
+    expect(help).toContain('--repo-path <path>');
     expect(help).toContain('--headless');
     expect(help).toContain('--run-checks');
     expect(help).toContain('--dry-run');

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -3,7 +3,9 @@ import { mkdirSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { DoctorOrchestrator } from '../src/orchestration/doctor.js';
+import * as runtimeDiagnosticsModule from '../src/services/runtime-diagnostics.js';
 import type { AppConfig } from '../src/types/index.js';
+import { mock, spyOn } from 'bun:test';
 
 let tempRoot = '';
 
@@ -78,6 +80,7 @@ describe('DoctorOrchestrator', () => {
   });
 
   afterEach(() => {
+    mock.restore();
     delete process.env['OPENMETA_CONFIG_DIR'];
     delete process.env['OPENMETA_HOME'];
 
@@ -89,11 +92,26 @@ describe('DoctorOrchestrator', () => {
 
   test('reports a ready local surface when required config and directories are present', async () => {
     prepareOpenMetaDirs();
+    spyOn(runtimeDiagnosticsModule, 'inspectBinaryOnPath').mockReturnValue({
+      onPath: true,
+      command: 'openmeta',
+      version: '1.2.3',
+      invokedPath: '/Users/demo/.bun/bin/openmeta',
+      resolvedPath: '/Users/demo/work/openmeta-cli/bin/openmeta.js',
+      symlinkTarget: '../install/global/node_modules/openmeta-cli/bin/openmeta.js',
+      source: 'bun-link',
+    });
 
     const report = await new DoctorOrchestrator().inspect(createConfig());
 
     expect(report.ready).toBe(true);
     expect(report.totals.fail).toBe(0);
+    expect(report.openmetaBinary).toEqual(expect.objectContaining({
+      source: 'bun-link',
+      invokedPath: '/Users/demo/.bun/bin/openmeta',
+      resolvedPath: '/Users/demo/work/openmeta-cli/bin/openmeta.js',
+    }));
+    expect(report.checks.find((check) => check.id === 'runtime-openmeta')?.detail).toContain('Resolved path');
     expect(report.checks.find((check) => check.id === 'github-config')?.status).toBe('pass');
     expect(report.checks.find((check) => check.id === 'llm-config')?.status).toBe('pass');
   });

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -231,6 +231,25 @@ describe('machine flow result builders', () => {
     expect(result.opportunities).toEqual([issue]);
   });
 
+  test('machine scout returns an actionable empty explanation when no issues survive the filters', async () => {
+    const config = createConfig();
+    const orchestrator = new AgentOrchestrator();
+
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as AgentOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
+    spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
+
+    const result = await orchestrator.scoutMachine({ localOnly: true });
+
+    expect(result.opportunities).toEqual([]);
+    expect(result.emptyExplanation).toEqual(expect.objectContaining({
+      title: 'No issues cleared the current filters',
+    }));
+    expect(result.emptyExplanation?.detail).toContain('75/100 threshold');
+    expect(result.emptyExplanation?.suggestions[0]).toContain('Lower automation.minMatchScore');
+    expect(result.nextActions).toEqual(['broaden_profile_filters']);
+  });
+
   test('machine analyze returns selected suggestion and artifact paths', async () => {
     const config = createConfig();
     const workspace = createWorkspace({

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -189,6 +189,8 @@ describe('machine flow result builders', () => {
 
     const combined = stderrWrites.join('');
     expect(combined).toContain('--repo-path <local-path>');
+    expect(combined).toContain('Step 3/7 Preparing repository workspace');
+    expect(combined).toContain('Step 4/7 Inspecting repository for grounded contribution ideas');
     expect(combined).toContain('Inspecting repository for grounded contribution ideas');
     expect(combined).toContain('Selecting the strongest repository suggestion');
     expect(combined).toContain('Drafting patch strategy for the selected suggestion');

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -188,6 +188,7 @@ describe('machine flow result builders', () => {
     }));
 
     const combined = stderrWrites.join('');
+    expect(combined).toContain('--repo-path <local-path>');
     expect(combined).toContain('Inspecting repository for grounded contribution ideas');
     expect(combined).toContain('Selecting the strongest repository suggestion');
     expect(combined).toContain('Drafting patch strategy for the selected suggestion');

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:
 import * as infra from '../src/infra/index.js';
 import { AgentOrchestrator } from '../src/orchestration/agent.js';
 import { AnalyzeOrchestrator } from '../src/orchestration/analyze.js';
+import { runInMachineContext } from '../src/infra/execution-context.js';
 import { contentService, inboxService, issueRankingService, llmService, memoryService, proofOfWorkService, workspaceService } from '../src/services/index.js';
 import type { MachineAgentResult } from '../src/orchestration/agent.js';
 import { createInboxItem, createMemory, createPatchDraft, createProofRecord, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
@@ -128,6 +129,71 @@ afterEach(() => {
 });
 
 describe('machine flow result builders', () => {
+  test('machine analyze emits stage progress to stderr during long-running phases', async () => {
+    mock.restore();
+    const config = createConfig();
+    const workspace = createWorkspace({
+      workspacePath: '/tmp/openmeta-machine-progress',
+      branchName: 'openmeta/analyze-machine-progress',
+      candidateFiles: ['README.md', 'src/index.ts'],
+    });
+    const memory = createMemory({ repoFullName: 'acme/demo' });
+    const suggestion = createRepositorySuggestion({
+      id: 'machine-progress',
+      title: 'Surface machine progress',
+      summary: 'Make long-running analysis stages visible to host tools.',
+      targetFiles: [{ path: 'src/infra/ui/live.ts', reason: 'Machine progress rendering' }],
+      prPotentialScore: 91,
+    });
+    const patchDraft = createPatchDraft();
+    const prDraft = createPullRequestDraft();
+    const stderrWrites: string[] = [];
+    const orchestrator = new AnalyzeOrchestrator();
+
+    spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    spyOn(infra.configService, 'get').mockResolvedValue(config);
+    spyOn(orchestrator as AnalyzeOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
+    spyOn(orchestrator as AnalyzeOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValue(memory);
+    spyOn(workspaceService, 'prepareRepositoryWorkspace').mockResolvedValue(workspace);
+    spyOn(llmService, 'analyzeRepository').mockResolvedValue({
+      version: '1',
+      kind: 'repository_suggestion_list',
+      status: 'success',
+      data: [suggestion],
+    });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatRepositoryAnalysisMarkdown').mockReturnValue('# Repository Analysis');
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
+
+    await runInMachineContext(() => orchestrator.runMachine({
+      repo: 'acme/demo',
+      headless: true,
+      dryRun: true,
+    }));
+
+    const combined = stderrWrites.join('');
+    expect(combined).toContain('Inspecting repository for grounded contribution ideas');
+    expect(combined).toContain('Selecting the strongest repository suggestion');
+    expect(combined).toContain('Drafting patch strategy for the selected suggestion');
+    expect(combined).toContain('Drafting pull request narrative for the selected suggestion');
+  });
+
   test('machine scout returns ranked opportunities with mode metadata', async () => {
     const config = createConfig();
     const issue = createRankedIssue();

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -51,6 +51,8 @@ describe('machine commands', () => {
 
     const machineCommand = program.commands.find((command) => command.name() === 'machine');
     const help = machineCommand?.helpInformation() ?? '';
+    const analyzeHelp = machineCommand?.commands.find((command) => command.name() === 'analyze')?.helpInformation() ?? '';
+    const agentHelp = machineCommand?.commands.find((command) => command.name() === 'agent')?.helpInformation() ?? '';
 
     expect(help).toContain('doctor');
     expect(help).toContain('config');
@@ -59,6 +61,8 @@ describe('machine commands', () => {
     expect(help).toContain('scout');
     expect(help).toContain('analyze');
     expect(help).toContain('agent');
+    expect(analyzeHelp).toContain('--repo-path <path>');
+    expect(agentHelp).toContain('--repo-path <path>');
   });
 
   test('machine doctor writes only JSON to stdout', async () => {
@@ -306,7 +310,7 @@ describe('machine commands', () => {
     spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
     spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
 
-    await program.parseAsync(['machine', 'analyze', '--repo', 'acme/demo', '--headless', '--dry-run'], { from: 'user' });
+    await program.parseAsync(['machine', 'analyze', '--repo', 'acme/demo', '--repo-path', '/Users/example/src/demo', '--headless', '--dry-run'], { from: 'user' });
 
     const output = JSON.parse(writes.join(''));
     expect(output.command).toBe('machine analyze');

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -316,11 +316,14 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine analyze');
     expect(output.data.repoFullName).toBe('acme/demo');
     expect(output.data.mode.dryRun).toBe(true);
+    expect(stderrWrites.join('')).toContain('Machine execution plan for machine analyze');
+    expect(stderrWrites.join('')).toContain('Prepare repository workspace');
     expect(stderrWrites.join('')).toContain('Inspecting repository for grounded contribution ideas');
   });
 
   test('machine agent writes execution outcome as JSON only', async () => {
     const writes = captureStdout();
+    const stderrWrites = captureStderr();
     const program = new Command();
     registerMachineCommand(program);
     const issue = createRankedIssue({ repoFullName: 'acme/demo', number: 42 });
@@ -373,6 +376,8 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine agent');
     expect(output.data.executionOutcome).toBe('draft_only');
     expect(output.data.repoMutated).toBe(false);
+    expect(stderrWrites.join('')).toContain('Machine execution plan for machine agent');
+    expect(stderrWrites.join('')).toContain('Draft patch and PR artifacts without mutating the repository');
   });
 
   test('machine scout suppresses human task output during real machine execution', async () => {

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -3,12 +3,21 @@ import { Command } from 'commander';
 import { registerMachineCommand } from '../src/commands/machine.js';
 import * as infra from '../src/infra/index.js';
 import { agentOrchestrator, analyzeOrchestrator, configOrchestrator, providerOrchestrator } from '../src/orchestration/index.js';
-import { githubService, issueRankingService } from '../src/services/index.js';
-import { createPatchDraft, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
+import { contentService, githubService, issueRankingService, llmService, memoryService, workspaceService } from '../src/services/index.js';
+import { createMemory, createPatchDraft, createPullRequestDraft, createRankedIssue, createRepositorySuggestion, createWorkspace } from './helpers/factories.js';
 
 function captureStdout(): string[] {
   const writes: string[] = [];
   spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  return writes;
+}
+
+function captureStderr(): string[] {
+  const writes: string[] = [];
+  spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
     writes.push(String(chunk));
     return true;
   });
@@ -238,6 +247,7 @@ describe('machine commands', () => {
 
   test('machine analyze writes repository analysis output as JSON only', async () => {
     const writes = captureStdout();
+    const stderrWrites = captureStderr();
     const program = new Command();
     registerMachineCommand(program);
     const suggestion = createRepositorySuggestion();
@@ -248,25 +258,53 @@ describe('machine commands', () => {
       branchName: 'openmeta/analyze-acme-demo',
     });
 
-    spyOn(analyzeOrchestrator, 'runMachine').mockResolvedValue({
-      repoFullName: 'acme/demo',
-      workspace,
-      selectedSuggestion: suggestion,
-      suggestions: [suggestion],
-      patchDraft,
-      prDraft,
-      artifacts: {
-        artifactDir: '/tmp/openmeta/artifacts/analyze',
-        analysisPath: '/tmp/openmeta/artifacts/analyze/repository-analysis.md',
-        patchDraftPath: '/tmp/openmeta/artifacts/analyze/patch-draft.md',
-        prDraftPath: '/tmp/openmeta/artifacts/analyze/pr-draft.md',
+    spyOn(infra.configService, 'get').mockResolvedValue({
+      userProfile: { techStack: ['typescript'], proficiency: 'intermediate', focusAreas: ['tooling'] },
+      github: { pat: 'ghp_test_token', username: 'octocat', targetRepoPath: '' },
+      llm: {
+        provider: 'custom',
+        apiBaseUrl: 'https://example.com/v1',
+        apiKey: 'sk-test',
+        modelName: 'test-model',
+        apiHeaders: {},
       },
-      mode: {
-        headless: true,
-        runChecks: false,
-        dryRun: true,
+      automation: {
+        enabled: false,
+        scheduleTime: '09:00',
+        timezone: 'UTC',
+        contentType: 'research_note',
+        scheduler: 'manual',
+        minMatchScore: 70,
+        skipIfAlreadyGeneratedToday: true,
       },
+      scoring: DEFAULT_SCORING,
+      commitTemplate: 'feat: {{title}}',
     });
+    spyOn(analyzeOrchestrator as unknown as { validateConfig(config: unknown): Promise<void> }, 'validateConfig').mockResolvedValue(undefined);
+    spyOn(analyzeOrchestrator as unknown as { initializeClients(config: unknown): Promise<void> }, 'initializeClients').mockResolvedValue(undefined);
+    spyOn(memoryService, 'load').mockReturnValue(createMemory({ repoFullName: 'acme/demo' }));
+    spyOn(workspaceService, 'prepareRepositoryWorkspace').mockResolvedValue(workspace);
+    spyOn(llmService, 'analyzeRepository').mockResolvedValue({
+      version: '1',
+      kind: 'repository_suggestion_list',
+      status: 'success',
+      data: [suggestion],
+    });
+    spyOn(llmService, 'generatePatchDraft').mockResolvedValue({
+      version: '1',
+      kind: 'patch_draft',
+      status: 'success',
+      data: patchDraft,
+    });
+    spyOn(llmService, 'generatePrDraft').mockResolvedValue({
+      version: '1',
+      kind: 'pull_request_draft',
+      status: 'success',
+      data: prDraft,
+    });
+    spyOn(contentService, 'formatRepositoryAnalysisMarkdown').mockReturnValue('# Repository Analysis');
+    spyOn(contentService, 'formatPatchDraftMarkdown').mockReturnValue('# Patch');
+    spyOn(contentService, 'formatPullRequestDraftMarkdown').mockReturnValue('# PR');
 
     await program.parseAsync(['machine', 'analyze', '--repo', 'acme/demo', '--headless', '--dry-run'], { from: 'user' });
 
@@ -274,6 +312,7 @@ describe('machine commands', () => {
     expect(output.command).toBe('machine analyze');
     expect(output.data.repoFullName).toBe('acme/demo');
     expect(output.data.mode.dryRun).toBe(true);
+    expect(stderrWrites.join('')).toContain('Inspecting repository for grounded contribution ideas');
   });
 
   test('machine agent writes execution outcome as JSON only', async () => {

--- a/test/skill-bundle.test.ts
+++ b/test/skill-bundle.test.ts
@@ -33,6 +33,8 @@ describe('skill bundle rendering', () => {
     expect(claudeSkill).toStartWith('---\nname: openmeta\n');
     expect(claudeSkill).toContain('Install target: `~/.claude/skills/openmeta`');
     expect(claudeSkill).toContain('Keep the generated file at `SKILL.md`');
+    expect(claudeSkill).toContain('## What OpenMeta Can Do');
+    expect(claudeSkill).toContain('Discover and rank worthwhile issues');
     expect(claudeSkill).toContain('## Config Keys For `machine config set`');
     expect(claudeSkill).toContain('`executionOutcome`');
     expect(claudeSkill).toContain('"errorCodes"');
@@ -79,6 +81,7 @@ describe('skill bundle rendering', () => {
     const exportedSkill = readFileSync(join(exportRoot, 'claude-code', 'SKILL.md'), 'utf-8');
     expect(exportedSkill).toStartWith('---\nname: openmeta\n');
     expect(exportedSkill).toContain('Install target: `~/.claude/skills/openmeta`');
+    expect(exportedSkill).toContain('## What OpenMeta Can Do');
     expect(exportedSkill).toContain('## Result Interpretation');
     expect(exportedSkill).toContain('"inspectFields"');
     expect(exportedSkill).toContain('openmeta machine doctor');
@@ -100,6 +103,7 @@ describe('skill bundle rendering', () => {
     const installedSkill = readFileSync(skillPath, 'utf-8');
     expect(installedSkill).toStartWith('---\nname: openmeta\n');
     expect(installedSkill).toContain('description: Use when');
+    expect(installedSkill).toContain('## What OpenMeta Can Do');
     expect(installedSkill).toContain('openmeta machine doctor');
   });
 });

--- a/test/skill-doctor.test.ts
+++ b/test/skill-doctor.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import * as runtimeDiagnosticsModule from '../src/services/runtime-diagnostics.js';
+import { doctorSkillBundle } from '../src/orchestration/skill/doctor.js';
+
+describe('doctorSkillBundle', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('reports the resolved openmeta binary details when PATH wiring is healthy', async () => {
+    spyOn(runtimeDiagnosticsModule, 'inspectBinaryOnPath').mockReturnValue({
+      onPath: true,
+      command: 'openmeta',
+      version: '1.2.3',
+      invokedPath: '/Users/demo/.bun/bin/openmeta',
+      resolvedPath: '/Users/demo/work/openmeta-cli/bin/openmeta.js',
+      symlinkTarget: '../install/global/node_modules/openmeta-cli/bin/openmeta.js',
+      source: 'bun-link',
+    });
+
+    const result = await doctorSkillBundle('claude-code');
+
+    expect(result.openmetaOnPath).toBe(true);
+    expect(result.openmetaBinary).toEqual(expect.objectContaining({
+      source: 'bun-link',
+      invokedPath: '/Users/demo/.bun/bin/openmeta',
+      resolvedPath: '/Users/demo/work/openmeta-cli/bin/openmeta.js',
+      version: '1.2.3',
+    }));
+    expect(result.nextActions).not.toContain('ensure_openmeta_on_path');
+  });
+
+  test('keeps the missing PATH remediation when openmeta cannot be resolved', async () => {
+    spyOn(runtimeDiagnosticsModule, 'inspectBinaryOnPath').mockReturnValue({
+      onPath: false,
+      command: 'openmeta',
+      source: 'missing',
+      error: 'openmeta is not available on PATH.',
+    });
+
+    const result = await doctorSkillBundle('claude-code');
+
+    expect(result.openmetaOnPath).toBe(false);
+    expect(result.openmetaBinary.source).toBe('missing');
+    expect(result.nextActions).toContain('ensure_openmeta_on_path');
+  });
+});

--- a/test/ui-task.test.ts
+++ b/test/ui-task.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { runInMachineContext } from '../src/infra/execution-context.js';
+import { runTask } from '../src/infra/ui/live.js';
+import type { UiCapabilities } from '../src/infra/ui/types.js';
+
+const capabilities: UiCapabilities = {
+  width: 100,
+  isInteractive: false,
+  supportsColor: false,
+  supportsUnicode: true,
+  mode: 'plain',
+};
+
+describe('ui task progress', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('machine task prefixes step progress and emits heartbeat updates after quiet periods', async () => {
+    const stderrWrites: string[] = [];
+
+    spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await runInMachineContext(() => runTask(
+      capabilities,
+      {
+        title: 'Waiting for repository analysis',
+        doneMessage: 'Repository analysis finished',
+        step: { index: 2, total: 4 },
+        heartbeat: {
+          intervalMs: 5,
+          message: ({ elapsedMs }) => `Still working after ${elapsedMs}ms`,
+        },
+      },
+      async (task) => {
+        task.setMessage('Captured repository context');
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return true;
+      },
+    ));
+
+    const combined = stderrWrites.join('');
+    expect(combined).toContain('Step 2/4 Waiting for repository analysis');
+    expect(combined).toContain('Step 2/4 Captured repository context');
+    expect(combined).toContain('Step 2/4 Still working after');
+    expect(combined).toContain('[success] Step 2/4 Repository analysis finished');
+  });
+});

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -118,6 +118,54 @@ describe('workspaceService.applyGeneratedChanges', () => {
 });
 
 describe('workspaceService.detectTestCommands', () => {
+  test('uses a local repository path by creating an isolated worktree instead of cloning into the managed workspace', async () => {
+    const tempRoot = makeWorkspace();
+    const openMetaHome = join(tempRoot, 'openmeta-home');
+    const sourcePath = join(tempRoot, 'source');
+    process.env['OPENMETA_HOME'] = openMetaHome;
+
+    mkdirSync(sourcePath, { recursive: true });
+    const git = simpleGit(sourcePath);
+    await git.init(['--initial-branch=main']);
+    await git.addConfig('user.name', 'OpenMeta Test');
+    await git.addConfig('user.email', 'openmeta@example.com');
+    writeFileSync(join(sourcePath, 'README.md'), '# Local Demo\n', 'utf-8');
+    await git.add('README.md');
+    await git.commit('chore: seed local repo');
+
+    try {
+      const workspace = await (workspaceService as unknown as {
+        prepareRepositoryWorkspace(
+          repoFullName: string,
+          memory: ReturnType<typeof createMemory>,
+          runChecks: boolean,
+          executionMode?: 'interactive' | 'headless',
+          repoPath?: string,
+        ): Promise<{
+          workspacePath: string;
+          branchName?: string;
+          topLevelFiles: string[];
+        }>;
+      }).prepareRepositoryWorkspace(
+        'acme/demo',
+        createMemory({ repoFullName: 'acme/demo' }),
+        false,
+        'interactive',
+        sourcePath,
+      );
+
+      expect(workspace.workspacePath).toContain(join('openmeta-home', 'worktrees'));
+      expect(workspace.workspacePath).not.toBe(sourcePath);
+      expect(workspace.branchName).toMatch(/^openmeta\/analyze-acme-demo/);
+      expect(workspace.topLevelFiles).toContain('README.md');
+
+      const managedMirrorPath = join(openMetaHome, 'workspaces', 'acme__demo');
+      expect(existsSync(managedMirrorPath)).toBe(false);
+    } finally {
+      delete process.env['OPENMETA_HOME'];
+    }
+  });
+
   test('prepares repository workspace without a real issue target', async () => {
     const tempRoot = makeWorkspace();
     const openMetaHome = join(tempRoot, 'openmeta-home');
@@ -179,6 +227,54 @@ describe('workspaceService.detectTestCommands', () => {
       expect(workspace.candidateFiles).toContain('src/index.ts');
       expect(workspace.snippets.some((snippet) => snippet.path === 'README.md')).toBe(true);
       expect(workspace.testCommands.map((command) => command.command)).toContain('bun run test');
+    } finally {
+      service.buildRepoUrl = originalBuildRepoUrl;
+      delete process.env['OPENMETA_HOME'];
+    }
+  });
+
+  test('creates a shallow single-branch clone for new managed workspaces', async () => {
+    const tempRoot = makeWorkspace();
+    const openMetaHome = join(tempRoot, 'openmeta-home');
+    const remotePath = join(tempRoot, 'remote.git');
+    const seedPath = join(tempRoot, 'seed');
+    process.env['OPENMETA_HOME'] = openMetaHome;
+
+    mkdirSync(seedPath, { recursive: true });
+    const seedGit = simpleGit(seedPath);
+    await seedGit.init(['--initial-branch=main']);
+    await seedGit.addConfig('user.name', 'OpenMeta Test');
+    await seedGit.addConfig('user.email', 'openmeta@example.com');
+    writeFileSync(join(seedPath, 'README.md'), '# Demo\n', 'utf-8');
+    await seedGit.add('README.md');
+    await seedGit.commit('chore: seed repo');
+    await simpleGit().clone(seedPath, remotePath, ['--bare']);
+
+    const service = workspaceService as unknown as {
+      buildRepoUrl(repoFullName: string): string;
+      prepareRepositoryWorkspace(
+        repoFullName: string,
+        memory: ReturnType<typeof createMemory>,
+        runChecks: boolean,
+        executionMode?: 'interactive' | 'headless',
+        repoPath?: string,
+      ): Promise<{ workspacePath: string }>;
+    };
+    const originalBuildRepoUrl = service.buildRepoUrl;
+    service.buildRepoUrl = () => remotePath;
+
+    try {
+      const workspace = await service.prepareRepositoryWorkspace(
+        'acme/demo',
+        createMemory({ repoFullName: 'acme/demo' }),
+        false,
+      );
+      const clonedGit = simpleGit(workspace.workspacePath);
+      const shallowFile = join(workspace.workspacePath, '.git', 'shallow');
+      const remoteBranches = await clonedGit.branch(['-r']);
+
+      expect(existsSync(shallowFile)).toBe(true);
+      expect(remoteBranches.all).toEqual(['origin/main']);
     } finally {
       service.buildRepoUrl = originalBuildRepoUrl;
       delete process.env['OPENMETA_HOME'];

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -281,6 +281,62 @@ describe('workspaceService.detectTestCommands', () => {
     }
   });
 
+  test('rebuilds a managed workspace when the cached clone has an invalid HEAD', async () => {
+    const tempRoot = makeWorkspace();
+    const openMetaHome = join(tempRoot, 'openmeta-home');
+    const remotePath = join(tempRoot, 'remote.git');
+    const seedPath = join(tempRoot, 'seed');
+    process.env['OPENMETA_HOME'] = openMetaHome;
+
+    mkdirSync(seedPath, { recursive: true });
+    const seedGit = simpleGit(seedPath);
+    await seedGit.init(['--initial-branch=main']);
+    await seedGit.addConfig('user.name', 'OpenMeta Test');
+    await seedGit.addConfig('user.email', 'openmeta@example.com');
+    writeFileSync(join(seedPath, 'README.md'), '# Demo\n', 'utf-8');
+    await seedGit.add('README.md');
+    await seedGit.commit('chore: seed repo');
+    await simpleGit().clone(seedPath, remotePath, ['--bare']);
+
+    const service = workspaceService as unknown as {
+      buildRepoUrl(repoFullName: string): string;
+      prepareRepositoryWorkspace(
+        repoFullName: string,
+        memory: ReturnType<typeof createMemory>,
+        runChecks: boolean,
+        executionMode?: 'interactive' | 'headless',
+        repoPath?: string,
+      ): Promise<{ workspacePath: string; topLevelFiles: string[] }>;
+    };
+    const originalBuildRepoUrl = service.buildRepoUrl;
+    service.buildRepoUrl = () => remotePath;
+
+    try {
+      const firstWorkspace = await service.prepareRepositoryWorkspace(
+        'acme/demo',
+        createMemory({ repoFullName: 'acme/demo' }),
+        false,
+      );
+      const headPath = join(firstWorkspace.workspacePath, '.git', 'refs', 'heads', 'main');
+      writeFileSync(headPath, '0000000000000000000000000000000000000000\n', 'utf-8');
+
+      const recoveredWorkspace = await service.prepareRepositoryWorkspace(
+        'acme/demo',
+        createMemory({ repoFullName: 'acme/demo' }),
+        false,
+      );
+      const recoveredGit = simpleGit(recoveredWorkspace.workspacePath);
+      const branchSummary = await recoveredGit.branchLocal();
+
+      expect(recoveredWorkspace.workspacePath).toBe(firstWorkspace.workspacePath);
+      expect(recoveredWorkspace.topLevelFiles).toContain('README.md');
+      expect(branchSummary.current).toMatch(/^openmeta\/analyze-acme-demo/);
+    } finally {
+      service.buildRepoUrl = originalBuildRepoUrl;
+      delete process.env['OPENMETA_HOME'];
+    }
+  });
+
   test('prefers bun for package scripts when a bun lockfile is present', () => {
     const workspacePath = makeWorkspace();
     writeFileSync(join(workspacePath, 'package.json'), JSON.stringify({


### PR DESCRIPTION
## Summary
- add structured `openmeta` PATH and binary-source diagnostics to `doctor` and `skill doctor`
- rebuild managed workspace mirrors when a cached clone has an invalid `HEAD`
- explain empty scout results with threshold-aware guidance for both human and machine flows

## Why
Three usability gaps were still making `/openmeta` sessions harder to debug than they should be:

1. PATH checks only exposed a boolean, so users could not tell which `openmeta` binary Claude Code was actually invoking.
2. A corrupted managed workspace mirror could fail with `invalid HEAD` or `unable to read tree`, leaving the run stuck instead of self-healing.
3. Empty scout results did not explain whether the threshold, repo scope, local-only mode, or cached issue set was the likely cause.

## Validation
- `bun test test/skill-doctor.test.ts test/doctor.test.ts test/workspace.test.ts test/machine-agent.test.ts test/agent-orchestrator.test.ts test/machine-commands.test.ts`
- `bun run typecheck`
- `bun run build`
