### PR TITLE
feat(agent): add repository star range filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ openmeta skill doctor --host codex
 | `openmeta agent` | 运行自治贡献主流程 |
 | `openmeta agent --draft-only` | 只生成 dossier、patch draft 和 PR draft，不改仓库、不创建 PR |
 | `openmeta agent --refresh` | 忽略本地 issue 搜索缓存，重新从 GitHub 发现机会 |
+| `openmeta agent --min-stars <n> --max-stars <n>` | 仅搜索 star 数位于包含上下界范围内的仓库；默认最小值为 50 |
 | `openmeta agent --repo <repository>` | 限定到一个 GitHub 仓库 URL 或 `owner/name` 进行发现、分析和 PR 创建 |
 | `openmeta agent --repo <repository> --issue <number>` | 直接解决指定仓库里的某个 issue，并沿用 agent 的 patch / PR 流程 |
 | `openmeta agent --issue <issue-url>` | 直接从 GitHub issue URL 推导仓库并解决该 issue |
@@ -325,6 +326,7 @@ openmeta skill doctor --host codex
 | `openmeta daily` | `agent` 的兼容别名，支持相同运行参数 |
 | `openmeta scout --limit <count>` | 查看高价值贡献机会排名 |
 | `openmeta scout --refresh` | 强制刷新 GitHub issue discovery 缓存 |
+| `openmeta scout --min-stars <n> --max-stars <n>` | 按仓库 star 数范围筛选贡献机会 |
 | `openmeta scout --repo <repository>` | 从一个 GitHub 仓库 URL 或 `owner/name` 中筛选贡献机会 |
 | `openmeta scout --local` | 使用本地启发式评分，不调用 LLM，适合模型服务暂时不可用时先筛机会 |
 | `openmeta inbox` | 查看已起草的贡献机会收件箱 |
@@ -686,6 +688,7 @@ If `doctor` reports `supported: true` and `skillFileExists: true`, Codex should 
 | `openmeta agent` | Run the autonomous contribution workflow |
 | `openmeta agent --draft-only` | Generate dossier, patch draft, and PR draft artifacts without editing files or opening a PR |
 | `openmeta agent --refresh` | Ignore the local issue search cache and discover fresh GitHub opportunities |
+| `openmeta agent --min-stars <n> --max-stars <n>` | Search repositories within an inclusive star range; the default minimum is 50 |
 | `openmeta agent --repo <repository>` | Limit issue discovery, ranking, workspace prep, and draft PR creation to one upstream GitHub repository URL or `owner/name` |
 | `openmeta agent --repo <repository> --issue <number>` | Solve one issue from the specified repository and continue through the normal patch / PR flow |
 | `openmeta agent --issue <issue-url>` | Infer the repository from a GitHub issue URL and solve that issue directly |
@@ -694,6 +697,7 @@ If `doctor` reports `supported: true` and `skillFileExists: true`, Codex should 
 | `openmeta daily` | Compatibility alias for `agent` with the same runtime options |
 | `openmeta scout --limit <count>` | Show ranked contribution opportunities |
 | `openmeta scout --refresh` | Force-refresh the GitHub issue discovery cache |
+| `openmeta scout --min-stars <n> --max-stars <n>` | Filter contribution opportunities by repository star range |
 | `openmeta scout --repo <repository>` | Rank opportunities from one upstream GitHub repository URL or `owner/name` |
 | `openmeta scout --local` | Use local heuristic scoring without calling the LLM provider |
 | `openmeta inbox` | Show drafted contribution opportunities |

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,6 +1,7 @@
 import { type Command, Option } from 'commander';
 import { agentOrchestrator } from '../orchestration/index.js';
 import { runCommand } from './run-command.js';
