### PR TITLE
chore(format): apply biome to existing files

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,5 @@
 export { registerAgentCommand } from './agent.js';
 export { registerAnalyzeCommand } from './analyze.js';
-export { registerPresetCommand } from './preset.js';
 export { registerAutomationCommand } from './automation.js';
 export { registerConfigCommand } from './config.js';
 export { registerDailyCommand } from './daily.js';
@@ -9,6 +8,7 @@ export { registerInboxCommand } from './inbox.js';
 export { registerInitCommand } from './init.js';
 export { registerMachineCommand } from './machine.js';
 export { registerPowCommand } from './pow.js';
+export { registerPresetCommand } from './preset.js';
 export { registerProviderCommand } from './provider.js';
 export { registerRunsCommand } from './runs.js';
 export { registerScoutCommand } from './scout.js';

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -3,9 +3,7 @@ import { presetOrchestrator } from '../orchestration/index.js';
 import { runCommand } from './run-command.js';
 
 export function registerPresetCommand(program: Command): void {
-  const preset = program
-    .command('preset')
-    .description('Manage reusable repository target presets');
+  const preset = program.command('preset').description('Manage reusable repository target presets');
 
   preset
     .command('list')
@@ -16,12 +14,16 @@ export function registerPresetCommand(program: Command): void {
   preset
     .command('add <name>')
     .description('Add a repository preset from command-line values')
-    .requiredOption('--repo <repository>', 'GitHub repository URL or owner/name; repeat for multiple repos', (value, previous: string[] = []) => [...previous, value], [])
+    .requiredOption(
+      '--repo <repository>',
+      'GitHub repository URL or owner/name; repeat for multiple repos',
+      (value, previous: string[] = []) => [...previous, value],
+      [],
+    )
     .option('--activate', 'Mark this preset as the active default target set')
-    .action((name: string, options: { repo: string[]; activate?: boolean }) => runCommand(
-      'OpenMeta Preset',
-      () => presetOrchestrator.add(name, options),
-    ));
+    .action((name: string, options: { repo: string[]; activate?: boolean }) =>
+      runCommand('OpenMeta Preset', () => presetOrchestrator.add(name, options)),
+    );
 
   preset
     .command('use <name>')

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -11,13 +11,7 @@ export function registerScoutCommand(program: Command): void {
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
     .option('--preset <name>', 'Use one saved repository preset as the discovery scope')
     .option('--all-repos', 'Ignore the active repository preset and search the broader issue stream')
-    .action((options: {
-      limit?: string;
-      refresh?: boolean;
-      repo?: string;
-      preset?: string;
-      allRepos?: boolean;
-    }) =>
+    .action((options: { limit?: string; refresh?: boolean; repo?: string; preset?: string; allRepos?: boolean }) =>
       runCommand('OpenMeta Scout', () =>
         agentOrchestrator.scout({
           limit: Number.parseInt(options.limit || '10', 10) || 10,

--- a/src/infra/config.ts
+++ b/src/infra/config.ts
@@ -296,14 +296,14 @@ export class ConfigService {
   private normalizeRepositoryPresets(
     presets: AppConfig['repositoryTargeting']['presets'] = {},
   ): AppConfig['repositoryTargeting']['presets'] {
-    return Object.fromEntries(Object.entries(presets).map(([name, preset]) => [
-      name,
-      {
-        repos: Array.isArray(preset?.repos)
-          ? preset.repos.map((repo) => String(repo).trim()).filter(Boolean)
-          : [],
-      },
-    ]));
+    return Object.fromEntries(
+      Object.entries(presets).map(([name, preset]) => [
+        name,
+        {
+          repos: Array.isArray(preset?.repos) ? preset.repos.map((repo) => String(repo).trim()).filter(Boolean) : [],
+        },
+      ]),
+    );
   }
 }
 

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -282,7 +282,8 @@ export class AgentOrchestrator {
       );
     }
 
-    const presetIssueFlowAllowed = !issueTarget &&
+    const presetIssueFlowAllowed =
+      !issueTarget &&
       scope?.mode === 'preset' &&
       (rankedIssues[0]?.opportunity.overallScore || 0) >= config.automation.minMatchScore;
     const presetQualifiedIssue = presetIssueFlowAllowed
@@ -841,8 +842,8 @@ export class AgentOrchestrator {
           : scope?.mode === 'preset'
             ? `Issue discovery is limited to preset ${scope.presetName} (${scope.repos.length} repositories).`
             : repoFullName
-            ? `Issue discovery is limited to ${repoFullName}.`
-            : 'Issue discovery will scan the broader GitHub issue stream.',
+              ? `Issue discovery is limited to ${repoFullName}.`
+              : 'Issue discovery will scan the broader GitHub issue stream.',
         repoPath
           ? `Local repository reuse is enabled via ${repoPath}. OpenMeta will create an isolated worktree and a fresh branch before opening a PR.`
           : 'If the repository already exists locally, pass --repo-path <local-path> so OpenMeta can reuse it via an isolated worktree and open the PR from a fresh branch.',
@@ -912,7 +913,8 @@ export class AgentOrchestrator {
       const displayIssues = issueRankingService.diversifyScoutIssues(rankedIssues, 5);
       this.renderOpportunityList('Top ranked opportunities', displayIssues);
     }
-    const presetIssueFlowAllowed = !issueTarget &&
+    const presetIssueFlowAllowed =
+      !issueTarget &&
       scope?.mode === 'preset' &&
       (rankedIssues[0]?.opportunity.overallScore || 0) >= config.automation.minMatchScore;
     const presetQualifiedIssue = presetIssueFlowAllowed
@@ -1221,7 +1223,8 @@ export class AgentOrchestrator {
     ui.hero({
       label: 'OpenMeta Scout',
       title: 'Read the field before you spend your focus',
-      subtitle: 'OpenMeta turns a noisy issue stream into a shortlist shaped by technical fit, timing, and real opening momentum.',
+      subtitle:
+        'OpenMeta turns a noisy issue stream into a shortlist shaped by technical fit, timing, and real opening momentum.',
       lines: [
         `Saved threshold reference: ${config.automation.minMatchScore}/100.`,
         refresh
@@ -1326,9 +1329,7 @@ export class AgentOrchestrator {
       },
     );
     const emptyExplanation =
-      rankedIssues.length === 0
-        ? this.buildScoutEmptyExplanation(config, { repoFullName, refresh })
-        : undefined;
+      rankedIssues.length === 0 ? this.buildScoutEmptyExplanation(config, { repoFullName, refresh }) : undefined;
 
     return {
       opportunities: issueRankingService.diversifyScoutIssues(rankedIssues, limit),
@@ -1887,10 +1888,7 @@ export class AgentOrchestrator {
       label: 'OpenMeta Agent',
       title: 'Preset issue scout did not clear the automation threshold',
       subtitle: 'OpenMeta will switch from issue-first scouting to repository analysis across the active preset.',
-      lines: [
-        `Repositories: ${input.repos.join(', ')}`,
-        `Threshold: ${input.config.automation.minMatchScore}/100`,
-      ],
+      lines: [`Repositories: ${input.repos.join(', ')}`, `Threshold: ${input.config.automation.minMatchScore}/100`],
       tone: 'info',
     });
 
@@ -1911,7 +1909,11 @@ export class AgentOrchestrator {
     completedStages.add('prepare');
     this.showWorkspaceSummary(selectedCandidate.workspace, memory);
 
-    this.renderAgentStage('draft', completedStages, 'Drafting patch strategy and turning it into concrete file changes.');
+    this.renderAgentStage(
+      'draft',
+      completedStages,
+      'Drafting patch strategy and turning it into concrete file changes.',
+    );
     const patchDraftResult = await ui.task(
       {
         title: 'Generating patch strategy',
@@ -1951,7 +1953,11 @@ export class AgentOrchestrator {
       testResults: implementation.validationResults,
     };
 
-    this.renderAgentStage('validate', completedStages, 'Reviewing validation outcomes before opening or publishing anything.');
+    this.renderAgentStage(
+      'validate',
+      completedStages,
+      'Reviewing validation outcomes before opening or publishing anything.',
+    );
     this.showValidationSummary(workspaceForArtifacts, implementation.changedFiles);
     completedStages.add('validate');
 
@@ -2020,16 +2026,29 @@ export class AgentOrchestrator {
       pullRequestNumber: contributionPullRequest.number,
     };
 
-    const dossier = contentService.formatContributionDossier(selectedIssue, workspaceForArtifacts, memory, patchDraft, prDraft);
-    const proofMarkdown = proofOfWorkService.renderMarkdown([
-      proofRecord,
-      ...proofOfWorkService.load().records,
-    ].slice(0, 100));
+    const dossier = contentService.formatContributionDossier(
+      selectedIssue,
+      workspaceForArtifacts,
+      memory,
+      patchDraft,
+      prDraft,
+    );
+    const proofMarkdown = proofOfWorkService.renderMarkdown(
+      [proofRecord, ...proofOfWorkService.load().records].slice(0, 100),
+    );
 
-    this.renderAgentStage('publish', completedStages, 'Saving dossier assets, updating long-term memory, and deciding whether to publish them.');
+    this.renderAgentStage(
+      'publish',
+      completedStages,
+      'Saving dossier assets, updating long-term memory, and deciding whether to publish them.',
+    );
     this.showArtifactPreview({
       issue: selectedIssue,
-      artifactRelativeDir: join('contributions', getLocalDateStamp(), `${selectedIssue.repoFullName.replace(/\//g, '__')}__${selectedIssue.number}`),
+      artifactRelativeDir: join(
+        'contributions',
+        getLocalDateStamp(),
+        `${selectedIssue.repoFullName.replace(/\//g, '__')}__${selectedIssue.number}`,
+      ),
       draftTitle: prDraft.title,
       changedFiles: implementation.changedFiles,
       validationResults: implementation.validationResults,
@@ -2173,10 +2192,7 @@ export class AgentOrchestrator {
       candidates.slice(0, 5).map((candidate) => ({
         title: `${candidate.repoFullName} - ${candidate.suggestion.title}`,
         subtitle: candidate.suggestion.summary,
-        meta: [
-          `score ${candidate.suggestion.prPotentialScore}`,
-          `workload ${candidate.suggestion.estimatedWorkload}`,
-        ],
+        meta: [`score ${candidate.suggestion.prPotentialScore}`, `workload ${candidate.suggestion.estimatedWorkload}`],
         lines: [`Files: ${candidate.suggestion.targetFiles.map((file) => file.path).join(', ')}`],
         tone: candidate.suggestion.prPotentialScore >= 80 ? 'success' : 'info',
       })),

--- a/src/orchestration/analyze.ts
+++ b/src/orchestration/analyze.ts
@@ -92,27 +92,31 @@ export class AnalyzeOrchestrator {
     this.showLocalRepositoryHint(repoPath);
 
     const totalSteps = 7;
-    const groups = scope.mode === 'single'
-      ? [
-          await this.collectSingleAnalysisGroup(scope.repo!, {
+    const groups =
+      scope.mode === 'single'
+        ? [
+            await this.collectSingleAnalysisGroup(scope.repo!, {
+              headless,
+              runChecks,
+              repoPath,
+              totalSteps,
+            }),
+          ]
+        : await this.collectAnalysisGroups(scope.repos, {
             headless,
             runChecks,
-            repoPath,
             totalSteps,
-          }),
-        ]
-      : await this.collectAnalysisGroups(scope.repos, {
-          headless,
-          runChecks,
-          totalSteps,
-        });
+          });
     const candidates = groups.flatMap((group) =>
-      group.suggestions.map((suggestion) => ({
-        repoFullName: group.repoFullName,
-        workspace: group.workspace,
-        memory: group.memory,
-        suggestion,
-      }) satisfies PresetAnalyzeCandidate),
+      group.suggestions.map(
+        (suggestion) =>
+          ({
+            repoFullName: group.repoFullName,
+            workspace: group.workspace,
+            memory: group.memory,
+            suggestion,
+          }) satisfies PresetAnalyzeCandidate,
+      ),
     );
     const selectedCandidate = headless
       ? this.selectTopCandidate(candidates)
@@ -121,7 +125,9 @@ export class AnalyzeOrchestrator {
     const workspace = selectedCandidate.workspace;
     const memory = selectedCandidate.memory;
     const selectedSuggestion = selectedCandidate.suggestion;
-    const suggestions = groups.find((group) => group.repoFullName === repoFullName)?.suggestions || [selectedSuggestion];
+    const suggestions = groups.find((group) => group.repoFullName === repoFullName)?.suggestions || [
+      selectedSuggestion,
+    ];
     const syntheticIssue = this.buildSyntheticIssue(repoFullName, selectedSuggestion);
 
     await ui.task(
@@ -214,11 +220,12 @@ export class AnalyzeOrchestrator {
       preset: options.preset,
       allowGlobal: false,
     });
-    const scopeLabel = scope.mode === 'single'
-      ? scope.repo!
-      : scope.presetName
-        ? `preset ${scope.presetName}`
-        : `${scope.repos.length} repositories`;
+    const scopeLabel =
+      scope.mode === 'single'
+        ? scope.repo!
+        : scope.presetName
+          ? `preset ${scope.presetName}`
+          : `${scope.repos.length} repositories`;
 
     ui.hero({
       label: 'OpenMeta Analyze',

--- a/src/orchestration/init.ts
+++ b/src/orchestration/init.ts
@@ -8,11 +8,11 @@ import {
   ui,
 } from '../infra/index.js';
 import {
-  repositoryTargetingService,
   findLLMProviderPreset,
   githubService,
   LLM_PROVIDER_PRESETS,
   llmService,
+  repositoryTargetingService,
   type SchedulerSyncResult,
   schedulerService,
 } from '../services/index.js';
@@ -417,7 +417,11 @@ export class InitOrchestrator {
       () => {
         ui.keyValues('Repository presets', [
           { label: 'Active preset', value: repositoryTargeting.activePreset, tone: 'success' },
-          { label: 'Saved presets', value: String(Object.keys(repositoryTargeting.presets || {}).length), tone: 'info' },
+          {
+            label: 'Saved presets',
+            value: String(Object.keys(repositoryTargeting.presets || {}).length),
+            tone: 'info',
+          },
           {
             label: 'Active repos',
             value: repositoryTargetingService.getActiveRepos({ ...workingConfig, repositoryTargeting }).join(', '),
@@ -519,11 +523,16 @@ export class InitOrchestrator {
             value: repositoryTargeting.activePreset || '(none)',
             tone: repositoryTargeting.activePreset ? 'success' : 'muted',
           },
-          { label: 'Saved presets', value: String(Object.keys(repositoryTargeting.presets || {}).length), tone: 'info' },
+          {
+            label: 'Saved presets',
+            value: String(Object.keys(repositoryTargeting.presets || {}).length),
+            tone: 'info',
+          },
           {
             label: 'Active repos',
             value:
-              repositoryTargetingService.getActiveRepos({ ...workingConfig, repositoryTargeting }).join(', ') || '(none)',
+              repositoryTargetingService.getActiveRepos({ ...workingConfig, repositoryTargeting }).join(', ') ||
+              '(none)',
             tone: 'info',
           },
         ]);

--- a/src/orchestration/preset.ts
+++ b/src/orchestration/preset.ts
@@ -16,9 +16,7 @@ export class PresetOrchestrator {
       label: 'OpenMeta Preset',
       title: names.length > 0 ? 'Saved repository presets are ready to reuse' : 'No repository presets saved yet',
       subtitle: 'Repository presets let you reuse fixed exploration targets across scout, analyze, and agent runs.',
-      lines: [
-        `Active preset: ${config.repositoryTargeting.activePreset || '(none)'}`,
-      ],
+      lines: [`Active preset: ${config.repositoryTargeting.activePreset || '(none)'}`],
       tone: names.length > 0 ? 'accent' : 'warning',
     });
 
@@ -31,15 +29,16 @@ export class PresetOrchestrator {
       return;
     }
 
-    ui.recordList('Repository presets', names.map((name) => ({
-      title: name,
-      subtitle: `${presets[name]?.repos.length || 0} repository target(s)`,
-      meta: [
-        config.repositoryTargeting.activePreset === name ? 'active' : 'saved',
-      ],
-      lines: (presets[name]?.repos || []).map((repo) => `- ${repo}`),
-      tone: config.repositoryTargeting.activePreset === name ? 'success' : 'info',
-    })));
+    ui.recordList(
+      'Repository presets',
+      names.map((name) => ({
+        title: name,
+        subtitle: `${presets[name]?.repos.length || 0} repository target(s)`,
+        meta: [config.repositoryTargeting.activePreset === name ? 'active' : 'saved'],
+        lines: (presets[name]?.repos || []).map((repo) => `- ${repo}`),
+        tone: config.repositoryTargeting.activePreset === name ? 'success' : 'info',
+      })),
+    );
   }
 
   async add(nameInput: string, options: PresetAddOptions): Promise<void> {
@@ -60,7 +59,9 @@ export class PresetOrchestrator {
     ui.card({
       label: 'OpenMeta Preset',
       title: 'Repository preset saved',
-      subtitle: options.activate ? 'This preset is now the active exploration target set.' : 'Switch to it later with "openmeta preset use <name>".',
+      subtitle: options.activate
+        ? 'This preset is now the active exploration target set.'
+        : 'Switch to it later with "openmeta preset use <name>".',
       lines: [
         `Preset: ${name}`,
         `Repositories: ${repos.join(', ')}`,
@@ -89,10 +90,7 @@ export class PresetOrchestrator {
       label: 'OpenMeta Preset',
       title: 'Active repository preset switched',
       subtitle: 'OpenMeta will use this preset by default unless a command overrides the target scope.',
-      lines: [
-        `Preset: ${name}`,
-        `Repositories: ${preset.repos.join(', ')}`,
-      ],
+      lines: [`Preset: ${name}`, `Repositories: ${preset.repos.join(', ')}`],
       tone: 'success',
     });
   }
@@ -106,7 +104,8 @@ export class PresetOrchestrator {
     }
 
     delete presets[name];
-    const activePreset = config.repositoryTargeting.activePreset === name ? '' : config.repositoryTargeting.activePreset;
+    const activePreset =
+      config.repositoryTargeting.activePreset === name ? '' : config.repositoryTargeting.activePreset;
     await configService.update({
       repositoryTargeting: {
         activePreset,
@@ -117,11 +116,10 @@ export class PresetOrchestrator {
     ui.card({
       label: 'OpenMeta Preset',
       title: 'Repository preset removed',
-      subtitle: activePreset ? 'The active preset remained unchanged.' : 'The removed preset was active, so no preset is now marked active.',
-      lines: [
-        `Preset: ${name}`,
-        `Active preset: ${activePreset || '(none)'}`,
-      ],
+      subtitle: activePreset
+        ? 'The active preset remained unchanged.'
+        : 'The removed preset was active, so no preset is now marked active.',
+      lines: [`Preset: ${name}`, `Active preset: ${activePreset || '(none)'}`],
       tone: 'success',
     });
   }

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -170,10 +170,7 @@ export class ContentService {
         '## Repository Groups',
         '',
         ...groups.flatMap((group) => {
-          const groupLines = [
-            `### ${group.repoFullName}`,
-            '',
-          ];
+          const groupLines = [`### ${group.repoFullName}`, ''];
 
           if (selectedSuggestion && group.repoFullName === repoFullName) {
             groupLines.push('Selected across all preset repositories', '');
@@ -184,14 +181,16 @@ export class ContentService {
             return groupLines;
           }
 
-          groupLines.push(...group.suggestions.flatMap((suggestion) => ([
-            `#### ${suggestion.title}`,
-            '',
-            `ID: ${suggestion.id}`,
-            `PR Potential: ${suggestion.prPotentialScore}/100`,
-            `Target Files: ${suggestion.targetFiles.map((file) => file.path).join(', ') || 'n/a'}`,
-            '',
-          ])));
+          groupLines.push(
+            ...group.suggestions.flatMap((suggestion) => [
+              `#### ${suggestion.title}`,
+              '',
+              `ID: ${suggestion.id}`,
+              `PR Potential: ${suggestion.prPotentialScore}/100`,
+              `Target Files: ${suggestion.targetFiles.map((file) => file.path).join(', ') || 'n/a'}`,
+              '',
+            ]),
+          );
 
           return groupLines;
         }),

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,8 +10,8 @@ export { MemoryService, memoryService } from './memory.js';
 export { OpportunityService, opportunityService } from './opportunity.js';
 export { ProofOfWorkService, proofOfWorkService } from './proof-of-work.js';
 export {
-  type ResolvedRepositoryScope,
   RepositoryTargetingService,
+  type ResolvedRepositoryScope,
   repositoryTargetingService,
 } from './repository-targeting.js';
 export { RunHistoryService, runHistoryService } from './run-history.js';

--- a/src/services/repository-targeting.ts
+++ b/src/services/repository-targeting.ts
@@ -12,7 +12,9 @@ export class RepositoryTargetingService {
   normalizePresetName(nameInput: string): string {
     const name = nameInput.trim();
     if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
-      throw new Error('Repository preset name must start with a letter or number and may contain letters, numbers, dots, underscores, or dashes.');
+      throw new Error(
+        'Repository preset name must start with a letter or number and may contain letters, numbers, dots, underscores, or dashes.',
+      );
     }
 
     return name;
@@ -103,7 +105,12 @@ export class RepositoryTargetingService {
     };
   }
 
-  validateConfig(config: AppConfig): { status: 'pass' | 'warn' | 'fail'; summary: string; detail?: string; remediation?: string } {
+  validateConfig(config: AppConfig): {
+    status: 'pass' | 'warn' | 'fail';
+    summary: string;
+    detail?: string;
+    remediation?: string;
+  } {
     const targeting = config.repositoryTargeting ?? { activePreset: '', presets: {} };
     const presets = targeting.presets || {};
     const names = Object.keys(presets);

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -960,16 +960,10 @@ describe('AnalyzeOrchestrator run flow', () => {
       demoWorkspace,
       demoMemory,
     );
-    expect(analysisMarkdownSpy).toHaveBeenCalledWith(
-      'acme/demo',
-      demoWorkspace,
-      [demoSuggestion],
-      demoSuggestion,
-      [
-        { repoFullName: 'acme/demo', suggestions: [demoSuggestion] },
-        { repoFullName: 'acme/docs', suggestions: [docsSuggestion] },
-      ],
-    );
+    expect(analysisMarkdownSpy).toHaveBeenCalledWith('acme/demo', demoWorkspace, [demoSuggestion], demoSuggestion, [
+      { repoFullName: 'acme/demo', suggestions: [demoSuggestion] },
+      { repoFullName: 'acme/docs', suggestions: [docsSuggestion] },
+    ]);
     expect(writeArtifactsSpy).toHaveBeenCalledWith({
       artifacts,
       analysisMarkdown: '# Repository Analysis',

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -161,28 +161,32 @@ describe('DoctorOrchestrator', () => {
   test('warns when presets exist without an active preset and fails on invalid active preset references', async () => {
     const doctor = new DoctorOrchestrator();
 
-    const warned = await doctor.inspect(createConfig({
-      repositoryTargeting: {
-        activePreset: '',
-        presets: {
-          frontend: {
-            repos: ['vercel/next.js'],
+    const warned = await doctor.inspect(
+      createConfig({
+        repositoryTargeting: {
+          activePreset: '',
+          presets: {
+            frontend: {
+              repos: ['vercel/next.js'],
+            },
           },
         },
-      },
-    }));
+      }),
+    );
     expect(warned.checks.find((check) => check.id === 'repository-targeting')?.status).toBe('warn');
 
-    const failed = await doctor.inspect(createConfig({
-      repositoryTargeting: {
-        activePreset: 'missing',
-        presets: {
-          frontend: {
-            repos: ['vercel/next.js'],
+    const failed = await doctor.inspect(
+      createConfig({
+        repositoryTargeting: {
+          activePreset: 'missing',
+          presets: {
+            frontend: {
+              repos: ['vercel/next.js'],
+            },
           },
         },
-      },
-    }));
+      }),
+    );
     expect(failed.checks.find((check) => check.id === 'repository-targeting')?.status).toBe('fail');
   });
 });

--- a/test/init-orchestrator.test.ts
+++ b/test/init-orchestrator.test.ts
@@ -103,9 +103,7 @@ describe('InitOrchestrator LLM reasoning setup', () => {
     spyOn(infra.ui, 'stats').mockImplementation(() => {});
     spyOn(infra.ui, 'callout').mockImplementation(() => {});
     spyOn(infra.ui, 'task').mockImplementation(async (_options, task) => task({ setMessage() {} } as never));
-    spyOn(infra, 'selectPrompt')
-      .mockResolvedValueOnce('beginner')
-      .mockResolvedValueOnce('research_note');
+    spyOn(infra, 'selectPrompt').mockResolvedValueOnce('beginner').mockResolvedValueOnce('research_note');
     const promptSpy = spyOn(infra, 'prompt')
       .mockResolvedValueOnce({ techStack: ['TypeScript'] })
       .mockResolvedValueOnce({ focusAreas: ['open-source'] })
@@ -117,21 +115,25 @@ describe('InitOrchestrator LLM reasoning setup', () => {
       .mockResolvedValueOnce({ automationEnabled: false });
     await orchestrator.execute();
 
-    expect(promptSpy).toHaveBeenCalledWith(expect.arrayContaining([
+    expect(promptSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'createPreset',
+          message: 'Create a reusable repository preset now?',
+        }),
+      ]),
+    );
+    expect(saveSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: 'createPreset',
-        message: 'Create a reusable repository preset now?',
-      }),
-    ]));
-    expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({
-      repositoryTargeting: {
-        activePreset: 'default',
-        presets: {
-          default: {
-            repos: ['vercel/next.js', 'facebook/react'],
+        repositoryTargeting: {
+          activePreset: 'default',
+          presets: {
+            default: {
+              repos: ['vercel/next.js', 'facebook/react'],
+            },
           },
         },
-      },
-    }));
+      }),
+    );
   });
 });

--- a/test/preset-orchestrator.test.ts
+++ b/test/preset-orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
 import { tmpdir } from 'os';
+import { join } from 'path';
 import { configService } from '../src/infra/config.js';
 import { PresetOrchestrator } from '../src/orchestration/preset.js';
 import type { AppConfig } from '../src/types/index.js';
@@ -35,17 +35,11 @@ describe('PresetOrchestrator', () => {
     const orchestrator = new PresetOrchestrator();
 
     await orchestrator.add('frontend-core', {
-      repo: [
-        'vercel/next.js',
-        'https://github.com/vercel/next.js',
-        'git@github.com:facebook/react.git',
-      ],
+      repo: ['vercel/next.js', 'https://github.com/vercel/next.js', 'git@github.com:facebook/react.git'],
       activate: true,
     });
     await orchestrator.add('tooling', {
-      repo: [
-        'oven-sh/bun',
-      ],
+      repo: ['oven-sh/bun'],
     });
     await orchestrator.use('tooling');
 
@@ -63,13 +57,17 @@ describe('PresetOrchestrator', () => {
   test('rejects invalid preset repositories and repo counts beyond the configured limit', async () => {
     const orchestrator = new PresetOrchestrator();
 
-    await expect(orchestrator.add('broken', {
-      repo: ['https://gitlab.com/acme/demo'],
-    })).rejects.toThrow('Repository must be a GitHub repository');
+    await expect(
+      orchestrator.add('broken', {
+        repo: ['https://gitlab.com/acme/demo'],
+      }),
+    ).rejects.toThrow('Repository must be a GitHub repository');
 
-    await expect(orchestrator.add('too-many', {
-      repo: Array.from({ length: 11 }, (_, index) => `acme/demo-${index}`),
-    })).rejects.toThrow('must contain between 1 and 10 repositories');
+    await expect(
+      orchestrator.add('too-many', {
+        repo: Array.from({ length: 11 }, (_, index) => `acme/demo-${index}`),
+      }),
+    ).rejects.toThrow('must contain between 1 and 10 repositories');
   });
 
   test('removes repository presets and clears the active preset when needed', async () => {

--- a/test/scout-targeting.test.ts
+++ b/test/scout-targeting.test.ts
@@ -70,9 +70,11 @@ beforeEach(() => {
   spyOn(infra.ui, 'stats').mockImplementation(() => {});
   spyOn(infra.ui, 'recordList').mockImplementation(() => {});
   spyOn(infra.ui, 'emptyState').mockImplementation(() => {});
-  spyOn(infra.ui, 'task').mockImplementation(async (_options, task) => task({
-    setMessage() {},
-  } as never));
+  spyOn(infra.ui, 'task').mockImplementation(async (_options, task) =>
+    task({
+      setMessage() {},
+    } as never),
+  );
 });
 
 afterEach(() => {
@@ -97,19 +99,35 @@ describe('AgentOrchestrator scout targeting', () => {
       .mockResolvedValueOnce([createRankedIssue({ repoFullName: 'facebook/react', number: 2 })]);
 
     spyOn(infra.configService, 'get').mockResolvedValue(config);
-    spyOn(orchestrator as unknown as { validateConfig(config: AppConfig, options?: { requireLlm?: boolean }): Promise<void> }, 'validateConfig')
-      .mockResolvedValue(undefined);
-    spyOn(orchestrator as unknown as { initializeClients(config: AppConfig, options?: { validateLlm?: boolean }): Promise<void> }, 'initializeClients')
-      .mockResolvedValue(undefined);
+    spyOn(
+      orchestrator as unknown as {
+        validateConfig(config: AppConfig, options?: { requireLlm?: boolean }): Promise<void>;
+      },
+      'validateConfig',
+    ).mockResolvedValue(undefined);
+    spyOn(
+      orchestrator as unknown as {
+        initializeClients(config: AppConfig, options?: { validateLlm?: boolean }): Promise<void>;
+      },
+      'initializeClients',
+    ).mockResolvedValue(undefined);
 
     await orchestrator.scout({ limit: 5 });
 
-    expect(loadRankedIssuesSpy).toHaveBeenNthCalledWith(1, config, expect.objectContaining({
-      repoFullName: 'vercel/next.js',
-    }));
-    expect(loadRankedIssuesSpy).toHaveBeenNthCalledWith(2, config, expect.objectContaining({
-      repoFullName: 'facebook/react',
-    }));
+    expect(loadRankedIssuesSpy).toHaveBeenNthCalledWith(
+      1,
+      config,
+      expect.objectContaining({
+        repoFullName: 'vercel/next.js',
+      }),
+    );
+    expect(loadRankedIssuesSpy).toHaveBeenNthCalledWith(
+      2,
+      config,
+      expect.objectContaining({
+        repoFullName: 'facebook/react',
+      }),
+    );
   });
 
   test('bypasses the active preset when scout runs with --all-repos', async () => {
@@ -124,20 +142,30 @@ describe('AgentOrchestrator scout targeting', () => {
         },
       },
     });
-    const loadRankedIssuesSpy = spyOn(issueRankingService, 'loadRankedIssues')
-      .mockResolvedValue([createRankedIssue()]);
+    const loadRankedIssuesSpy = spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([createRankedIssue()]);
 
     spyOn(infra.configService, 'get').mockResolvedValue(config);
-    spyOn(orchestrator as unknown as { validateConfig(config: AppConfig, options?: { requireLlm?: boolean }): Promise<void> }, 'validateConfig')
-      .mockResolvedValue(undefined);
-    spyOn(orchestrator as unknown as { initializeClients(config: AppConfig, options?: { validateLlm?: boolean }): Promise<void> }, 'initializeClients')
-      .mockResolvedValue(undefined);
+    spyOn(
+      orchestrator as unknown as {
+        validateConfig(config: AppConfig, options?: { requireLlm?: boolean }): Promise<void>;
+      },
+      'validateConfig',
+    ).mockResolvedValue(undefined);
+    spyOn(
+      orchestrator as unknown as {
+        initializeClients(config: AppConfig, options?: { validateLlm?: boolean }): Promise<void>;
+      },
+      'initializeClients',
+    ).mockResolvedValue(undefined);
 
     await orchestrator.scout({ allRepos: true, limit: 5 });
 
     expect(loadRankedIssuesSpy).toHaveBeenCalledTimes(1);
-    expect(loadRankedIssuesSpy).toHaveBeenCalledWith(config, expect.not.objectContaining({
-      repoFullName: 'vercel/next.js',
-    }));
+    expect(loadRankedIssuesSpy).toHaveBeenCalledWith(
+      config,
+      expect.not.objectContaining({
+        repoFullName: 'vercel/next.js',
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #68 as agreed in the PR thread. Runs `biome check --write` across the 16 source files that had pre-existing format / organize-imports drift, bringing CI back to 0 errors.

## Background

After #68 was merged, `bunx biome ci --linter-enabled=false src test index.ts package.json tsconfig.json` still reported 18 errors on `main`. None of these errors were introduced by #68 — they are pre-existing drift left over from the biome bump in #63 that never got a full reformat sweep. This PR closes that gap in one mechanical commit.

## Verification
$ bunx biome ci --linter-enabled=false src test index.ts package.json tsconfig.json
Checked 134 files in 169ms. No fixes applied.
(0 errors after this PR)

## Changes

Pure mechanical output of `biome check --write`. No logic changes. The diff is split across:

- 10 source files (`src/...`) — whitespace and import-order normalization
- 6 test files (`test/...`) — whitespace and import-order normalization

Spot-checked diffs:

- `src/commands/index.ts` — single import reordered alphabetically
- `src/services/index.ts` — `type` keyword position reordered alphabetically
- `src/commands/scout.ts` — multi-line type signature collapsed to one line under the 120 char width

## Notes

- Zero functional changes; safe to land independently
- Recommend a clean rebase / no-squash so the format-only commit stays isolated and easy to revert if needed