### PR TITLE
remove scout local mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Issue ranking now has a dedicated service:
 It is responsible for:
 
 - local pre-ranking against the saved profile
-- local heuristic issue matching when `--local` is used
+- local heuristic issue matching before batched scoring
 - batched LLM issue scoring
 - selecting the first issue above the automation threshold
 - diversifying scout output across repositories

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ openmeta agent
 
 # 3. 只看机会排名
 openmeta scout --limit 10
-openmeta scout --local --limit 10
 
 # 4. 查看贡献沉淀
 openmeta inbox
@@ -300,7 +299,6 @@ openmeta machine analyze --repo owner/name --dry-run
 | `openmeta scout --limit <count>` | 查看高价值贡献机会排名 |
 | `openmeta scout --refresh` | 强制刷新 GitHub issue discovery 缓存 |
 | `openmeta scout --repo <repository>` | 从一个 GitHub 仓库 URL 或 `owner/name` 中筛选贡献机会 |
-| `openmeta scout --local` | 使用本地启发式评分，不调用 LLM，适合模型服务暂时不可用时先筛机会 |
 | `openmeta inbox` | 查看已起草的贡献机会收件箱 |
 | `openmeta pow` | 查看贡献工作量证明记录 |
 | `openmeta runs` | 查看最近命令运行记录、耗时和失败原因 |
@@ -574,7 +572,6 @@ openmeta agent
 
 # 3. Only scout and rank opportunities
 openmeta scout --limit 10
-openmeta scout --local --limit 10
 
 # 4. Inspect durable contribution assets
 openmeta inbox
@@ -644,7 +641,6 @@ openmeta machine analyze --repo owner/name --dry-run
 | `openmeta scout --limit <count>` | Show ranked contribution opportunities |
 | `openmeta scout --refresh` | Force-refresh the GitHub issue discovery cache |
 | `openmeta scout --repo <repository>` | Rank opportunities from one upstream GitHub repository URL or `owner/name` |
-| `openmeta scout --local` | Use local heuristic scoring without calling the LLM provider |
 | `openmeta inbox` | Show drafted contribution opportunities |
 | `openmeta pow` | Show proof-of-work history |
 | `openmeta runs` | Show recent command runs, durations, and failure reasons |

--- a/docs/superpowers/plans/2026-06-08-openmeta-machine-interface-and-skill-bundle.md
+++ b/docs/superpowers/plans/2026-06-08-openmeta-machine-interface-and-skill-bundle.md
@@ -595,8 +595,8 @@ git commit -m "feat: add machine inbox pow and run state surfaces"
 
 ```ts
 test('machine scout returns ranked opportunities with mode metadata', async () => {
-  const result = await new AgentOrchestrator().scoutMachine({ limit: 5, refresh: true, localOnly: true });
-  expect(result.mode.localOnly).toBe(true);
+  const result = await new AgentOrchestrator().scoutMachine({ limit: 5, refresh: true });
+  expect(result.mode.refresh).toBe(true);
   expect(result.opportunities).toBeArray();
 });
 
@@ -630,7 +630,6 @@ Implement `AgentOrchestrator.scoutMachine(options)` so it reuses `issueRankingSe
     limit: number;
     refresh: boolean;
     repo?: string;
-    localOnly: boolean;
   };
   nextActions: string[];
 }

--- a/docs/superpowers/specs/2026-06-08-openmeta-machine-interface-and-skill-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-08-openmeta-machine-interface-and-skill-bundle-design.md
@@ -45,7 +45,7 @@ openmeta machine config get
 openmeta machine config set <key> <value>
 openmeta machine provider add <name> --base-url <url> --model <model> --api-key <key>
 openmeta machine provider use <name>
-openmeta machine scout [--limit <count>] [--refresh] [--repo <repository>] [--local]
+openmeta machine scout [--limit <count>] [--refresh] [--repo <repository>]
 openmeta machine analyze --repo <repository> [--headless] [--run-checks] [--dry-run]
 openmeta machine agent [--headless] [--run-checks] [--draft-only] [--refresh] [--repo <repository>] [--issue <issue>] [--dry-run]
 openmeta machine runs [id]
@@ -203,7 +203,7 @@ Return a stable ranked opportunity list:
 
 - `opportunities[]`
 - per-item repo, issue number, issue URL, score, summary, breakdown
