### PR TITLE
feat:add openmeta support for codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,29 @@ openmeta machine scout --limit 10
 openmeta machine analyze --repo owner/name --dry-run
 ```
 
+### 接入 Codex
+
+OpenMeta 也内置 Codex skill bundle，可以直接安装到 Codex 的个人技能目录。
+
+```bash
+# 1. 确保 openmeta 已安装并可执行
+openmeta --version
+
+# 2. 安装 OpenMeta 的 Codex skill
+openmeta skill install --host codex
+
+# 3. 检查接入状态
+openmeta skill doctor --host codex
+```
+
+默认安装路径：
+
+```text
+~/.agents/skills/openmeta/SKILL.md
+```
+
+如果 `doctor` 返回 `supported: true` 且 `skillFileExists: true`，说明 Codex 已能发现这套 OpenMeta skill。Codex 也支持仓库级 `.agents/skills`，但 `install` 命令默认写入个人目录，便于跨项目复用。
+
 ### 命令一览
 
 | 命令 | 说明 |
@@ -630,6 +653,29 @@ openmeta machine doctor
 openmeta machine scout --limit 10
 openmeta machine analyze --repo owner/name --dry-run
 ```
+
+### Connect Codex
+
+OpenMeta also ships with a Codex skill bundle that can be installed directly into Codex's personal skill directory.
+
+```bash
+# 1. Make sure openmeta is installed and on PATH
+openmeta --version
+
+# 2. Install the OpenMeta Codex skill bundle
+openmeta skill install --host codex
+
+# 3. Verify the integration
+openmeta skill doctor --host codex
+```
+
+Default install path:
+
+```text
+~/.agents/skills/openmeta/SKILL.md
+```
+
+If `doctor` reports `supported: true` and `skillFileExists: true`, Codex should be able to discover the OpenMeta skill bundle. Codex also supports repository-scoped `.agents/skills`, but `install` writes to the personal directory by default for reuse across projects.
 
 ### Command Surface
 

--- a/skills/core/openmeta.md
+++ b/skills/core/openmeta.md
@@ -30,6 +30,7 @@ OpenMeta is built for contribution-oriented open source work.
 ## Host Paths
 
 - Claude Code default install path: `~/.claude/skills/openmeta`
+- Codex default personal install path: `~/.agents/skills/openmeta`
 - OpenClaw default install path: `~/.openclaw/skills/openmeta`
 
 ## Non-Negotiable Rules

--- a/skills/examples/codex.md
+++ b/skills/examples/codex.md
@@ -1,0 +1,3 @@
+# Codex Example
+
+Run `openmeta skill export --host codex --output ./tmp`.