+import { parseStarCount } from './star-range.js';
 
 export function registerAgentCommand(program: Command): void {
   program
@@ -12,6 +13,8 @@ export function registerAgentCommand(program: Command): void {
     .option('--draft-only', 'Generate dossier and PR draft artifacts without applying file edits or opening a PR')
     .option('--local-artifacts-only', 'Write local artifacts without publishing, committing, or pushing them')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--min-stars <count>', 'Minimum repository star count', parseStarCount)
+    .option('--max-stars <count>', 'Maximum repository star count', parseStarCount)
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
     .option('--preset <name>', 'Use one saved repository preset as the exploration scope')
     .option('--all-repos', 'Ignore the active repository preset and search the broader issue stream')
@@ -27,6 +30,8 @@ export function registerAgentCommand(program: Command): void {
         draftOnly?: boolean;
         localArtifactsOnly?: boolean;
         refresh?: boolean;
+        minStars?: number;
+        maxStars?: number;
         repo?: string;
         preset?: string;
         allRepos?: boolean;
@@ -43,6 +48,8 @@ export function registerAgentCommand(program: Command): void {
             draftOnly: options.draftOnly,
             localArtifactsOnly: options.localArtifactsOnly,
             refresh: options.refresh,
+            minStars: options.minStars,
+            maxStars: options.maxStars,
             repo: options.repo,
             preset: options.preset,
             allRepos: options.allRepos,

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -1,6 +1,7 @@
 import { type Command, Option } from 'commander';
 import { dailyOrchestrator } from '../orchestration/index.js';
 import { runCommand } from './run-command.js';
+import { parseStarCount } from './star-range.js';
 
 export function registerDailyCommand(program: Command): void {
   program
@@ -12,6 +13,8 @@ export function registerDailyCommand(program: Command): void {
     .option('--draft-only', 'Generate dossier and PR draft artifacts without applying file edits or opening a PR')
     .option('--local-artifacts-only', 'Write local artifacts without publishing, committing, or pushing them')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--min-stars <count>', 'Minimum repository star count', parseStarCount)
+    .option('--max-stars <count>', 'Maximum repository star count', parseStarCount)
     .addOption(new Option('--scheduler-run', 'Internal flag for scheduled automation').hideHelp())
     .action(
       (options: {
@@ -21,6 +24,8 @@ export function registerDailyCommand(program: Command): void {
         draftOnly?: boolean;
         localArtifactsOnly?: boolean;
         refresh?: boolean;
+        minStars?: number;
+        maxStars?: number;
         schedulerRun?: boolean;
       }) =>
         runCommand('OpenMeta Daily', () =>
@@ -31,6 +36,8 @@ export function registerDailyCommand(program: Command): void {
             draftOnly: options.draftOnly,
             localArtifactsOnly: options.localArtifactsOnly,
             refresh: options.refresh,
+            minStars: options.minStars,
+            maxStars: options.maxStars,
             schedulerRun: options.schedulerRun,
           }),
         ),

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -10,6 +10,7 @@ import {
   machineRunsOrchestrator,
   machineScoutOrchestrator,
 } from '../orchestration/machine/index.js';
+import { parseStarCount } from './star-range.js';
 
 export function registerMachineCommand(program: Command): void {
   const machine = program.command('machine').description('Stable JSON-first automation surface');
@@ -89,8 +90,10 @@ export function registerMachineCommand(program: Command): void {
     .description('Machine-safe opportunity discovery')
     .option('--limit <count>', 'Number of opportunities to return', '10')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--min-stars <count>', 'Minimum repository star count', parseStarCount)
+    .option('--max-stars <count>', 'Maximum repository star count', parseStarCount)
     .option('--repo <repository>', 'Limit issue discovery to one repository')
-    .action((options: { limit?: string; refresh?: boolean; repo?: string }) =>
+    .action((options: { limit?: string; refresh?: boolean; minStars?: number; maxStars?: number; repo?: string }) =>
       machineScoutOrchestrator.execute(options),
     );
 
@@ -115,6 +118,8 @@ export function registerMachineCommand(program: Command): void {
     .option('--draft-only', 'Generate artifacts without applying file edits or opening a PR')
     .option('--local-artifacts-only', 'Write local artifacts without publishing, committing, or pushing them')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--min-stars <count>', 'Minimum repository star count', parseStarCount)
+    .option('--max-stars <count>', 'Maximum repository star count', parseStarCount)
     .option('--repo <repository>', 'Limit issue discovery to one repository')
     .option('--repo-path <path>', 'Reuse a local repository path via an isolated worktree')
     .option('--issue <issue>', 'Solve one GitHub issue number or issue URL')
@@ -126,6 +131,8 @@ export function registerMachineCommand(program: Command): void {
         draftOnly?: boolean;
         localArtifactsOnly?: boolean;
         refresh?: boolean;
+        minStars?: number;
+        maxStars?: number;
         repo?: string;
         repoPath?: string;
         issue?: string;

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import { agentOrchestrator } from '../orchestration/index.js';
 import { runCommand } from './run-command.js';
+import { parseStarCount } from './star-range.js';
 
 export function registerScoutCommand(program: Command): void {
   program
@@ -8,18 +9,31 @@ export function registerScoutCommand(program: Command): void {
     .description('Rank the highest-value contribution opportunities')
     .option('--limit <count>', 'Number of opportunities to show', '10')
     .option('--refresh', 'Ignore cached GitHub issue discovery results')
+    .option('--min-stars <count>', 'Minimum repository star count', parseStarCount)
+    .option('--max-stars <count>', 'Maximum repository star count', parseStarCount)
     .option('--repo <repository>', 'Limit issue discovery to one GitHub repository URL or owner/name')
     .option('--preset <name>', 'Use one saved repository preset as the discovery scope')
     .option('--all-repos', 'Ignore the active repository preset and search the broader issue stream')
-    .action((options: { limit?: string; refresh?: boolean; repo?: string; preset?: string; allRepos?: boolean }) =>
-      runCommand('OpenMeta Scout', () =>
-        agentOrchestrator.scout({
-          limit: Number.parseInt(options.limit || '10', 10) || 10,
-          refresh: options.refresh,
-          repo: options.repo,
-          preset: options.preset,
-          allRepos: options.allRepos,
-        }),
-      ),
+    .action(
+      (options: {
+        limit?: string;
+        refresh?: boolean;
+        minStars?: number;
+        maxStars?: number;
+        repo?: string;
+        preset?: string;
+        allRepos?: boolean;
+      }) =>
+        runCommand('OpenMeta Scout', () =>
+          agentOrchestrator.scout({
+            limit: Number.parseInt(options.limit || '10', 10) || 10,
+            refresh: options.refresh,
+            minStars: options.minStars,
+            maxStars: options.maxStars,
+            repo: options.repo,
+            preset: options.preset,
+            allRepos: options.allRepos,
+          }),
+        ),
     );
 }

--- a/src/commands/star-range.ts
+++ b/src/commands/star-range.ts
@@ -1,0 +1,9 @@
+import { InvalidArgumentError } from 'commander';
+
+export function parseStarCount(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new InvalidArgumentError('Expected a non-negative integer.');
+  }
+  return parsed;
+}

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -54,6 +54,8 @@ export interface AgentRunOptions {
   draftOnly?: boolean;
   localArtifactsOnly?: boolean;
   refresh?: boolean;
+  minStars?: number;
+  maxStars?: number;
   repo?: string;
   preset?: string;
   allRepos?: boolean;
@@ -65,6 +67,8 @@ export interface AgentRunOptions {
 export interface ScoutRunOptions {
   limit?: number;
   refresh?: boolean;
+  minStars?: number;
+  maxStars?: number;
   repo?: string;
   preset?: string;
   allRepos?: boolean;
@@ -76,6 +80,8 @@ export interface MachineScoutResult {
     limit: number;
     refresh: boolean;
     repo?: string;
+    minStars?: number;
+    maxStars?: number;
   };
   emptyExplanation?: {
     title: string;
@@ -119,6 +125,8 @@ export interface MachineAgentResult {
     runChecks: boolean;
     dryRun: boolean;
     refresh: boolean;
+    minStars?: number;
+    maxStars?: number;
   };
   skipReasons: string[];
   nextActions: string[];
@@ -257,6 +265,9 @@ export class AgentOrchestrator {
     const dryRun = Boolean(options.dryRun);
     const repoPath = options.repoPath?.trim() || undefined;
     const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
+    const starRange = issueTarget
+      ? undefined
+      : githubService.resolveRepositoryStarRange(options.minStars, options.maxStars);
     const scope = issueTarget
       ? undefined
       : repositoryTargetingService.resolveScope(config, {
@@ -310,11 +321,15 @@ export class AgentOrchestrator {
             scope?.mode === 'preset'
               ? this.loadPresetRankedIssues(config, scope.repos, {
                   refresh,
+                  minStars: starRange?.minStars,
+                  maxStars: starRange?.maxStars,
                   onStatus: (message) => task.setMessage(message),
                 })
               : issueRankingService.loadRankedIssues(config, {
                   refresh,
                   repoFullName,
+                  minStars: starRange?.minStars,
+                  maxStars: starRange?.maxStars,
                   onStatus: (message) => task.setMessage(message),
                 }),
         );
@@ -587,6 +602,8 @@ export class AgentOrchestrator {
             runChecks,
             dryRun,
             refresh,
+            minStars: starRange?.minStars,
+            maxStars: starRange?.maxStars,
           },
           skipReasons: [...new Set(skipReasons)],
           nextActions: dryRun
@@ -867,6 +884,8 @@ export class AgentOrchestrator {
         runChecks,
         dryRun,
         refresh,
+        minStars: starRange?.minStars,
+        maxStars: starRange?.maxStars,
       },
       skipReasons: [...new Set(skipReasons)],
       nextActions: dryRun
@@ -892,6 +911,9 @@ export class AgentOrchestrator {
     const refresh = Boolean(options.refresh);
     const repoPath = options.repoPath?.trim() || undefined;
     const issueTarget = options.issue ? resolveGitHubIssueTarget(options.issue, options.repo) : undefined;
+    const starRange = issueTarget
+      ? undefined
+      : githubService.resolveRepositoryStarRange(options.minStars, options.maxStars);
     const scope = issueTarget
       ? undefined
       : repositoryTargetingService.resolveScope(config, {
@@ -925,6 +947,11 @@ export class AgentOrchestrator {
           : refresh
             ? 'Issue discovery will bypass the local search cache for this run.'
             : 'Issue discovery may reuse the short local search cache.',
+        ...(starRange
+          ? [
+              `Repository stars: ${starRange.minStars} to ${starRange.maxStars === undefined ? 'unbounded' : starRange.maxStars}.`,
+            ]
+          : []),
         issueTarget
           ? 'Issue discovery and interactive selection are skipped for this run.'
           : scope?.mode === 'preset'
@@ -973,11 +1000,15 @@ export class AgentOrchestrator {
           : scope?.mode === 'preset'
             ? this.loadPresetRankedIssues(config, scope.repos, {
                 refresh,
+                minStars: starRange?.minStars,
+                maxStars: starRange?.maxStars,
                 onStatus: (message) => task.setMessage(message),
               })
             : issueRankingService.loadRankedIssues(config, {
                 refresh,
                 repoFullName,
+                minStars: starRange?.minStars,
+                maxStars: starRange?.maxStars,
                 onStatus: (message) => task.setMessage(message),
               }),
     );
@@ -1320,6 +1351,9 @@ export class AgentOrchestrator {
   async scout(options: ScoutRunOptions | number = {}): Promise<void> {
     const limit = typeof options === 'number' ? options : (options.limit ?? 10);
     const refresh = typeof options === 'number' ? false : Boolean(options.refresh);
+    const minStars = typeof options === 'number' ? undefined : options.minStars;
+    const maxStars = typeof options === 'number' ? undefined : options.maxStars;
+    const starRange = githubService.resolveRepositoryStarRange(minStars, maxStars);
     const explicitRepo =
       typeof options === 'number' || !options.repo ? undefined : parseGitHubRepoFullName(options.repo);
     const config = await configService.get();
@@ -1351,6 +1385,7 @@ export class AgentOrchestrator {
             ? `Issue discovery is limited to ${repoFullName}.`
             : 'Issue discovery will scan the broader GitHub issue stream.',
         'LLM scoring will refine the local candidate shortlist.',
+        `Repository stars: ${starRange.minStars} to ${starRange.maxStars === undefined ? 'unbounded' : starRange.maxStars}.`,
       ],
     });
 
@@ -1365,6 +1400,8 @@ export class AgentOrchestrator {
         if (scope.mode === 'preset') {
           return this.loadPresetRankedIssues(config, scope.repos, {
             refresh,
+            minStars: starRange.minStars,
+            maxStars: starRange.maxStars,
             onStatus: (message) => task.setMessage(message),
           });
         }
@@ -1372,6 +1409,8 @@ export class AgentOrchestrator {
         return issueRankingService.loadRankedIssues(config, {
           refresh,
           repoFullName,
+          minStars: starRange.minStars,
+          maxStars: starRange.maxStars,
           onStatus: (message) => task.setMessage(message),
         });
       },
@@ -1399,6 +1438,7 @@ export class AgentOrchestrator {
     const totalSteps = 3;
     const limit = options.limit ?? 10;
     const refresh = Boolean(options.refresh);
+    const starRange = githubService.resolveRepositoryStarRange(options.minStars, options.maxStars);
     const config = await configService.get();
     const scope = repositoryTargetingService.resolveScope(config, {
       repo: options.repo,
@@ -1432,6 +1472,8 @@ export class AgentOrchestrator {
         if (scope.mode === 'preset') {
           return this.loadPresetRankedIssues(config, scope.repos, {
             refresh,
+            minStars: starRange.minStars,
+            maxStars: starRange.maxStars,
             onStatus: (message) => task.setMessage(message),
           });
         }
@@ -1439,6 +1481,8 @@ export class AgentOrchestrator {
         return issueRankingService.loadRankedIssues(config, {
           refresh,
           repoFullName,
+          minStars: starRange.minStars,
+          maxStars: starRange.maxStars,
           onStatus: (message) => task.setMessage(message),
         });
       },
@@ -1452,6 +1496,8 @@ export class AgentOrchestrator {
         limit,
         refresh,
         repo: repoFullName,
+        minStars: starRange.minStars,
+        maxStars: starRange.maxStars,
       },
       ...(emptyExplanation ? { emptyExplanation } : {}),
       nextActions: rankedIssues.length === 0 ? ['broaden_profile_filters'] : ['inspect_ranked_opportunities'],
@@ -1977,6 +2023,8 @@ export class AgentOrchestrator {
     repos: string[],
     options: {
       refresh?: boolean;
+      minStars?: number;
+      maxStars?: number;
       onStatus?: (message: string) => void;
     } = {},
   ): Promise<RankedIssue[]> {
@@ -1987,6 +2035,8 @@ export class AgentOrchestrator {
       const issues = await issueRankingService.loadRankedIssues(config, {
         refresh: options.refresh,
         repoFullName,
+        minStars: options.minStars,
+        maxStars: options.maxStars,
       });
 
       for (const issue of issues) {

--- a/src/orchestration/machine/agent.ts
+++ b/src/orchestration/machine/agent.ts
@@ -11,6 +11,8 @@ export class MachineAgentFlowOrchestrator {
       draftOnly?: boolean;
       localArtifactsOnly?: boolean;
       refresh?: boolean;
+      minStars?: number;
+      maxStars?: number;
       repo?: string;
       repoPath?: string;
       issue?: string;
@@ -34,6 +36,8 @@ export class MachineAgentFlowOrchestrator {
           draftOnly: options.draftOnly,
           localArtifactsOnly: options.localArtifactsOnly,
           refresh: options.refresh,
+          minStars: options.minStars,
+          maxStars: options.maxStars,
           repo: options.repo,
           repoPath: options.repoPath,
           issue: options.issue,

--- a/src/orchestration/machine/scout.ts
+++ b/src/orchestration/machine/scout.ts
@@ -4,7 +4,9 @@ import { mapMachineError } from './errors.js';
 import { buildMachineEnvelope, writeMachinePayload, writeMachinePlan } from './runtime.js';
 
 export class MachineScoutOrchestrator {
-  async execute(options: { limit?: string; refresh?: boolean; repo?: string } = {}): Promise<void> {
+  async execute(
+    options: { limit?: string; refresh?: boolean; minStars?: number; maxStars?: number; repo?: string } = {},
+  ): Promise<void> {
     try {
       writeMachinePlan('machine scout', [
         'Validate GitHub access',
@@ -16,6 +18,8 @@ export class MachineScoutOrchestrator {
         agentOrchestrator.scoutMachine({
           limit: Number.parseInt(options.limit || '10', 10) || 10,
           refresh: options.refresh,
+          minStars: options.minStars,
+          maxStars: options.maxStars,
           repo: options.repo,
         }),
       );

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -27,7 +27,7 @@ const MAX_SEARCH_PAGES = 4;
 const SEARCH_PAGE_PACING_DELAY_MS = 3_000;
 const RATE_LIMIT_RETRY_FALLBACK_DELAY_MS = 10_000;
 const MAX_ISSUES_PER_REPO = 3;
-const MIN_REPO_STARS = 50;
+export const DEFAULT_MIN_REPO_STARS = 50;
 
 type SearchIssueItem = RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'][number];
 
@@ -58,6 +58,13 @@ interface IssueDiscoveryOptions {
   repoFullName?: string;
   onStatus?: (message: string) => void;
   techStack?: string[];
+  minStars?: number;
+  maxStars?: number;
+}
+
+export interface RepositoryStarRange {
+  minStars: number;
+  maxStars?: number;
 }
 
 export interface RepositoryProbe {
@@ -115,12 +122,16 @@ export class GitHubService {
     }
 
     const repoFullName = options.repoFullName ? parseGitHubRepoFullName(options.repoFullName) : undefined;
+    const starRange = this.resolveRepositoryStarRange(options.minStars, options.maxStars);
 
     if (!options.refresh) {
       const cachedIssues = this.loadCachedIssues(repoFullName);
       if (cachedIssues) {
-        logger.info(`Using cached GitHub issues (${cachedIssues.length}) to avoid unnecessary Search API calls.`);
-        return cachedIssues;
+        const filteredIssues = this.filterIssuesByStarRange(cachedIssues, starRange);
+        logger.info(
+          `Using cached GitHub issues (${filteredIssues.length}/${cachedIssues.length} in the requested star range) to avoid unnecessary Search API calls.`,
+        );
+        return filteredIssues;
       }
     } else {
       logger.info('Refreshing GitHub issue discovery and ignoring the local search cache.');
@@ -229,12 +240,6 @@ export class GitHubService {
         const repoId = this.parseRepositoryUrl(item.repository_url);
         const repoData = await this.fetchRepoMetadata(repoId, repoCache);
 
-        // Post-fetch quality gate: GitHub issue search does not support the
-        // `stars:` qualifier, so we filter by repo stars after resolving metadata.
-        if (repoData.stars < MIN_REPO_STARS) {
-          continue;
-        }
-
         issues.push({
           id: item.id,
           number: item.number,
@@ -250,13 +255,6 @@ export class GitHubService {
           updatedAt: item.updated_at,
         });
       }
-
-      logger.success(
-        repoFullName
-          ? `Fetched ${issues.length} open issues from ${repoFullName}`
-          : `Fetched ${issues.length} trending issues from ${FILTER_LABEL_GROUPS.length} label searches`,
-      );
-      this.saveCachedIssues(issues, repoFullName);
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('GitHub issue discovery')) {
         throw error;
@@ -266,7 +264,14 @@ export class GitHubService {
       throw new Error('GitHub issue discovery failed. Please try again in a moment.');
     }
 
-    return issues;
+    this.saveCachedIssues(issues, repoFullName);
+    const filteredIssues = this.filterIssuesByStarRange(issues, starRange);
+    logger.success(
+      repoFullName
+        ? `Fetched ${filteredIssues.length} open issues from ${repoFullName} in the requested star range`
+        : `Fetched ${filteredIssues.length} trending issues from ${FILTER_LABEL_GROUPS.length} label searches in the requested star range`,
+    );
+    return filteredIssues;
   }
 
   async fetchIssue(repoFullName: string, issueNumber: number): Promise<GitHubIssue> {
@@ -371,6 +376,28 @@ export class GitHubService {
 
   getUsername(): string {
     return this.username;
+  }
+
+  resolveRepositoryStarRange(minStars?: number, maxStars?: number): RepositoryStarRange {
+    const min = minStars ?? DEFAULT_MIN_REPO_STARS;
+    if (!Number.isSafeInteger(min) || min < 0) {
+      throw new Error('Minimum repository stars must be a non-negative integer.');
+    }
+    if (maxStars !== undefined && (!Number.isSafeInteger(maxStars) || maxStars < 0)) {
+      throw new Error('Maximum repository stars must be a non-negative integer.');
+    }
+    if (maxStars !== undefined && maxStars < min) {
+      throw new Error(`Maximum repository stars (${maxStars}) cannot be lower than minimum repository stars (${min}).`);
+    }
+
+    return maxStars === undefined ? { minStars: min } : { minStars: min, maxStars };
+  }
+
+  private filterIssuesByStarRange(issues: GitHubIssue[], range: RepositoryStarRange): GitHubIssue[] {
+    return issues.filter(
+      (issue) =>
+        issue.repoStars >= range.minStars && (range.maxStars === undefined || issue.repoStars <= range.maxStars),
+    );
   }
 
   private async fetchRepoTextFile(owner: string, repo: string, path: string): Promise<string | null> {

--- a/src/services/issue-ranking.ts
+++ b/src/services/issue-ranking.ts
@@ -82,6 +82,8 @@ export class IssueRankingService {
       refresh?: boolean;
       repoFullName?: string;
       onStatus?: (message: string) => void;
+      minStars?: number;
+      maxStars?: number;
     } = {},
   ): Promise<RankedIssue[]> {
     const issues = await githubService.fetchTrendingIssues({
@@ -89,6 +91,8 @@ export class IssueRankingService {
       repoFullName: options.repoFullName,
       onStatus: options.onStatus,
       techStack: config.userProfile.techStack,
+      minStars: options.minStars,
+      maxStars: options.maxStars,
     });
     const rankedCandidates = this.rankIssuesForProfile(issues, config.userProfile);
     const matched = await this.scoreIssuesInBatches(config.userProfile, rankedCandidates);

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -32,6 +32,8 @@ interface AgentRunInternals {
     draftOnly?: boolean;
     localArtifactsOnly?: boolean;
     refresh?: boolean;
+    minStars?: number;
+    maxStars?: number;
     repo?: string;
     preset?: string;
     allRepos?: boolean;
@@ -286,6 +288,25 @@ describe('AgentOrchestrator run flow', () => {
     });
 
     expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  test('passes repository star ranges into issue discovery', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+    spyOn(infra.configService, 'get').mockResolvedValue(createConfig());
+    spyOn(
+      orchestrator as object as { initializeClients: AgentRunInternals['initializeClients'] },
+      'initializeClients',
+    ).mockResolvedValue(undefined);
+    const loadSpy = spyOn(issueRankingService, 'loadRankedIssues').mockResolvedValue([]);
+
+    await orchestrator.run({
+      headless: true,
+      schedulerRun: true,
+      minStars: 100,
+      maxStars: 500,
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ minStars: 100, maxStars: 500 }));
   });
 
   test('returns early when automation cannot select an issue above the threshold', async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -335,6 +335,34 @@ describe('GitHubService internals', () => {
     expect(loaded).toEqual(issues);
   });
 
+  test('filters cached issues by a configurable inclusive repository star range', async () => {
+    const service = new GitHubService();
+    const internals = service as unknown as GitHubServiceInternals;
+    internals.saveCachedIssues([
+      createIssue({ number: 1, repoStars: 10 }),
+      createIssue({ number: 2, repoStars: 100 }),
+      createIssue({ number: 3, repoStars: 1_000 }),
+    ]);
+    internals.octokit = { rest: {} } as unknown as GitHubServiceInternals['octokit'];
+
+    const defaults = await service.fetchTrendingIssues();
+    const bounded = await service.fetchTrendingIssues({ minStars: 100, maxStars: 500 });
+    const broadened = await service.fetchTrendingIssues({ minStars: 0, maxStars: 20 });
+
+    expect(defaults.map((issue) => issue.number)).toEqual([2, 3]);
+    expect(bounded.map((issue) => issue.number)).toEqual([2]);
+    expect(broadened.map((issue) => issue.number)).toEqual([1]);
+  });
+
+  test('rejects invalid repository star ranges', () => {
+    const service = new GitHubService();
+
+    expect(() => service.resolveRepositoryStarRange(-1, 10)).toThrow('non-negative integer');
+    expect(() => service.resolveRepositoryStarRange(100, 99)).toThrow(
+      'Maximum repository stars (99) cannot be lower than minimum repository stars (100).',
+    );
+  });
+
   test('ignores stale or malformed cached issue payloads', () => {
     const service = new GitHubService() as unknown as GitHubServiceInternals;
     const cachePath = service.getCachePath();

--- a/test/machine-commands.test.ts
+++ b/test/machine-commands.test.ts
@@ -258,7 +258,7 @@ describe('machine commands', () => {
     registerMachineCommand(program);
     const issue = createRankedIssue();
 
-    spyOn(agentOrchestrator, 'scoutMachine').mockResolvedValue({
+    const scoutSpy = spyOn(agentOrchestrator, 'scoutMachine').mockResolvedValue({
       opportunities: [issue],
       mode: {
         limit: 10,
@@ -268,11 +268,17 @@ describe('machine commands', () => {
       nextActions: ['inspect_ranked_opportunities'],
     });
 
-    await program.parseAsync(['machine', 'scout'], { from: 'user' });
+    await program.parseAsync(['machine', 'scout', '--min-stars', '100', '--max-stars', '500'], { from: 'user' });
 
     const output = JSON.parse(writes.join(''));
     expect(output.command).toBe('machine scout');
     expect(output.data.opportunities[0].repoFullName).toBe(issue.repoFullName);
+    expect(scoutSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        minStars: 100,
+        maxStars: 500,
+      }),
+    );
   });
 
   test('machine analyze writes repository analysis output as JSON only', async () => {
@@ -481,6 +487,10 @@ describe('machine commands', () => {
         'https://github.com/acme/demo/issues/42',
         '--draft-only',
         '--local-artifacts-only',
+        '--min-stars',
+        '100',
+        '--max-stars',
+        '500',
       ],
       { from: 'user' },
     );
@@ -489,6 +499,8 @@ describe('machine commands', () => {
       expect.objectContaining({
         draftOnly: true,
         localArtifactsOnly: true,
+        minStars: 100,
+        maxStars: 500,
       }),
     );
   });

--- a/test/targeting-commands.test.ts
+++ b/test/targeting-commands.test.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { registerAgentCommand } from '../src/commands/agent.js';
 import { registerAnalyzeCommand } from '../src/commands/analyze.js';
 import { registerScoutCommand } from '../src/commands/scout.js';
+import { parseStarCount } from '../src/commands/star-range.js';
 
 describe('repository targeting command options', () => {
   test('registers scout targeting options for presets and all-repos fallback', () => {
@@ -14,6 +15,8 @@ describe('repository targeting command options', () => {
 
     expect(help).toContain('--preset <name>');
     expect(help).toContain('--all-repos');
+    expect(help).toContain('--min-stars <count>');
+    expect(help).toContain('--max-stars <count>');
   });
 
   test('registers agent targeting options for presets and all-repos fallback', () => {
@@ -25,6 +28,15 @@ describe('repository targeting command options', () => {
 
     expect(help).toContain('--preset <name>');
     expect(help).toContain('--all-repos');
+    expect(help).toContain('--min-stars <count>');
+    expect(help).toContain('--max-stars <count>');
+  });
+
+  test('parses non-negative integer star counts', () => {
+    expect(parseStarCount('0')).toBe(0);
+    expect(parseStarCount('125')).toBe(125);
+    expect(() => parseStarCount('-1')).toThrow('Expected a non-negative integer.');
+    expect(() => parseStarCount('1.5')).toThrow('Expected a non-negative integer.');
   });
 
   test('registers analyze targeting options for presets', () => {


### PR DESCRIPTION

  ## Summary
  - Add `--min-stars` and `--max-stars` filters to agent, daily, scout, and machine flows.
  - Apply the configured star range to fresh GitHub Search results and cached issue candidates.
  - Return the effective star range in machine scout metadata and document CLI usage.

  ## Why
  This lets users tune issue discovery by repository size. For example, they can focus on mature projects with `--min-
  stars 100`, or intentionally search smaller repositories with `--min-stars 0 --max-stars 50`.

  ## Validation
  - `bun run check`
  - `bun run typecheck`
  - `bun run build`
  - `bun test`