-- invocation mode metadata such as `refresh`, `repo`, and `localOnly`
+- invocation mode metadata such as `refresh` and `repo`
 
 ### `machine analyze`
 

--- a/skills/core/openmeta.md
+++ b/skills/core/openmeta.md
@@ -64,7 +64,7 @@ OpenMeta is built for contribution-oriented open source work.
 
 ### Discovery and Execution
 
-- `openmeta machine scout [--limit <count>] [--refresh] [--repo <owner/name>] [--local]`
+- `openmeta machine scout [--limit <count>] [--refresh] [--repo <owner/name>]`
 - `openmeta machine analyze --repo <owner/name|url> [--headless] [--run-checks] [--dry-run]`
 - `openmeta machine agent [--headless] [--run-checks] [--draft-only] [--refresh] [--repo <owner/name>] [--issue <number|url>] [--dry-run]`
 
@@ -206,9 +206,7 @@ Look for:
 
 - `opportunities`
 - per-item `repoFullName`, `issueNumber`, `issueUrl`, `overallScore`, and scoring breakdown
-- mode flags such as `refresh`, `repo`, and `localOnly`
-
-Use `--local` when the host wants heuristic ranking without LLM calls.
+- mode flags such as `refresh` and `repo`
 
 ### `machine analyze`
 