--- a/skills/templates/codex/skill.md
+++ b/skills/templates/codex/skill.md
@@ -1,0 +1,18 @@
+# Codex OpenMeta Skill
+
+Host: Codex
+
+Install target: `~/.agents/skills/openmeta`
+
+## Host Notes
+
+- Keep the generated file at `SKILL.md` inside the OpenMeta skill directory.
+- Re-run `openmeta skill install --host codex` after upgrading OpenMeta CLI.
+- Verify installation with `openmeta skill doctor --host codex`.
+- Codex also supports repository-scoped skills under `.agents/skills`, but this installer targets the personal skill directory.
+
+{{coreSkill}}
+
+## Capability Catalog
+
+{{capabilityCatalog}}

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -9,7 +9,7 @@ import {
 } from '../orchestration/skill/index.js';
 
 function parseHost(value: string): SkillHost {
-  if (value === 'claude-code' || value === 'openclaw') {
+  if (value === 'claude-code' || value === 'codex' || value === 'openclaw') {
     return value;
   }
 

--- a/src/orchestration/skill/catalog.ts
+++ b/src/orchestration/skill/catalog.ts
@@ -22,14 +22,14 @@ function resolveSkillsRoot(): string {
 
 const SKILLS_ROOT = resolveSkillsRoot();
 
-export type SkillHost = 'claude-code' | 'openclaw';
+export type SkillHost = 'claude-code' | 'codex' | 'openclaw';
 
 export function getSkillsRoot(): string {
   return SKILLS_ROOT;
 }
 
 export function getSupportedSkillHosts(): SkillHost[] {
-  return ['claude-code', 'openclaw'];
+  return ['claude-code', 'codex', 'openclaw'];
 }
 
 export function loadCoreSkill(): string {

--- a/src/orchestration/skill/installer.ts
+++ b/src/orchestration/skill/installer.ts
@@ -21,6 +21,10 @@ function resolveDefaultInstallPath(host: SkillHost, homeDir = homedir()): string
     return join(homeDir, '.claude', 'skills', 'openmeta');
   }
 
+  if (host === 'codex') {
+    return join(homeDir, '.agents', 'skills', 'openmeta');
+  }
+
   if (host === 'openclaw') {
     return join(homeDir, '.openclaw', 'skills', 'openmeta');
   }

--- a/src/orchestration/skill/renderer.ts
+++ b/src/orchestration/skill/renderer.ts
@@ -14,21 +14,25 @@ function renderSkillMarkdown(host: SkillHost): string {
     .replace('{{capabilityCatalog}}', loadCapabilityCatalog());
 }
 
-function addClaudeCodeFrontmatter(content: string): string {
+function addSkillFrontmatter(content: string): string {
   if (content.startsWith('---\n')) {
     return content;
   }
 
-  return `---\nname: openmeta\ndescription: Use when connecting Claude Code to OpenMeta, using openmeta-cli, running OpenMeta machine commands, installing or validating the OpenMeta skill bundle, scouting or analyzing contribution opportunities, or executing an OpenMeta workflow.\n---\n\n${content}`;
+  return `---\nname: openmeta\ndescription: Use when connecting an agent host to OpenMeta, using openmeta-cli, running OpenMeta machine commands, installing or validating the OpenMeta skill bundle, scouting or analyzing contribution opportunities, or executing an OpenMeta workflow.\n---\n\n${content}`;
+}
+
+function usesSkillFrontmatter(host: SkillHost): boolean {
+  return host === 'claude-code' || host === 'codex';
 }
 
 export function getInstalledSkillFileName(host: SkillHost): string {
-  return host === 'claude-code' ? 'SKILL.md' : 'skill.md';
+  return usesSkillFrontmatter(host) ? 'SKILL.md' : 'skill.md';
 }
 
 export function renderInstallSkillContent(host: SkillHost): string {
   const rendered = renderSkillMarkdown(host);
-  return host === 'claude-code' ? addClaudeCodeFrontmatter(rendered) : rendered;
+  return usesSkillFrontmatter(host) ? addSkillFrontmatter(rendered) : rendered;
 }
 
 export async function renderSkillBundle(host: SkillHost, outputDir: string): Promise<RenderedSkillBundle> {

--- a/test/skill-bundle.test.ts
+++ b/test/skill-bundle.test.ts
@@ -51,13 +51,15 @@ describe('skill bundle rendering', () => {
     }
   });
 
-  test('renders claude-code and openclaw bundles from one canonical spec', async () => {
-    expect(getSupportedSkillHosts()).toEqual(['claude-code', 'openclaw']);
+  test('renders claude-code, codex, and openclaw bundles from one canonical spec', async () => {
+    expect(getSupportedSkillHosts()).toEqual(['claude-code', 'codex', 'openclaw']);
 
     const claude = await renderSkillBundle('claude-code', tempRoot);
+    const codex = await renderSkillBundle('codex', tempRoot);
     const openclaw = await renderSkillBundle('openclaw', tempRoot);
 
     const claudeSkill = readFileSync(claude.files[0]!, 'utf-8');
+    const codexSkill = readFileSync(codex.files[0]!, 'utf-8');
     const openclawSkill = readFileSync(openclaw.files[0]!, 'utf-8');
 
     expect(claude.files[0]).toBe(join(tempRoot, 'claude-code', 'SKILL.md'));
@@ -70,6 +72,14 @@ describe('skill bundle rendering', () => {
     expect(claudeSkill).toContain('`executionOutcome`');
     expect(claudeSkill).toContain('"errorCodes"');
     expect(claudeSkill).toContain('openmeta machine agent');
+
+    expect(codex.files[0]).toBe(join(tempRoot, 'codex', 'SKILL.md'));
+    expect(codexSkill).toStartWith('---\nname: openmeta\n');
+    expect(codexSkill).toContain('Install target: `~/.agents/skills/openmeta`');
+    expect(codexSkill).toContain('personal skill directory');
+    expect(codexSkill).toContain('## What OpenMeta Can Do');
+    expect(codexSkill).toContain('Codex default personal install path: `~/.agents/skills/openmeta`');
+    expect(codexSkill).toContain('openmeta machine doctor');
 
     expect(openclaw.files[0]).toBe(join(tempRoot, 'openclaw', 'skill.md'));
     expect(openclawSkill).toContain('Install target: `~/.openclaw/skills/openmeta`');
@@ -145,6 +155,24 @@ describe('skill bundle rendering', () => {
     expect(installedSkill).toStartWith('---\nname: openmeta\n');
     expect(installedSkill).toContain('description: Use when');
     expect(installedSkill).toContain('## What OpenMeta Can Do');
+    expect(installedSkill).toContain('openmeta machine doctor');
+  });
+
+  test('installs codex bundle at the Codex personal skill discovery entrypoint', async () => {
+    const homeRoot = join(tempRoot, 'home');
+
+    const result = await installSkillBundle('codex', { homeDir: homeRoot });
+    const skillPath = join(homeRoot, '.agents', 'skills', 'openmeta', 'SKILL.md');
+
+    expect(result.installed).toBe(true);
+    expect(result.installPath).toBe(join(homeRoot, '.agents', 'skills', 'openmeta'));
+    expect(result.exportedFiles).toEqual([skillPath]);
+    expect(existsSync(skillPath)).toBe(true);
+
+    const installedSkill = readFileSync(skillPath, 'utf-8');
+    expect(installedSkill).toStartWith('---\nname: openmeta\n');
+    expect(installedSkill).toContain('description: Use when');
+    expect(installedSkill).toContain('Host: Codex');
     expect(installedSkill).toContain('openmeta machine doctor');
   });
 });


### PR DESCRIPTION
这个pr为 OpenMeta skill 系统新增 Codex 接入能力，下文简要讲述实现方式
- 采用skill方式安装到用户目录，codex启动时即能识别
- 大部分改动都水平拓展了接入cc的工作，除了渲染管线抽象把渲染逻辑抽象出来复用了（见render.ts)

后续改进工作接着采用水平模式拓展即可，当host数量足够多时再用设计模式抽象一下

#### 测试结果截图

<img width="1439" height="624" alt="image" src="https://github.com/user-attachments/assets/fd90ac01-cc45-462e-a329-41d06a147a67" />

---


#### Test Result Screenshot
This pr add openmeta support for codex.The following contents is about its'implemention
- Install to the user directory using the skill method, so Codex can recognize it upon startup.
- Most of the changes horizontally extended the CC integration work, except for the render pipeline abstraction, which abstracts and reuses the rendering logic (see render.ts).
 
For future improvements, we can continue with this horizontal expansion pattern, and then abstract it further using design patterns once the number of hosts becomes large enough.
<img width="1439" height="624" alt="image" src="https://github.com/user-attachments/assets/203660b3-9581-4cbe-9254-37ae82a60162" />
