### PR TITLE
feat(config): add export and import subcommands (#67)

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { resolve } from 'path';
 import { configOrchestrator } from '../orchestration/index.js';
 import { runCommand } from './run-command.js';
 
@@ -19,6 +20,24 @@ export function registerConfigCommand(program: Command): void {
     .command('scoring')
     .description('Configure scoring weights interactively with presets or custom values')
     .action(() => runCommand('OpenMeta Scoring', () => configOrchestrator.scoring()));
+
+  config
+    .command('export')
+    .description('Export configuration to a portable JSON file (secrets redacted by default)')
+    .option('-o, --output <path>', 'Output file path', 'openmeta-config.json')
+    .option('--include-secrets', 'Include sensitive credentials in plaintext')
+    .action((opts: { output: string; includeSecrets?: boolean }) =>
+      runCommand('OpenMeta Config', () =>
+        configOrchestrator.exportConfig(resolve(opts.output), { includeSecrets: opts.includeSecrets }),
+      ),
+    );
+
+  config
+    .command('import <path>')
+    .description('Import configuration from a previously exported JSON file')
+    .action((inputPath: string) =>
+      runCommand('OpenMeta Config', () => configOrchestrator.importConfig(resolve(inputPath))),
+    );
 
   config
     .command('reset')

--- a/src/orchestration/config.ts
+++ b/src/orchestration/config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { configService, parseLLMReasoningEffort, prompt, selectPrompt, ui } from '../infra/index.js';
 import {
   getPreset,
@@ -152,7 +153,11 @@ export class ConfigOrchestrator {
         tone: config.github.username ? 'info' : 'warning',
       },
       { label: 'PAT', value: ui.maskSecret(config.github.pat), tone: config.github.pat ? 'info' : 'warning' },
-      { label: 'Artifact repo', value: config.github.targetRepoPath || 'Auto-managed private repository', tone: 'info' },
+      {
+        label: 'Artifact repo',
+        value: config.github.targetRepoPath || 'Auto-managed private repository',
+        tone: 'info',
+      },
     ]);
 
     ui.keyValues('Repository targeting', [
@@ -437,6 +442,152 @@ export class ConfigOrchestrator {
         tone: 'info',
       });
     }
+  }
+
+  async exportConfig(outputPath: string, options: { includeSecrets?: boolean } = {}): Promise<void> {
+    const config = await configService.get();
+
+    const exported: Record<string, unknown> = {
+      userProfile: config.userProfile,
+      github: {
+        username: config.github.username,
+        pat: options.includeSecrets ? config.github.pat : '<REDACTED>',
+        targetRepoPath: config.github.targetRepoPath,
+      },
+      repositoryTargeting: config.repositoryTargeting,
+      llm: {
+        provider: config.llm.provider,
+        apiBaseUrl: config.llm.apiBaseUrl,
+        apiKey: options.includeSecrets ? config.llm.apiKey : '<REDACTED>',
+        modelName: config.llm.modelName,
+        apiHeaders: config.llm.apiHeaders ?? {},
+        reasoningEffort: config.llm.reasoningEffort,
+        stream: config.llm.stream,
+        activeProfile: config.llm.activeProfile,
+        profiles: options.includeSecrets ? config.llm.profiles : this.redactProfileSecrets(config.llm.profiles ?? {}),
+      },
+      automation: config.automation,
+      scoring: config.scoring,
+      commitTemplate: config.commitTemplate,
+    };
+
+    const content = JSON.stringify(exported, null, 2);
+    writeFileSync(outputPath, content, 'utf-8');
+
+    ui.card({
+      label: 'OpenMeta Config',
+      title: 'Configuration exported',
+      subtitle: options.includeSecrets
+        ? 'Secrets are included in plaintext. Keep this file safe.'
+        : 'Secrets have been redacted. Use --include-secrets to include credentials.',
+      lines: [`Output: ${outputPath}`],
+      tone: options.includeSecrets ? 'warning' : 'success',
+    });
+  }
+
+  async importConfig(inputPath: string): Promise<void> {
+    if (!existsSync(inputPath)) {
+      throw new Error(`File not found: ${inputPath}`);
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      const content = readFileSync(inputPath, 'utf-8');
+      parsed = JSON.parse(content) as Record<string, unknown>;
+    } catch (error) {
+      throw new Error(`Failed to parse config file: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    const current = await configService.get();
+    const partial: Record<string, unknown> = {};
+
+    if (parsed['userProfile'] && typeof parsed['userProfile'] === 'object') {
+      partial['userProfile'] = parsed['userProfile'];
+    }
+
+    if (parsed['github'] && typeof parsed['github'] === 'object') {
+      const gh = parsed['github'] as Record<string, unknown>;
+      partial['github'] = {
+        ...current.github,
+        ...(gh['username'] && gh['username'] !== '<REDACTED>' ? { username: gh['username'] } : {}),
+        ...(gh['pat'] && gh['pat'] !== '<REDACTED>' ? { pat: gh['pat'] } : {}),
+        ...(gh['targetRepoPath'] !== undefined ? { targetRepoPath: gh['targetRepoPath'] } : {}),
+      };
+    }
+
+    if (parsed['repositoryTargeting'] && typeof parsed['repositoryTargeting'] === 'object') {
+      partial['repositoryTargeting'] = parsed['repositoryTargeting'];
+    }
+
+    if (parsed['llm'] && typeof parsed['llm'] === 'object') {
+      const llm = parsed['llm'] as Record<string, unknown>;
+      partial['llm'] = {
+        ...current.llm,
+        ...(llm['provider'] !== undefined ? { provider: llm['provider'] } : {}),
+        ...(llm['apiBaseUrl'] !== undefined ? { apiBaseUrl: llm['apiBaseUrl'] } : {}),
+        ...(llm['apiKey'] && llm['apiKey'] !== '<REDACTED>' ? { apiKey: llm['apiKey'] } : {}),
+        ...(llm['modelName'] !== undefined ? { modelName: llm['modelName'] } : {}),
+        ...(llm['apiHeaders'] !== undefined ? { apiHeaders: llm['apiHeaders'] } : {}),
+        ...(llm['reasoningEffort'] !== undefined ? { reasoningEffort: llm['reasoningEffort'] } : {}),
+        ...(llm['stream'] !== undefined ? { stream: llm['stream'] } : {}),
+        ...(llm['activeProfile'] !== undefined ? { activeProfile: llm['activeProfile'] } : {}),
+        ...(llm['profiles'] !== undefined
+          ? {
+              profiles: this.restoreProfileSecrets(
+                llm['profiles'] as Record<string, unknown>,
+                current.llm.profiles ?? {},
+              ),
+            }
+          : {}),
+      };
+    }
+
+    if (parsed['automation'] && typeof parsed['automation'] === 'object') {
+      partial['automation'] = parsed['automation'];
+    }
+
+    if (parsed['scoring'] && typeof parsed['scoring'] === 'object') {
+      partial['scoring'] = parsed['scoring'];
+    }
+
+    if (parsed['commitTemplate'] && typeof parsed['commitTemplate'] === 'string') {
+      partial['commitTemplate'] = parsed['commitTemplate'];
+    }
+
+    await configService.update(partial as Partial<typeof current>);
+
+    ui.card({
+      label: 'OpenMeta Config',
+      title: 'Configuration imported',
+      subtitle:
+        'Settings have been merged into the local configuration. Redacted secrets were preserved from the existing config.',
+      lines: [`Source: ${inputPath}`, `Config: ${configService.getConfigPath()}`],
+      tone: 'success',
+    });
+  }
+
+  private redactProfileSecrets(
+    profiles: Record<string, { apiKey?: string; [key: string]: unknown }>,
+  ): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(profiles).map(([name, profile]) => [name, { ...profile, apiKey: '<REDACTED>' }]),
+    );
+  }
+
+  private restoreProfileSecrets(
+    imported: Record<string, unknown>,
+    existing: Record<string, { apiKey?: string; [key: string]: unknown }>,
+  ): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(imported).map(([name, profile]) => {
+        const p = profile as Record<string, unknown>;
+        const existingProfile = existing[name];
+        if (p['apiKey'] === '<REDACTED>' && existingProfile?.apiKey) {
+          return [name, { ...p, apiKey: existingProfile.apiKey }];
+        }
+        return [name, p];
+      }),
+    );
   }
 
   async reset(): Promise<void> {

--- a/test/config-orchestrator.test.ts
+++ b/test/config-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ConfigService, configService } from '../src/infra/config.js';
@@ -133,13 +133,114 @@ describe('ConfigOrchestrator', () => {
     expect(heroSpy).toHaveBeenCalled();
     expect(statsSpy).toHaveBeenCalled();
     expect(cardSpy).toHaveBeenCalled();
-    expect(keyValuesSpy).toHaveBeenCalledWith('GitHub', expect.arrayContaining([
-      expect.objectContaining({ label: 'Artifact repo', value: '/tmp/private-artifacts' }),
-    ]));
+    expect(keyValuesSpy).toHaveBeenCalledWith(
+      'GitHub',
+      expect.arrayContaining([expect.objectContaining({ label: 'Artifact repo', value: '/tmp/private-artifacts' })]),
+    );
     expect(keyValuesSpy).toHaveBeenCalledWith('Repository targeting', [
       { label: 'Active preset', value: 'frontend', tone: 'success' },
       { label: 'Saved presets', value: '2', tone: 'info' },
       { label: 'Active repos', value: 'vercel/next.js, facebook/react', tone: 'info' },
     ]);
+  });
+
+  test('exports config with secrets redacted by default', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('github.pat', 'ghp_export_secret');
+    await orchestrator.set('llm.apiKey', 'sk-export-secret');
+    await orchestrator.set('github.username', 'testuser');
+
+    const exportPath = join(tempRoot, 'exported.json');
+    const cardSpy = spyOn(infra.ui, 'card').mockImplementation(() => {});
+
+    await orchestrator.exportConfig(exportPath);
+
+    expect(existsSync(exportPath)).toBe(true);
+    const content = JSON.parse(readFileSync(exportPath, 'utf-8'));
+    expect(content.github.pat).toBe('<REDACTED>');
+    expect(content.llm.apiKey).toBe('<REDACTED>');
+    expect(content.github.username).toBe('testuser');
+    expect(content.userProfile).toBeDefined();
+    expect(content.scoring).toBeDefined();
+    expect(cardSpy).toHaveBeenCalled();
+  });
+
+  test('exports config with secrets included when flag is set', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('github.pat', 'ghp_include_secret');
+    await orchestrator.set('llm.apiKey', 'sk-include-secret');
+
+    const exportPath = join(tempRoot, 'exported-secrets.json');
+    spyOn(infra.ui, 'card').mockImplementation(() => {});
+
+    await orchestrator.exportConfig(exportPath, { includeSecrets: true });
+
+    const content = JSON.parse(readFileSync(exportPath, 'utf-8'));
+    expect(content.github.pat).toBe('ghp_include_secret');
+    expect(content.llm.apiKey).toBe('sk-include-secret');
+  });
+
+  test('imports config and merges non-redacted fields', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('github.pat', 'ghp_original');
+    await orchestrator.set('llm.apiKey', 'sk-original');
+
+    const exportPath = join(tempRoot, 'to-import.json');
+    spyOn(infra.ui, 'card').mockImplementation(() => {});
+
+    await orchestrator.exportConfig(exportPath);
+
+    clearSharedConfigCache();
+    await configService.load();
+
+    await orchestrator.importConfig(exportPath);
+
+    const loaded = await configService.get();
+    expect(loaded.github.pat).toBe('ghp_original');
+    expect(loaded.llm.apiKey).toBe('sk-original');
+  });
+
+  test('import preserves existing secrets when file has redacted values', async () => {
+    const orchestrator = new ConfigOrchestrator();
+
+    await orchestrator.set('github.pat', 'ghp_keep_me');
+    await orchestrator.set('llm.apiKey', 'sk-keep-me');
+    await orchestrator.set('userProfile.techStack', 'rust,go');
+
+    const exportPath = join(tempRoot, 'redacted-import.json');
+    spyOn(infra.ui, 'card').mockImplementation(() => {});
+
+    await orchestrator.exportConfig(exportPath);
+
+    const exportedContent = JSON.parse(readFileSync(exportPath, 'utf-8'));
+    exportedContent.userProfile.techStack = ['typescript', 'python'];
+
+    const modifiedPath = join(tempRoot, 'modified-import.json');
+    const { writeFileSync } = await import('fs');
+    writeFileSync(modifiedPath, JSON.stringify(exportedContent, null, 2), 'utf-8');
+
+    await orchestrator.importConfig(modifiedPath);
+
+    const loaded = await configService.get();
+    expect(loaded.github.pat).toBe('ghp_keep_me');
+    expect(loaded.llm.apiKey).toBe('sk-keep-me');
+    expect(loaded.userProfile.techStack).toEqual(['typescript', 'python']);
+  });
+
+  test('import throws on non-existent file', async () => {
+    const orchestrator = new ConfigOrchestrator();
+    await expect(orchestrator.importConfig('/nonexistent/path.json')).rejects.toThrow('File not found');
+  });
+
+  test('import throws on invalid JSON', async () => {
+    const orchestrator = new ConfigOrchestrator();
+    const badPath = join(tempRoot, 'bad.json');
+    const { writeFileSync } = await import('fs');
+    writeFileSync(badPath, 'not valid json {{{', 'utf-8');
+
+    await expect(orchestrator.importConfig(badPath)).rejects.toThrow('Failed to parse config file');
   });
 });


### PR DESCRIPTION
## Summary

Implements `openmeta config export` and `openmeta config import` subcommands as proposed in #67. Enables portable configuration backup, restore, and migration between machines.

Closes #67

## Motivation

OpenMeta currently has no way to migrate configuration between machines. Users switching devices must rerun `openmeta init` and manually rebuild profile, scoring preferences, commit template, and repository targeting presets. This PR introduces a single-file portable format that solves backup, migration, and team-sharing scenarios in one shot.

## Changes

- `src/commands/config.ts` — Register `export` and `import` subcommands following the existing thin-command pattern
- `src/orchestration/config.ts` — Implement `exportConfig()` and `importConfig()` methods with secret redaction logic
- `test/config-orchestrator.test.ts` — Add 6 new test cases covering export, import, secret handling, and error paths

## Design Decisions

- **Secrets redacted by default** — `export` replaces `github.pat`, `llm.apiKey`, and per-profile `apiKey` with `<REDACTED>`. Use `--include-secrets` for full export with an explicit warning.
- **Import preserves existing secrets on `<REDACTED>`** — Imported `<REDACTED>` placeholders never overwrite local credentials, preventing accidental wipes when re-importing a sanitized backup.
- **Reuses `configService.update()`** — Goes through the existing normalize / encrypt pipeline rather than writing config directly, avoiding divergence.
- **JSON format mirrors `AppConfig`** — Output structure matches the runtime config shape, making files human-readable and editable.

## Usage

```bash
# Export with secrets redacted (default)
openmeta config export
openmeta config export -o ~/backup.json

# Export with secrets in plaintext (warned)
openmeta config export --include-secrets -o ~/full-backup.json

# Import (merges into current config)
openmeta config import ~/backup.json

## Test
Six new test cases added to test/config-orchestrator.test.ts:
Exports config with secrets redacted by default
Exports config with secrets included when flag is set
Imports config and merges non-redacted fields
Import preserves existing secrets when file has redacted values
Import throws on non-existent file
Import throws on invalid JSON

## Verification
- bun run check — passes (Biome formatting clean)
- bun run lint — passes (no new warnings introduced)
- bun test test/config-orchestrator.test.ts — passes (6 new tests + existing tests)

## Notes
- No breaking changes; pure additive feature
- Does not modify the existing reset .backup behavior
- Follows the project's three-layer separation: command → orchestration → service
---