--- a/skills/schema/capability-catalog.json
+++ b/skills/schema/capability-catalog.json
@@ -44,7 +44,7 @@
     {
       "name": "openmeta machine scout",
       "requiredArgs": [],
-      "optionalArgs": ["--limit", "--refresh", "--repo", "--local"],
+      "optionalArgs": ["--limit", "--refresh", "--repo"],
       "outcome": "machine_scout_result",
       "purpose": "Return ranked contribution opportunities in a stable JSON shape.",
       "inspectFields": ["opportunities", "mode", "nextActions"]

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -90,8 +90,7 @@ export function registerMachineCommand(program: Command): void {
     .option('--limit <count>', 'Number of opportunities to return', '10')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one repository')
-    .option('--local', 'Use local heuristic scoring without calling the LLM provider')
-    .action((options: { limit?: string; refresh?: boolean; repo?: string; local?: boolean }) =>
+    .action((options: { limit?: string; refresh?: boolean; repo?: string }) =>
       machineScoutOrchestrator.execute(options),
     );
 

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -9,14 +9,12 @@ export function registerScoutCommand(program: Command): void {
     .option('--limit <count>', 'Number of opportunities to show', '10')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
-    .option('--local', 'Use local heuristic scoring without calling the LLM provider')
-    .action((options: { limit?: string; refresh?: boolean; repo?: string; local?: boolean }) =>
+    .action((options: { limit?: string; refresh?: boolean; repo?: string }) =>
       runCommand('OpenMeta Scout', () =>
         agentOrchestrator.scout({
           limit: Number.parseInt(options.limit || '10', 10) || 10,
           refresh: options.refresh,
           repo: options.repo,
-          localOnly: options.local,
         }),
       ),
     );

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -56,7 +56,6 @@ export interface ScoutRunOptions {
   limit?: number;
   refresh?: boolean;
   repo?: string;
-  localOnly?: boolean;
 }
 
 export interface MachineScoutResult {
@@ -65,7 +64,6 @@ export interface MachineScoutResult {
     limit: number;
     refresh: boolean;
     repo?: string;
-    localOnly: boolean;
   };
   emptyExplanation?: {
     title: string;
@@ -170,7 +168,7 @@ export class AgentOrchestrator {
 
   private buildScoutEmptyExplanation(
     config: AppConfig,
-    options: { repoFullName?: string; localOnly: boolean; refresh: boolean },
+    options: { repoFullName?: string; refresh: boolean },
   ): { title: string; detail: string; suggestions: string[] } {
     const scopeLine = options.repoFullName
       ? `This run was limited to ${options.repoFullName}.`
@@ -184,11 +182,9 @@ export class AgentOrchestrator {
         options.repoFullName
           ? 'Try a different repository or remove the repo filter.'
           : 'Broaden your tech stack or focus areas in the saved profile.',
-        options.localOnly
-          ? 'Run scout without --local after the LLM provider is healthy to widen scoring coverage.'
-          : options.refresh
-            ? 'Try again later after new issues appear.'
-            : 'Rerun with --refresh to ignore the local issue cache.',
+        options.refresh
+          ? 'Try again later after new issues appear.'
+          : 'Rerun with --refresh to ignore the local issue cache.',
       ],
     };
   }
@@ -899,19 +895,15 @@ export class AgentOrchestrator {
     const refresh = typeof options === 'number' ? false : Boolean(options.refresh);
     const repoFullName =
       typeof options === 'number' || !options.repo ? undefined : parseGitHubRepoFullName(options.repo);
-    const localOnly = typeof options === 'number' ? false : Boolean(options.localOnly);
     const config = await configService.get();
-    await this.validateConfig(config, { requireGithub: !localOnly, requireLlm: !localOnly });
-    if (!localOnly || repoFullName) {
-      await this.initializeClients(config, { validateGithub: true, validateLlm: !localOnly });
-    }
+    await this.validateConfig(config);
+    await this.initializeClients(config, { validateGithub: true, validateLlm: true });
 
     ui.hero({
       label: 'OpenMeta Scout',
-      title: localOnly ? 'Read the field while the model stays offline' : 'Read the field before you spend your focus',
-      subtitle: localOnly
-        ? 'OpenMeta will use local profile heuristics to keep scouting useful even when the LLM provider is unavailable.'
-        : 'OpenMeta turns a noisy issue stream into a shortlist shaped by technical fit, timing, and real opening momentum.',
+      title: 'Read the field before you spend your focus',
+      subtitle:
+        'OpenMeta turns a noisy issue stream into a shortlist shaped by technical fit, timing, and real opening momentum.',
       lines: [
         `Saved threshold reference: ${config.automation.minMatchScore}/100.`,
         refresh
@@ -920,9 +912,7 @@ export class AgentOrchestrator {
         repoFullName
           ? `Issue discovery is limited to ${repoFullName}.`
           : 'Issue discovery will scan the broader GitHub issue stream.',
-        localOnly
-          ? 'LLM validation and model scoring are skipped for this run.'
-          : 'LLM scoring will refine the local candidate shortlist.',
+        'LLM scoring will refine the local candidate shortlist.',
       ],
     });
 
@@ -937,12 +927,11 @@ export class AgentOrchestrator {
         issueRankingService.loadRankedIssues(config, {
           refresh,
           repoFullName,
-          localOnly,
           onStatus: (message) => task.setMessage(message),
         }),
     );
     if (rankedIssues.length === 0) {
-      const emptyExplanation = this.buildScoutEmptyExplanation(config, { repoFullName, localOnly, refresh });
+      const emptyExplanation = this.buildScoutEmptyExplanation(config, { repoFullName, refresh });
       ui.emptyState(
         'OpenMeta Scout',
         emptyExplanation.title,
@@ -965,20 +954,17 @@ export class AgentOrchestrator {
     const limit = options.limit ?? 10;
     const refresh = Boolean(options.refresh);
     const repoFullName = options.repo ? parseGitHubRepoFullName(options.repo) : undefined;
-    const localOnly = Boolean(options.localOnly);
     const config = await configService.get();
 
-    await this.validateConfig(config, { requireGithub: !localOnly, requireLlm: !localOnly });
-    if (!localOnly || repoFullName) {
-      await this.initializeClients(config, {
-        validateGithub: true,
-        validateLlm: !localOnly,
-        taskSteps: {
-          github: { index: 1, total: totalSteps },
-          ...(localOnly ? {} : { llm: { index: 2, total: totalSteps } }),
-        },
-      });
-    }
+    await this.validateConfig(config);
+    await this.initializeClients(config, {
+      validateGithub: true,
+      validateLlm: true,
+      taskSteps: {
+        github: { index: 1, total: totalSteps },
+        llm: { index: 2, total: totalSteps },
+      },
+    });
 
     const rankedIssues = await ui.task(
       {
@@ -986,7 +972,7 @@ export class AgentOrchestrator {
         doneMessage: 'Contribution opportunities scored',
         failedMessage: 'Contribution opportunity scoring failed',
         tone: 'info',
-        step: { index: localOnly ? 2 : 3, total: totalSteps },
+        step: { index: 3, total: totalSteps },
         heartbeat: {
           message: 'Still scoring contribution opportunities',
         },
@@ -995,14 +981,11 @@ export class AgentOrchestrator {
         issueRankingService.loadRankedIssues(config, {
           refresh,
           repoFullName,
-          localOnly,
           onStatus: (message) => task.setMessage(message),
         }),
     );
     const emptyExplanation =
-      rankedIssues.length === 0
-        ? this.buildScoutEmptyExplanation(config, { repoFullName, localOnly, refresh })
-        : undefined;
+      rankedIssues.length === 0 ? this.buildScoutEmptyExplanation(config, { repoFullName, refresh }) : undefined;
 
     return {
       opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
@@ -1010,7 +993,6 @@ export class AgentOrchestrator {
         limit,
         refresh,
         repo: repoFullName,
-        localOnly,
       },
       ...(emptyExplanation ? { emptyExplanation } : {}),
       nextActions: rankedIssues.length === 0 ? ['broaden_profile_filters'] : ['inspect_ranked_opportunities'],

--- a/src/orchestration/machine/scout.ts
+++ b/src/orchestration/machine/scout.ts
@@ -4,11 +4,11 @@ import { mapMachineError } from './errors.js';
 import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineScoutOrchestrator {
-  async execute(options: { limit?: string; refresh?: boolean; repo?: string; local?: boolean } = {}): Promise<void> {
+  async execute(options: { limit?: string; refresh?: boolean; repo?: string } = {}): Promise<void> {
     try {
       writeMachinePlan('machine scout', [
-        'Validate GitHub access when remote scouting is enabled',
-        'Validate LLM provider when model scoring is enabled',
+        'Validate GitHub access',
+        'Validate LLM provider',
         'Fetch and score contribution opportunities',
         'Return ranked opportunities with mode metadata',
       ]);
@@ -17,7 +17,6 @@ export class MachineScoutOrchestrator {
           limit: Number.parseInt(options.limit || '10', 10) || 10,
           refresh: options.refresh,
           repo: options.repo,
-          localOnly: options.local,
         }),
       );
       writeMachinePayload(buildMachineEnvelope('machine scout', result));

--- a/src/services/issue-ranking.ts
+++ b/src/services/issue-ranking.ts
@@ -1,7 +1,6 @@
 import { logger } from '../infra/index.js';
 import type { AppConfig, GitHubIssue, MatchedIssue, RankedIssue } from '../types/index.js';
 import { githubService } from './github.js';
-import { inboxService } from './inbox.js';
 import { llmService } from './llm.js';
 import { opportunityService } from './opportunity.js';
 import { proofOfWorkService } from './proof-of-work.js';
@@ -41,15 +40,9 @@ export class IssueRankingService {
     options: {
       refresh?: boolean;
       repoFullName?: string;
-      localOnly?: boolean;
       onStatus?: (message: string) => void;
     } = {},
   ): Promise<RankedIssue[]> {
-    if (options.localOnly && !options.repoFullName) {
-      const issues = this.loadLocalRetainedIssues();
-      return opportunityService.rankIssues(this.buildLocalIssueMatches(issues, config.userProfile), config.scoring);
-    }
-
     const issues = await githubService.fetchTrendingIssues({
       refresh: options.refresh,
       repoFullName: options.repoFullName,
@@ -57,55 +50,8 @@ export class IssueRankingService {
       techStack: config.userProfile.techStack,
     });
     const rankedCandidates = this.rankIssuesForProfile(issues, config.userProfile);
-    if (options.localOnly) {
-      return opportunityService.rankIssues(
-        this.buildLocalIssueMatches(rankedCandidates, config.userProfile),
-        config.scoring,
-      );
-    }
-
     const matched = await this.scoreIssuesInBatches(config.userProfile, rankedCandidates);
     return opportunityService.rankIssues(matched, config.scoring);
-  }
-
-  loadLocalRetainedIssues(): GitHubIssue[] {
-    const issueMap = new Map<string, GitHubIssue>();
-
-    const addIssue = (issue: GitHubIssue): void => {
-      issueMap.set(`${issue.repoFullName}#${issue.number}`, issue);
-    };
-
-    for (const item of inboxService.load().items) {
-      addIssue(
-        this.retainedRecordToIssue({
-          repoFullName: item.repoFullName,
-          issueNumber: item.issueNumber,
-          issueTitle: item.issueTitle,
-          summary: item.summary,
-          generatedAt: item.generatedAt,
-          score: item.overallScore,
-        }),
-      );
-    }
-
-    for (const record of proofOfWorkService.load().records) {
-      addIssue(
-        this.retainedRecordToIssue({
-          repoFullName: record.repoFullName,
-          issueNumber: record.issueNumber,
-          issueTitle: record.issueTitle,
-          summary: record.published
-            ? 'Previously published OpenMeta proof-of-work record.'
-            : 'Previous OpenMeta proof-of-work record.',
-          generatedAt: record.generatedAt,
-          score: record.overallScore,
-        }),
-      );
-    }
-
-    return [...issueMap.values()].sort(
-      (left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
-    );
   }
 
   async loadTargetIssue(
@@ -133,46 +79,11 @@ export class IssueRankingService {
           coreDemand: issue.title,
           techRequirements,
           solutionSuggestion:
-            'Local scout mode can shortlist this issue, then run "openmeta agent" when the LLM provider is healthy to draft a concrete patch plan.',
+            'OpenMeta can shortlist this issue heuristically, then run "openmeta agent" to draft a concrete patch plan.',
           estimatedWorkload: this.estimateLocalWorkload(issue),
         },
       };
     });
-  }
-
-  private retainedRecordToIssue(record: {
-    repoFullName: string;
-    issueNumber: number;
-    issueTitle: string;
-    summary: string;
-    generatedAt: string;
-    score: number;
-  }): GitHubIssue {
-    const repoName = record.repoFullName.split('/').pop() || record.repoFullName;
-    const stars = Math.max(0, Math.round(record.score));
-
-    return {
-      id: Math.abs(this.hashIssueKey(`${record.repoFullName}#${record.issueNumber}`)),
-      number: record.issueNumber,
-      title: record.issueTitle,
-      body: record.summary,
-      htmlUrl: `https://github.com/${record.repoFullName}/issues/${record.issueNumber}`,
-      repoName,
-      repoFullName: record.repoFullName,
-      repoDescription: `Retained OpenMeta opportunity for ${record.repoFullName}.`,
-      repoStars: stars,
-      labels: ['openmeta-local'],
-      createdAt: record.generatedAt,
-      updatedAt: record.generatedAt,
-    };
-  }
-
-  private hashIssueKey(value: string): number {
-    let hash = 0;
-    for (const char of value) {
-      hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;
-    }
-    return hash;
   }
 
   async scoreIssuesInBatches(userProfile: AppConfig['userProfile'], issues: GitHubIssue[]): Promise<MatchedIssue[]> {

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -226,7 +226,7 @@ afterEach(() => {
 });
 
 describe('AgentOrchestrator support behavior', () => {
-  test('validateConfig accepts local-only scout runs without an LLM key', async () => {
+  test('validateConfig allows explicitly skipping the LLM requirement', async () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
 
     await expect(
@@ -816,7 +816,7 @@ describe('AgentOrchestrator support behavior', () => {
     ).mockResolvedValue(undefined as never);
     spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
 
-    await orchestrator.scout({ localOnly: true });
+    await orchestrator.scout();
 
     expect(emptyStateSpy).toHaveBeenCalledWith(
       'OpenMeta Scout',

--- a/test/issue-ranking.test.ts
+++ b/test/issue-ranking.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  githubService,
-  inboxService,
-  issueRankingService,
-  llmService,
-  proofOfWorkService,
-} from '../src/services/index.js';
-import {
-  createInboxItem,
-  createIssue,
-  createMatchedIssue,
-  createProofRecord,
-  createRankedIssue,
-} from './helpers/factories.js';
+import { githubService, issueRankingService, llmService } from '../src/services/index.js';
+import { createIssue, createMatchedIssue, createRankedIssue } from './helpers/factories.js';
 
 describe('IssueRankingService', () => {
   test('selects the first issue that meets the automation threshold', () => {
@@ -150,95 +138,7 @@ describe('IssueRankingService', () => {
     expect(matches[0]?.analysis.techRequirements).toContain('TypeScript');
     expect(matches[0]?.analysis.techRequirements).toContain('React');
     expect(matches[0]?.analysis.estimatedWorkload).toBe('1-3 hours');
-    expect(matches[0]?.analysis.solutionSuggestion).toContain('Local scout mode');
-  });
-
-  test('local scout uses retained local state without GitHub issue discovery', async () => {
-    const originalFetchTrendingIssues = githubService.fetchTrendingIssues;
-    const originalInboxLoad = inboxService.load;
-    const originalProofLoad = proofOfWorkService.load;
-
-    try {
-      githubService.fetchTrendingIssues = async () => {
-        throw new Error('GitHub discovery should not run for local scout');
-      };
-      inboxService.load = () => ({
-        items: [
-          createInboxItem({
-            id: 'acme/local#7',
-            repoFullName: 'acme/local',
-            issueNumber: 7,
-            issueTitle: 'Fix React keyboard flow',
-            overallScore: 91,
-            opportunityScore: 87,
-            summary: 'Retained local opportunity',
-            artifactDir: '/tmp/openmeta/acme-local-7',
-            generatedAt: '2026-06-08T00:00:00.000Z',
-          }),
-        ],
-      });
-      proofOfWorkService.load = () => ({
-        records: [
-          createProofRecord({
-            id: 'acme/proof#9@1',
-            repoFullName: 'acme/proof',
-            issueNumber: 9,
-            issueTitle: 'Add TypeScript coverage',
-            overallScore: 73,
-            opportunityScore: 70,
-            artifactDir: '/tmp/openmeta/acme-proof-9',
-            generatedAt: '2026-06-07T00:00:00.000Z',
-          }),
-        ],
-      });
-
-      const ranked = await issueRankingService.loadRankedIssues(
-        {
-          userProfile: {
-            techStack: ['TypeScript', 'React'],
-            proficiency: 'intermediate',
-            focusAreas: ['web-dev'],
-          },
-          github: {
-            pat: 'ghp-test',
-            username: 'octocat',
-            targetRepoPath: '',
-          },
-          llm: {
-            provider: 'openai',
-            apiBaseUrl: 'https://api.openai.com/v1',
-            apiKey: '',
-            modelName: 'gpt-5.5',
-            reasoningEffort: 'none',
-          },
-          automation: {
-            enabled: false,
-            scheduleTime: '09:00',
-            timezone: 'UTC',
-            contentType: 'research_note',
-            scheduler: 'manual',
-            minMatchScore: 70,
-            skipIfAlreadyGeneratedToday: true,
-          },
-          scoring: {
-            weights: { freshness: 0.25, onboardingClarity: 0.25, mergePotential: 0.3, impact: 0.2, riskPenalty: 0.35 },
-            overallWeights: { technicalMatch: 0.45, opportunityScore: 0.55 },
-            preset: 'balanced',
-          },
-          commitTemplate: '{{content}}',
-        },
-        {
-          localOnly: true,
-        },
-      );
-
-      expect(ranked.map((issue) => `${issue.repoFullName}#${issue.number}`)).toContain('acme/local#7');
-      expect(ranked.map((issue) => `${issue.repoFullName}#${issue.number}`)).toContain('acme/proof#9');
-    } finally {
-      githubService.fetchTrendingIssues = originalFetchTrendingIssues;
-      inboxService.load = originalInboxLoad;
-      proofOfWorkService.load = originalProofLoad;
-    }
+    expect(matches[0]?.analysis.solutionSuggestion).toContain('OpenMeta can shortlist this issue heuristically');
   });
 
   test('builds a ranked target issue without batch discovery', async () => {
@@ -380,7 +280,6 @@ describe('IssueRankingService', () => {
         },
         {
           repoFullName: 'vercel/next.js',
-          localOnly: true,
         },
       );
 

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -229,14 +229,13 @@ describe('machine flow result builders', () => {
     spyOn(orchestrator as AgentOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
     spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([issue]);
 
-    const result = await orchestrator.scoutMachine({ limit: 5, refresh: true, localOnly: true });
+    const result = await orchestrator.scoutMachine({ limit: 5, refresh: true });
 
-    expect(result.mode.localOnly).toBe(true);
     expect(result.mode.refresh).toBe(true);
     expect(result.opportunities).toEqual([issue]);
   });
 
-  test('machine local scout skips external client initialization', async () => {
+  test('machine scout validates config and initializes clients before ranking', async () => {
     const config = createConfig();
     const issue = createRankedIssue();
     const orchestrator = new AgentOrchestrator();
@@ -250,10 +249,10 @@ describe('machine flow result builders', () => {
     spyOn(infra.configService, 'get').mockResolvedValue(config);
     spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([issue]);
 
-    const result = await orchestrator.scoutMachine({ limit: 3, localOnly: true });
+    const result = await orchestrator.scoutMachine({ limit: 3 });
 
-    expect(validateSpy).toHaveBeenCalledWith(config, { requireGithub: false, requireLlm: false });
-    expect(initializeSpy).not.toHaveBeenCalled();
+    expect(validateSpy).toHaveBeenCalledWith(config);
+    expect(initializeSpy).toHaveBeenCalled();
     expect(result.opportunities).toEqual([issue]);
   });
 
@@ -263,9 +262,10 @@ describe('machine flow result builders', () => {
 
     spyOn(infra.configService, 'get').mockResolvedValue(config);
     spyOn(orchestrator as AgentOrchestrator, 'validateConfig' as never).mockResolvedValue(undefined);
+    spyOn(orchestrator as AgentOrchestrator, 'initializeClients' as never).mockResolvedValue(undefined);
     spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
 
-    const result = await orchestrator.scoutMachine({ localOnly: true });
+    const result = await orchestrator.scoutMachine();
 
     expect(result.opportunities).toEqual([]);
     expect(result.emptyExplanation).toEqual(

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -261,12 +261,11 @@ describe('machine commands', () => {
         limit: 10,
         refresh: false,
         repo: undefined,
-        localOnly: true,
       },
       nextActions: ['inspect_ranked_opportunities'],
     });
 
-    await program.parseAsync(['machine', 'scout', '--local'], { from: 'user' });
+    await program.parseAsync(['machine', 'scout'], { from: 'user' });
 
     const output = JSON.parse(writes.join(''));
     expect(output.command).toBe('machine scout');
@@ -522,7 +521,7 @@ describe('machine commands', () => {
     spyOn(githubService, 'validateCredentials').mockResolvedValue(true);
     spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
 
-    await program.parseAsync(['machine', 'scout', '--local'], { from: 'user' });
+    await program.parseAsync(['machine', 'scout'], { from: 'user' });
 
     const output = writes.join('');
     expect(() => JSON.parse(output)).not.toThrow();

--- a/test/state-services.test.ts
+++ b/test/state-services.test.ts
@@ -230,7 +230,7 @@ describe('stateful services', () => {
   test('run history service records command lifecycle and error details', () => {
     const run = runHistoryService.start({
       commandName: 'OpenMeta Scout',
-      args: ['scout', '--local'],
+      args: ['scout', '--refresh'],
     });
     const finished = runHistoryService.finish(run.id, 'failed', 'LLM validation failed');
     const state = runHistoryService.load();
@@ -239,7 +239,7 @@ describe('stateful services', () => {
     expect(finished?.durationMs).toBeGreaterThanOrEqual(0);
     expect(finished?.error).toBe('LLM validation failed');
     expect(state.records[0]?.id).toBe(run.id);
-    expect(runHistoryService.find(run.id)?.args).toEqual(['scout', '--local']);
+    expect(runHistoryService.find(run.id)?.args).toEqual(['scout', '--refresh']);
   });
 
   test('run history service returns undefined for unknown runs', () => {


### PR DESCRIPTION
## Summary
- remove the `openmeta scout --local` CLI option and the machine `scout --local` variant
- delete the `localOnly` orchestration and ranking paths so scout always validates GitHub and LLM access
- update README, machine interface docs, skills metadata, and tests to match the removed option

## Validation
- `bun build --target=bun --outfile=bin/openmeta.js ./src/cli.ts`
- `bun run typecheck`
- `bun test test/issue-ranking.test.ts test/machine-agent.test.ts test/machine-commands.test.ts test/agent-orchestrator.test.ts test/state-services.test.ts`