### PR TITLE
feat: respect repository contribution rules

### DIFF
--- a/src/contracts/agent-contracts.ts
+++ b/src/contracts/agent-contracts.ts
@@ -93,6 +93,25 @@ export const PullRequestDraftSchema = z.object({
   changes: z.array(nonEmptyTrimmedString).min(1).max(12),
   validation: z.array(nonEmptyTrimmedString).default([]),
   risks: z.array(nonEmptyTrimmedString).default([]),
+  body: trimmedString.optional(),
+});
+
+export const RepositoryContributionRulesSchema = z.object({
+  detectedFiles: z.array(nonEmptyTrimmedString).default([]).transform(dedupeStrings),
+  summary: z.array(nonEmptyTrimmedString).default([]),
+  prTemplateBody: trimmedString.optional(),
+  prTitleRule: trimmedString.optional(),
+  commitMessageRule: trimmedString.optional(),
+  branchNamingRule: trimmedString.optional(),
+  requiredChecklistItems: z.array(nonEmptyTrimmedString).default([]),
+  requiredValidationNotes: z.array(nonEmptyTrimmedString).default([]),
+  requiredIssueLinking: trimmedString.optional(),
+  allowsDraftPr: z.boolean().optional(),
+  requiresPriorDiscussion: z.boolean().default(false),
+  missingRequirements: z.array(nonEmptyTrimmedString).default([]),
+  blockingRequirements: z.array(nonEmptyTrimmedString).default([]),
+  requiredReleaseNotes: z.boolean().default(false),
+  requiredDiscussionEvidence: z.boolean().default(false),
 });
 
 export const RepositoryImprovementSuggestionSchema = z.object({
@@ -192,6 +211,7 @@ export type PatchDraft = z.infer<typeof PatchDraftSchema>;
 export type GeneratedFileChange = z.infer<typeof GeneratedFileChangeSchema>;
 export type ImplementationDraft = z.infer<typeof ImplementationDraftSchema>;
 export type PullRequestDraft = z.infer<typeof PullRequestDraftSchema>;
+export type RepositoryContributionRules = z.infer<typeof RepositoryContributionRulesSchema>;
 export type RepositoryImprovementSuggestion = z.infer<typeof RepositoryImprovementSuggestionSchema>;
 export type RepositorySuggestionList = z.infer<typeof RepositorySuggestionListSchema>;
 export type EnvironmentGap = z.infer<typeof EnvironmentGapSchema>;

--- a/src/infra/prompt-templates.ts
+++ b/src/infra/prompt-templates.ts
@@ -129,6 +129,9 @@ Repo Context:
 
 Repo Memory:
 {{repoMemory}}
+
+Repository Rules:
+{{repositoryRules}}
 `;
 
 export const PATCH_DRAFT_REPAIR_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.
@@ -412,6 +415,47 @@ Patch Draft:
 
 Validation Context:
 {{validationContext}}
+
+Repository Rules:
+{{repositoryRules}}
+`;
+
+export const REPOSITORY_RULES_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.
+
+Read the repository contribution rule files and extract only repository-specific pull request and contribution constraints into strict JSON.
+
+Requirements:
+1. Return one valid JSON object only. No markdown. No commentary.
+2. Only use evidence from the provided files.
+3. If a rule is uncertain, leave the structured field empty and add a note to missingRequirements instead of inventing it.
+4. Only add items to blockingRequirements when the file text clearly states a hard prerequisite or requirement that would block opening a PR safely.
+5. summary must be a short flat list of the most relevant detected rules.
+6. Set requiredReleaseNotes to true when the repository clearly asks for release notes, changelog entries, or breaking change notes.
+7. Set requiredDiscussionEvidence to true when the repository clearly says contributors should discuss first or get maintainer approval before opening a PR.
+
+Output schema:
+{
+  "detectedFiles": ["relative/path"],
+  "summary": ["short rule summary"],
+  "prTemplateBody": "optional full PR template body when present",
+  "prTitleRule": "optional PR title convention",
+  "commitMessageRule": "optional commit message convention",
+  "branchNamingRule": "optional branch naming convention",
+  "requiredChecklistItems": ["required checklist item"],
+  "requiredValidationNotes": ["required validation or test note"],
+  "requiredIssueLinking": "optional issue linking requirement",
+  "allowsDraftPr": true,
+  "requiresPriorDiscussion": false,
+  "missingRequirements": ["what a human still needs to verify"],
+  "blockingRequirements": ["clear blocker for automatic PR opening"],
+  "requiredReleaseNotes": false,
+  "requiredDiscussionEvidence": false
+}
+
+Repository: {{repoFullName}}
+
+Rule Files:
+{{ruleFiles}}
 `;
 
 export const REPOSITORY_ANALYSIS_PROMPT = `You are OpenMeta, an autonomous open source contribution agent.

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -132,6 +132,7 @@ export interface MachineAgentResult {
   nextActions: string[];
   pullRequestUrl?: string;
   pullRequestNumber?: number;
+  reviewReason?: string;
 }
 
 interface TargetRepoContext {
@@ -147,6 +148,7 @@ interface ContributionPullRequestResult {
   number?: number;
   changedFiles: string[];
   validationResults: TestResult[];
+  reviewReason?: string;
 }
 
 interface ConcretePatchResult {
@@ -745,6 +747,7 @@ export class AgentOrchestrator {
       ...(patchDraftResult.status !== 'success' ? ['patch_draft_requires_review'] : []),
       ...(implementation.reviewRequired ? ['implementation_requires_review'] : []),
       ...(prDraftResult.status !== 'success' ? ['pr_draft_requires_review'] : []),
+      ...(contributionPullRequest.reviewReason ? ['repository_rules_blocked_pr'] : []),
       ...(contributionPullRequest.url
         ? []
         : implementation.changedFiles.length > 0
@@ -779,6 +782,7 @@ export class AgentOrchestrator {
         published: false,
         pullRequestUrl: contributionPullRequest.url,
         pullRequestNumber: contributionPullRequest.number,
+        reviewReason: contributionPullRequest.reviewReason,
       };
       const dossier = contentService.formatContributionDossier(
         selectedIssue,
@@ -843,6 +847,7 @@ export class AgentOrchestrator {
         published: publishResult.published,
         pullRequestUrl: contributionPullRequest.url,
         reviewRequired,
+        reviewReason: contributionPullRequest.reviewReason,
       });
       proofOfWorkService.record(finalProofRecord);
       const finalProofMarkdown = proofOfWorkService.renderMarkdown(proofOfWorkService.load().records);
@@ -898,6 +903,7 @@ export class AgentOrchestrator {
       implementationAttempts: implementation.implementationAttempts,
       implementationStopReason: implementation.implementationStopReason,
       implementationContextFilesAdded: implementation.implementationContextFilesAdded,
+      reviewReason: contributionPullRequest.reviewReason,
     };
   }
 
@@ -1236,6 +1242,7 @@ export class AgentOrchestrator {
       published: false,
       pullRequestUrl: contributionPullRequest.url,
       pullRequestNumber: contributionPullRequest.number,
+      reviewReason: contributionPullRequest.reviewReason,
     };
 
     const dossier = contentService.formatContributionDossier(
@@ -1319,6 +1326,7 @@ export class AgentOrchestrator {
       published: publishResult.published,
       pullRequestUrl: contributionPullRequest.url,
       reviewRequired,
+      reviewReason: contributionPullRequest.reviewReason,
     });
     proofOfWorkService.record(finalProofRecord);
     const finalProofMarkdown = proofOfWorkService.renderMarkdown(proofOfWorkService.load().records);
@@ -1754,6 +1762,11 @@ export class AgentOrchestrator {
       { label: 'Default branch', value: workspace.defaultBranch, tone: 'info' },
       { label: 'Working branch', value: workspace.branchName || 'workspace already dirty', tone: 'info' },
       { label: 'Top-level files', value: workspace.topLevelFiles.slice(0, 8).join(', ') || 'n/a', tone: 'info' },
+      {
+        label: 'Rule files',
+        value: workspace.repositoryRules?.detectedFiles.slice(0, 4).join(', ') || 'none',
+        tone: workspace.repositoryRules?.detectedFiles.length ? 'accent' : 'muted',
+      },
     ]);
 
     ui.recordList('Repository context', [
@@ -3048,6 +3061,31 @@ export class AgentOrchestrator {
 
     const hasValidationFailures = input.validationResults.some((result) => !result.passed);
     const hasBlockingValidationFailures = this.hasBlockingValidationFailures(input.validationResults);
+    const complianceFailures = this.evaluateRepositoryRuleCompliance(
+      input.issue,
+      input.prDraft,
+      input.workspace.repositoryRules,
+      input.validationResults,
+    );
+    if (complianceFailures.length > 0) {
+      ui.callout({
+        label: 'Rule Gate',
+        title: 'Repository rules blocked automatic PR creation',
+        subtitle:
+          'OpenMeta kept this run in review/artifact mode because the repository has contribution requirements that were not safely satisfied.',
+        lines: complianceFailures.map((reason) => `[Rule Gate] Blocked: ${reason}`),
+        tone: 'warning',
+      });
+      logger.warn(
+        `Skipping real draft PR creation because repository rules blocked automatic submission: ${complianceFailures.join(' | ')}`,
+      );
+      return {
+        changedFiles: input.changedFiles,
+        validationResults: input.validationResults,
+        reviewReason: complianceFailures.join(' | '),
+      };
+    }
+
     const prDecision = permissionPolicyService.evaluatePullRequest({
       allowRealPr: input.allowRealPr,
       headless: input.headless,
@@ -3082,6 +3120,7 @@ export class AgentOrchestrator {
         return {
           changedFiles: input.changedFiles,
           validationResults: input.validationResults,
+          reviewReason: 'User declined real draft PR creation.',
         };
       }
 
@@ -3091,6 +3130,7 @@ export class AgentOrchestrator {
           return {
             changedFiles: input.changedFiles,
             validationResults: input.validationResults,
+            reviewReason: 'Validation failures were not approved for PR creation.',
           };
         }
       }
@@ -3102,6 +3142,7 @@ export class AgentOrchestrator {
         prDraft: input.prDraft,
         workspacePath: input.workspace.workspacePath,
         changedFiles: input.changedFiles,
+        repositoryRules: input.workspace.repositoryRules,
       });
 
       ui.card({
@@ -3132,8 +3173,90 @@ export class AgentOrchestrator {
       return {
         changedFiles: input.changedFiles,
         validationResults: input.validationResults,
+        reviewReason: 'Real PR submission failed; kept artifacts only.',
       };
     }
+  }
+
+  private evaluateRepositoryRuleCompliance(
+    issue: RankedIssue,
+    prDraft: PullRequestDraft,
+    rules: RepoWorkspaceContext['repositoryRules'],
+    validationResults: TestResult[],
+  ): string[] {
+    if (!rules) {
+      return [];
+    }
+
+    const failures = [...rules.blockingRequirements];
+    const body = `${prDraft.body || ''}\n${prDraft.summary}\n${prDraft.changes.join('\n')}\n${prDraft.validation.join('\n')}`.toLowerCase();
+
+    if (rules.allowsDraftPr === false) {
+      failures.push('Repository rules do not encourage draft PRs for this workflow.');
+    }
+
+    if (rules.requiresPriorDiscussion || rules.requiredDiscussionEvidence) {
+      const hasDiscussionEvidence =
+        /discussed in|discussion:|linked discussion|maintainer approval|approved by|pre-approved|prior discussion/i.test(
+          issue.body || '',
+        ) ||
+        /discussed in|discussion:|linked discussion|maintainer approval|approved by|pre-approved|prior discussion/i.test(
+          body,
+        );
+      if (!hasDiscussionEvidence) {
+        failures.push('Repository requires prior discussion or maintainer approval evidence before opening a PR.');
+      }
+    }
+
+    if (rules.requiredIssueLinking) {
+      const hasIssueReference =
+        body.includes(`#${issue.number}`.toLowerCase()) ||
+        body.includes(issue.htmlUrl.toLowerCase()) ||
+        body.includes(`${issue.repoFullName}#${issue.number}`.toLowerCase());
+      if (!hasIssueReference) {
+        failures.push(`PR draft is missing the required issue linking format: ${rules.requiredIssueLinking}`);
+      }
+    }
+
+    if (rules.prTitleRule) {
+      const normalizedRule = rules.prTitleRule.toLowerCase();
+      if (
+        normalizedRule.includes('conventional') ||
+        /\b(feat|fix|docs|chore|refactor|test)(?:\([^)]+\))?:/.test(normalizedRule)
+      ) {
+        const conventionalTitle = /^(feat|fix|docs|chore|refactor|test)(\([^)]+\))?:\s+\S+/i.test(prDraft.title);
+        if (!conventionalTitle) {
+          failures.push(`PR title does not satisfy the repository rule: ${rules.prTitleRule}`);
+        }
+      }
+    }
+
+    if (rules.requiredValidationNotes.length > 0) {
+      const validationText = prDraft.validation.join('\n').toLowerCase();
+      for (const note of rules.requiredValidationNotes) {
+        const normalized = note.toLowerCase();
+        if (normalized.includes('test') && validationResults.length === 0) {
+          failures.push(`Repository expects validation notes such as "${note}" before opening a PR.`);
+          continue;
+        }
+        if (normalized.length > 8 && !validationText.includes(normalized.slice(0, Math.min(24, normalized.length)))) {
+          failures.push(`PR draft is missing required validation note: ${note}`);
+        }
+      }
+    }
+
+    if (rules.requiredChecklistItems.length > 0 && !(prDraft.body || '').trim()) {
+      failures.push('Repository requires checklist items, but the PR draft did not preserve a template body.');
+    }
+
+    if (rules.requiredReleaseNotes) {
+      const hasReleaseNote = /release note|release-notes|changelog|breaking change/i.test(body);
+      if (!hasReleaseNote) {
+        failures.push('Repository requires release note or changelog context before opening a PR.');
+      }
+    }
+
+    return [...new Set(failures)];
   }
 
   private async confirmManualHeadlessRun(config: AppConfig): Promise<void> {

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -433,7 +433,10 @@ export class AgentOrchestrator {
           implementation.validationResults,
         );
         const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-        const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
+        const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(
+          prDraft,
+          workspaceForArtifacts.repositoryRules,
+        );
         const contributionPullRequest = await ui.task(
           {
             title: 'Evaluating draft PR creation',
@@ -721,7 +724,10 @@ export class AgentOrchestrator {
       implementation.validationResults,
     );
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(
+      prDraft,
+      workspaceForArtifacts.repositoryRules,
+    );
 
     const contributionPullRequest = await ui.task(
       {
@@ -1213,7 +1219,10 @@ export class AgentOrchestrator {
       });
     }
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(
+      prDraft,
+      workspaceForArtifacts.repositoryRules,
+    );
 
     const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
       config,
@@ -2217,7 +2226,10 @@ export class AgentOrchestrator {
       });
     }
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(
+      prDraft,
+      workspaceForArtifacts.repositoryRules,
+    );
 
     const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
       config: input.config,
@@ -3091,7 +3103,6 @@ export class AgentOrchestrator {
       input.issue,
       finalizedPrDraft,
       input.workspace.repositoryRules,
-      input.validationResults,
     );
     if (complianceFailures.length > 0) {
       ui.callout({
@@ -3208,14 +3219,14 @@ export class AgentOrchestrator {
     issue: RankedIssue,
     prDraft: PullRequestDraft,
     rules: RepoWorkspaceContext['repositoryRules'],
-    validationResults: TestResult[],
   ): string[] {
     if (!rules) {
       return [];
     }
 
     const failures = [...rules.blockingRequirements];
-    const body = `${prDraft.body || ''}\n${prDraft.summary}\n${prDraft.changes.join('\n')}\n${prDraft.validation.join('\n')}`.toLowerCase();
+    const body =
+      `${prDraft.body || ''}\n${prDraft.summary}\n${prDraft.changes.join('\n')}\n${prDraft.validation.join('\n')}`.toLowerCase();
 
     if (rules.allowsDraftPr === false) {
       failures.push('Repository rules do not encourage draft PRs for this workflow.');
@@ -3267,9 +3278,7 @@ export class AgentOrchestrator {
       rules.requiredChecklistItems.length > 0 &&
       !contentService.hasRequiredChecklistItems(prDraft.body || body, rules.requiredChecklistItems)
     ) {
-      failures.push(
-        `PR draft is missing required checklist items: ${rules.requiredChecklistItems.join(' | ')}`,
-      );
+      failures.push(`PR draft is missing required checklist items: ${rules.requiredChecklistItems.join(' | ')}`);
     }
 
     if (rules.requiredReleaseNotes) {

--- a/src/orchestration/agent.ts
+++ b/src/orchestration/agent.ts
@@ -426,9 +426,14 @@ export class AgentOrchestrator {
           },
           async () => llmService.generatePrDraft(syntheticIssue, patchDraft, workspaceForArtifacts),
         );
-        const prDraft = prDraftResult.data;
+        const prDraft = contentService.finalizePullRequestDraft(
+          prDraftResult.data,
+          syntheticIssue,
+          workspaceForArtifacts.repositoryRules,
+          implementation.validationResults,
+        );
         const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-        const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+        const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
         const contributionPullRequest = await ui.task(
           {
             title: 'Evaluating draft PR creation',
@@ -709,9 +714,14 @@ export class AgentOrchestrator {
       },
       async () => llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts),
     );
-    const prDraft = prDraftResult.data;
+    const prDraft = contentService.finalizePullRequestDraft(
+      prDraftResult.data,
+      selectedIssue,
+      workspaceForArtifacts.repositoryRules,
+      implementation.validationResults,
+    );
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
 
     const contributionPullRequest = await ui.task(
       {
@@ -1188,7 +1198,12 @@ export class AgentOrchestrator {
       },
       async () => llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts),
     );
-    const prDraft = prDraftResult.data;
+    const prDraft = contentService.finalizePullRequestDraft(
+      prDraftResult.data,
+      selectedIssue,
+      workspaceForArtifacts.repositoryRules,
+      implementation.validationResults,
+    );
     if (prDraftResult.status !== 'success') {
       this.showStructuredReviewNotice({
         title: 'PR narrative requires review',
@@ -1198,7 +1213,7 @@ export class AgentOrchestrator {
       });
     }
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
 
     const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
       config,
@@ -2187,7 +2202,12 @@ export class AgentOrchestrator {
       },
       async () => llmService.generatePrDraft(selectedIssue, patchDraft, workspaceForArtifacts),
     );
-    const prDraft = prDraftResult.data;
+    const prDraft = contentService.finalizePullRequestDraft(
+      prDraftResult.data,
+      selectedIssue,
+      workspaceForArtifacts.repositoryRules,
+      implementation.validationResults,
+    );
     if (prDraftResult.status !== 'success') {
       this.showStructuredReviewNotice({
         title: 'PR narrative requires review',
@@ -2197,7 +2217,7 @@ export class AgentOrchestrator {
       });
     }
     const patchDraftMarkdown = contentService.formatPatchDraftMarkdown(patchDraft);
-    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft);
+    const prDraftMarkdown = contentService.formatPullRequestDraftMarkdown(prDraft, workspaceForArtifacts.repositoryRules);
 
     const contributionPullRequest = await this.submitContributionPullRequestIfPossible({
       config: input.config,
@@ -3059,11 +3079,17 @@ export class AgentOrchestrator {
       };
     }
 
+    const finalizedPrDraft = contentService.finalizePullRequestDraft(
+      input.prDraft,
+      input.issue,
+      input.workspace.repositoryRules,
+      input.validationResults,
+    );
     const hasValidationFailures = input.validationResults.some((result) => !result.passed);
     const hasBlockingValidationFailures = this.hasBlockingValidationFailures(input.validationResults);
     const complianceFailures = this.evaluateRepositoryRuleCompliance(
       input.issue,
-      input.prDraft,
+      finalizedPrDraft,
       input.workspace.repositoryRules,
       input.validationResults,
     );
@@ -3139,7 +3165,7 @@ export class AgentOrchestrator {
     try {
       const contributionPullRequest = await contributionPrService.submitDraftPullRequest({
         issue: input.issue,
-        prDraft: input.prDraft,
+        prDraft: finalizedPrDraft,
         workspacePath: input.workspace.workspacePath,
         changedFiles: input.changedFiles,
         repositoryRules: input.workspace.repositoryRules,
@@ -3209,11 +3235,7 @@ export class AgentOrchestrator {
     }
 
     if (rules.requiredIssueLinking) {
-      const hasIssueReference =
-        body.includes(`#${issue.number}`.toLowerCase()) ||
-        body.includes(issue.htmlUrl.toLowerCase()) ||
-        body.includes(`${issue.repoFullName}#${issue.number}`.toLowerCase());
-      if (!hasIssueReference) {
+      if (!contentService.hasRequiredIssueLinking(prDraft.body || body, issue, rules.requiredIssueLinking)) {
         failures.push(`PR draft is missing the required issue linking format: ${rules.requiredIssueLinking}`);
       }
     }
@@ -3235,18 +3257,19 @@ export class AgentOrchestrator {
       const validationText = prDraft.validation.join('\n').toLowerCase();
       for (const note of rules.requiredValidationNotes) {
         const normalized = note.toLowerCase();
-        if (normalized.includes('test') && validationResults.length === 0) {
-          failures.push(`Repository expects validation notes such as "${note}" before opening a PR.`);
-          continue;
-        }
         if (normalized.length > 8 && !validationText.includes(normalized.slice(0, Math.min(24, normalized.length)))) {
           failures.push(`PR draft is missing required validation note: ${note}`);
         }
       }
     }
 
-    if (rules.requiredChecklistItems.length > 0 && !(prDraft.body || '').trim()) {
-      failures.push('Repository requires checklist items, but the PR draft did not preserve a template body.');
+    if (
+      rules.requiredChecklistItems.length > 0 &&
+      !contentService.hasRequiredChecklistItems(prDraft.body || body, rules.requiredChecklistItems)
+    ) {
+      failures.push(
+        `PR draft is missing required checklist items: ${rules.requiredChecklistItems.join(' | ')}`,
+      );
     }
 
     if (rules.requiredReleaseNotes) {

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -7,8 +7,8 @@ import type {
   MatchedIssue,
   ProofOfWorkRecord,
   RankedIssue,
-  RepositoryContributionRules,
   RepoMemory,
+  RepositoryContributionRules,
   RepoWorkspaceContext,
   TestResult,
 } from '../types/index.js';
@@ -50,7 +50,11 @@ export class ContentService {
     rules?: RepositoryContributionRules,
     validationResults: TestResult[] = [],
   ): PullRequestDraft {
-    const validation = this.mergeRequiredValidationNotes(draft.validation, rules?.requiredValidationNotes, validationResults);
+    const validation = this.mergeRequiredValidationNotes(
+      draft.validation,
+      rules?.requiredValidationNotes,
+      validationResults,
+    );
     let body = this.buildPullRequestDraftBody({ ...draft, validation }, rules);
 
     body = this.ensureChecklistItems(body, rules?.requiredChecklistItems);
@@ -264,11 +268,7 @@ export class ContentService {
       return body;
     }
 
-    return this.appendSection(
-      body,
-      'Checklist',
-      missingItems.map((item) => `- [ ] ${item}`).join('\n'),
-    );
+    return this.appendSection(body, 'Checklist', missingItems.map((item) => `- [ ] ${item}`).join('\n'));
   }
 
   private ensureIssueLinking(body: string, issue: RankedIssue, requirement?: string): string {

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -10,9 +10,61 @@ import type {
   RepositoryContributionRules,
   RepoMemory,
   RepoWorkspaceContext,
+  TestResult,
 } from '../types/index.js';
 
 export class ContentService {
+  hasRequiredChecklistItems(body: string, items: string[] | undefined): boolean {
+    const normalizedBody = body.toLowerCase();
+    return (items || []).every((item) => normalizedBody.includes(item.toLowerCase()));
+  }
+
+  hasRequiredIssueLinking(body: string, issue: RankedIssue, requirement?: string): boolean {
+    if (!requirement) {
+      return true;
+    }
+
+    const normalizedBody = body.toLowerCase();
+    if (issue.number <= 0) {
+      return normalizedBody.includes(issue.htmlUrl.toLowerCase());
+    }
+
+    const requiredKeyword = this.resolveIssueLinkKeyword(requirement);
+    if (requiredKeyword) {
+      return (
+        normalizedBody.includes(`${requiredKeyword} #${issue.number}`.toLowerCase()) ||
+        normalizedBody.includes(`${requiredKeyword} ${issue.repoFullName}#${issue.number}`.toLowerCase())
+      );
+    }
+
+    return (
+      normalizedBody.includes(issue.htmlUrl.toLowerCase()) ||
+      normalizedBody.includes(`#${issue.number}`.toLowerCase()) ||
+      normalizedBody.includes(`${issue.repoFullName}#${issue.number}`.toLowerCase())
+    );
+  }
+
+  finalizePullRequestDraft(
+    draft: PullRequestDraft,
+    issue: RankedIssue,
+    rules?: RepositoryContributionRules,
+    validationResults: TestResult[] = [],
+  ): PullRequestDraft {
+    const validation = this.mergeRequiredValidationNotes(draft.validation, rules?.requiredValidationNotes, validationResults);
+    let body = this.buildPullRequestDraftBody({ ...draft, validation }, rules);
+
+    body = this.ensureChecklistItems(body, rules?.requiredChecklistItems);
+    body = this.ensureIssueLinking(body, issue, rules?.requiredIssueLinking);
+    body = this.ensureValidationNotes(body, validation, rules?.requiredValidationNotes);
+    body = this.ensureReleaseNotes(body, draft, rules?.requiredReleaseNotes);
+
+    return {
+      ...draft,
+      validation,
+      body,
+    };
+  }
+
   generateResearchNote(issues: MatchedIssue[], reportContent: string): GeneratedContent {
     const title = `Daily Open Source Issue Research Notes - ${getLocalDateStamp()}`;
 
@@ -106,6 +158,10 @@ export class ContentService {
   }
 
   formatPullRequestDraftBody(draft: PullRequestDraft, rules?: RepositoryContributionRules): string {
+    return this.buildPullRequestDraftBody(draft, rules);
+  }
+
+  private buildPullRequestDraftBody(draft: PullRequestDraft, rules?: RepositoryContributionRules): string {
     if (draft.body?.trim()) {
       return draft.body.trim();
     }
@@ -169,6 +225,125 @@ export class ContentService {
     ensureSection('Risks', sections.risks);
 
     return output;
+  }
+
+  private mergeRequiredValidationNotes(
+    validation: string[],
+    requiredNotes: string[] | undefined,
+    validationResults: TestResult[],
+  ): string[] {
+    const merged = [...validation];
+
+    for (const note of requiredNotes || []) {
+      const normalizedNote = note.toLowerCase();
+      const alreadyPresent = merged.some((item) => item.toLowerCase().includes(normalizedNote));
+      if (alreadyPresent) {
+        continue;
+      }
+
+      const summary = this.describeValidationRequirement(validationResults);
+      merged.push(summary ? `${note}: ${summary}` : note);
+    }
+
+    return merged;
+  }
+
+  private describeValidationRequirement(validationResults: TestResult[]): string {
+    if (validationResults.length === 0) {
+      return 'not run in this automated pass';
+    }
+
+    return validationResults
+      .map((result) => `${result.command} ${result.passed ? 'passed' : `failed (${result.exitCode ?? 'n/a'})`}`)
+      .join('; ');
+  }
+
+  private ensureChecklistItems(body: string, items: string[] | undefined): string {
+    const missingItems = (items || []).filter((item) => !body.toLowerCase().includes(item.toLowerCase()));
+    if (missingItems.length === 0) {
+      return body;
+    }
+
+    return this.appendSection(
+      body,
+      'Checklist',
+      missingItems.map((item) => `- [ ] ${item}`).join('\n'),
+    );
+  }
+
+  private ensureIssueLinking(body: string, issue: RankedIssue, requirement?: string): string {
+    if (!requirement || this.hasRequiredIssueLinking(body, issue, requirement)) {
+      return body;
+    }
+
+    const issueReference = this.buildIssueLinkingSectionBody(issue, requirement);
+
+    return this.appendSection(body, 'Related Issue', issueReference);
+  }
+
+  private ensureValidationNotes(body: string, validation: string[], requiredNotes: string[] | undefined): string {
+    if ((requiredNotes || []).length === 0) {
+      return body;
+    }
+
+    const missingNotes = validation.filter((item) => !body.toLowerCase().includes(item.toLowerCase()));
+    if (missingNotes.length === 0) {
+      return body;
+    }
+
+    return this.appendSection(body, 'Validation Notes', missingNotes.map((item) => `- ${item}`).join('\n'));
+  }
+
+  private ensureReleaseNotes(body: string, draft: PullRequestDraft, requiredReleaseNotes?: boolean): string {
+    if (!requiredReleaseNotes || /release note|release-notes|changelog|breaking change/i.test(body)) {
+      return body;
+    }
+
+    const lines = [`- ${draft.summary}`];
+    if (draft.risks.length === 0) {
+      lines.push('- No breaking changes expected for this scoped fix.');
+    }
+
+    return this.appendSection(body, 'Release Notes', lines.join('\n'));
+  }
+
+  private appendSection(body: string, heading: string, sectionBody: string): string {
+    return `${body.trim()}\n\n## ${heading}\n\n${sectionBody}`.trim();
+  }
+
+  private buildIssueLinkingSectionBody(issue: RankedIssue, requirement?: string): string {
+    if (issue.number <= 0) {
+      return `- Related repository: ${issue.htmlUrl}`;
+    }
+
+    const requiredKeyword = this.resolveIssueLinkKeyword(requirement);
+    if (requiredKeyword) {
+      return `- ${this.capitalize(requiredKeyword)} ${issue.repoFullName}#${issue.number}\n- Link: ${issue.htmlUrl}`;
+    }
+
+    return `- Related issue: ${issue.repoFullName}#${issue.number}\n- Link: ${issue.htmlUrl}`;
+  }
+
+  private resolveIssueLinkKeyword(requirement?: string): string | null {
+    if (!requirement) {
+      return null;
+    }
+
+    const normalizedRequirement = requirement.toLowerCase();
+    if (/(close[sd]?|fix(?:e[sd])?|resolve[sd]?)/i.test(normalizedRequirement)) {
+      const match = normalizedRequirement.match(/(close[sd]?|fix(?:e[sd])?|resolve[sd]?)/i);
+      return match?.[1] || null;
+    }
+
+    if (/(ref(?:erence)?s?)/i.test(normalizedRequirement)) {
+      return 'refs';
+    }
+
+    return null;
+  }
+
+  private capitalize(value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1);
   }
 
   formatRepositoryAnalysisMarkdown(

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -7,6 +7,7 @@ import type {
   MatchedIssue,
   ProofOfWorkRecord,
   RankedIssue,
+  RepositoryContributionRules,
   RepoMemory,
   RepoWorkspaceContext,
 } from '../types/index.js';
@@ -104,7 +105,15 @@ export class ContentService {
     return lines.join('\n');
   }
 
-  formatPullRequestDraftBody(draft: PullRequestDraft): string {
+  formatPullRequestDraftBody(draft: PullRequestDraft, rules?: RepositoryContributionRules): string {
+    if (draft.body?.trim()) {
+      return draft.body.trim();
+    }
+
+    if (rules?.prTemplateBody?.trim()) {
+      return this.fillTemplateBody(rules.prTemplateBody, draft);
+    }
+
     const lines = [
       '## Summary',
       '',
@@ -127,8 +136,39 @@ export class ContentService {
     return lines.join('\n');
   }
 
-  formatPullRequestDraftMarkdown(draft: PullRequestDraft): string {
-    return [`Title: ${draft.title}`, '', this.formatPullRequestDraftBody(draft)].join('\n');
+  formatPullRequestDraftMarkdown(draft: PullRequestDraft, rules?: RepositoryContributionRules): string {
+    return [`Title: ${draft.title}`, '', this.formatPullRequestDraftBody(draft, rules)].join('\n');
+  }
+
+  private fillTemplateBody(template: string, draft: PullRequestDraft): string {
+    const sections = {
+      summary: draft.summary,
+      changes: draft.changes.map((change) => `- ${change}`).join('\n') || '- None',
+      validation: draft.validation.map((item) => `- ${item}`).join('\n') || '- Not run',
+      risks: draft.risks.map((item) => `- ${item}`).join('\n') || '- None',
+      issue: draft.summary,
+    };
+
+    let output = template.trim();
+    output = output.replace(/{{\s*summary\s*}}/gi, sections.summary);
+    output = output.replace(/{{\s*changes\s*}}/gi, sections.changes);
+    output = output.replace(/{{\s*validation\s*}}/gi, sections.validation);
+    output = output.replace(/{{\s*risks\s*}}/gi, sections.risks);
+    output = output.replace(/{{\s*issue\s*}}/gi, sections.issue);
+
+    const ensureSection = (heading: string, body: string) => {
+      if (new RegExp(`^##\\s+${heading}$`, 'im').test(output)) {
+        return;
+      }
+      output = `${output}\n\n## ${heading}\n\n${body}`.trim();
+    };
+
+    ensureSection('Summary', sections.summary);
+    ensureSection('Changes', sections.changes);
+    ensureSection('Validation', sections.validation);
+    ensureSection('Risks', sections.risks);
+
+    return output;
   }
 
   formatRepositoryAnalysisMarkdown(
@@ -311,6 +351,27 @@ export class ContentService {
           )
         : ['- Not executed']),
       '',
+      '## Repository Contribution Rules',
+      '',
+      ...(workspace.repositoryRules
+        ? [
+            `- Detected Files: ${workspace.repositoryRules.detectedFiles.join(', ') || 'none'}`,
+            `- Summary: ${workspace.repositoryRules.summary.join(' | ') || 'none'}`,
+            `- PR Title Rule: ${workspace.repositoryRules.prTitleRule || 'none'}`,
+            `- Commit Message Rule: ${workspace.repositoryRules.commitMessageRule || 'none'}`,
+            `- Branch Naming Rule: ${workspace.repositoryRules.branchNamingRule || 'none'}`,
+            `- Required Checklist: ${workspace.repositoryRules.requiredChecklistItems.join(' | ') || 'none'}`,
+            `- Required Validation Notes: ${workspace.repositoryRules.requiredValidationNotes.join(' | ') || 'none'}`,
+            `- Required Issue Linking: ${workspace.repositoryRules.requiredIssueLinking || 'none'}`,
+            `- Allows Draft PR: ${workspace.repositoryRules.allowsDraftPr === undefined ? 'unknown' : workspace.repositoryRules.allowsDraftPr ? 'yes' : 'no'}`,
+            `- Requires Prior Discussion: ${workspace.repositoryRules.requiresPriorDiscussion ? 'yes' : 'no'}`,
+            `- Required Release Notes: ${workspace.repositoryRules.requiredReleaseNotes ? 'yes' : 'no'}`,
+            `- Required Discussion Evidence: ${workspace.repositoryRules.requiredDiscussionEvidence ? 'yes' : 'no'}`,
+            `- Missing Requirements: ${workspace.repositoryRules.missingRequirements.join(' | ') || 'none'}`,
+            `- Blocking Requirements: ${workspace.repositoryRules.blockingRequirements.join(' | ') || 'none'}`,
+          ]
+        : ['- None detected']),
+      '',
       '## Repo Memory',
       '',
       `- Generated Dossiers: ${memory.generatedDossiers}`,
@@ -323,7 +384,7 @@ export class ContentService {
       '',
       '## PR Draft',
       '',
-      this.formatPullRequestDraftMarkdown(prDraft),
+      this.formatPullRequestDraftMarkdown(prDraft, workspace.repositoryRules),
       '',
       `_Generated at ${new Date().toISOString()}_`,
       '',

--- a/src/services/contribution-pr.ts
+++ b/src/services/contribution-pr.ts
@@ -82,15 +82,19 @@ export class ContributionPrService {
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '')
       .slice(0, 32);
-    const explicitPrefix = rules?.branchNamingRule?.match(/(feature|feat|fix|docs|chore|refactor|test)\//i)?.[0];
+    const branchRule = rules?.branchNamingRule;
+    const slashPrefix = branchRule?.match(/([a-z][a-z0-9_-]*)\//i)?.[0];
+    const keywordPrefix = branchRule?.match(/\b(feature|feat|fix|docs|chore|refactor|test|bugfix)\b/i)?.[0];
+    const explicitPrefix = slashPrefix || (keywordPrefix ? `${keywordPrefix.toLowerCase()}/` : undefined);
     const prefix = explicitPrefix || 'openmeta/agent-';
     return `${prefix}${issue.number}-${slug || 'issue'}-${Date.now()}`;
   }
 
   buildContributionCommitMessage(issue: RankedIssue, rules?: RepositoryContributionRules): string {
-    const conventionalType =
-      rules?.commitMessageRule?.match(/\b(feat|fix|docs|chore|refactor|test)(?:\([^)]+\))?:/i)?.[1] || 'feat';
-    return `${conventionalType}: address ${issue.repoFullName}#${issue.number} ${issue.title}`.slice(0, 120);
+    const conventionalHeader =
+      rules?.commitMessageRule?.match(/\b(feat|fix|docs|chore|refactor|test)(\([^)]+\))?:/i)?.[0] || 'feat:';
+    const header = conventionalHeader.endsWith(':') ? conventionalHeader.slice(0, -1) : conventionalHeader;
+    return `${header}: address ${issue.repoFullName}#${issue.number} ${issue.title}`.slice(0, 120);
   }
 
   private async getUpstreamRepositoryContext(issue: RankedIssue): Promise<ContributionRepositoryContext> {

--- a/src/services/contribution-pr.ts
+++ b/src/services/contribution-pr.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import type { PullRequestDraft } from '../contracts/index.js';
 import { logger } from '../infra/index.js';
-import type { RankedIssue } from '../types/index.js';
+import type { RankedIssue, RepositoryContributionRules } from '../types/index.js';
 import { contentService } from './content.js';
 import { githubService } from './github.js';
 
@@ -24,6 +24,7 @@ export interface ContributionPrSubmissionInput {
   prDraft: PullRequestDraft;
   workspacePath: string;
   changedFiles: string[];
+  repositoryRules?: RepositoryContributionRules;
 }
 
 export interface ContributionPrSubmissionResult {
@@ -42,9 +43,9 @@ export class ContributionPrService {
   async submitDraftPullRequest(input: ContributionPrSubmissionInput): Promise<ContributionPrSubmissionResult> {
     const upstreamRepo = await this.getUpstreamRepositoryContext(input.issue);
     const forkRepo = await this.ensureForkRepository(upstreamRepo);
-    const branchName = this.buildPublishBranchName(input.issue);
-    const draftPullRequest = this.buildDraftPullRequest(input.prDraft);
-    const commitMessage = this.buildContributionCommitMessage(input.issue);
+    const branchName = this.buildPublishBranchName(input.issue, input.repositoryRules);
+    const draftPullRequest = this.buildDraftPullRequest(input.prDraft, input.repositoryRules);
+    const commitMessage = this.buildContributionCommitMessage(input.issue, input.repositoryRules);
 
     await this.createCommitOnFork({
       forkRepo,
@@ -68,25 +69,28 @@ export class ContributionPrService {
     };
   }
 
-  buildDraftPullRequest(prDraft: PullRequestDraft): DraftPullRequest {
+  buildDraftPullRequest(prDraft: PullRequestDraft, repositoryRules?: RepositoryContributionRules): DraftPullRequest {
     return {
       title: prDraft.title,
-      body: contentService.formatPullRequestDraftBody(prDraft),
+      body: contentService.formatPullRequestDraftBody(prDraft, repositoryRules),
     };
   }
 
-  buildPublishBranchName(issue: RankedIssue): string {
+  buildPublishBranchName(issue: RankedIssue, rules?: RepositoryContributionRules): string {
     const slug = issue.title
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '')
       .slice(0, 32);
-
-    return `openmeta/agent-${issue.number}-${slug || 'issue'}-${Date.now()}`;
+    const explicitPrefix = rules?.branchNamingRule?.match(/(feature|feat|fix|docs|chore|refactor|test)\//i)?.[0];
+    const prefix = explicitPrefix || 'openmeta/agent-';
+    return `${prefix}${issue.number}-${slug || 'issue'}-${Date.now()}`;
   }
 
-  buildContributionCommitMessage(issue: RankedIssue): string {
-    return `feat: address ${issue.repoFullName}#${issue.number} ${issue.title}`.slice(0, 120);
+  buildContributionCommitMessage(issue: RankedIssue, rules?: RepositoryContributionRules): string {
+    const conventionalType =
+      rules?.commitMessageRule?.match(/\b(feat|fix|docs|chore|refactor|test)(?:\([^)]+\))?:/i)?.[1] || 'feat';
+    return `${conventionalType}: address ${issue.repoFullName}#${issue.number} ${issue.title}`.slice(0, 120);
   }
 
   private async getUpstreamRepositoryContext(issue: RankedIssue): Promise<ContributionRepositoryContext> {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -14,12 +14,12 @@ export { MemoryService, memoryService } from './memory.js';
 export { OpportunityService, opportunityService } from './opportunity.js';
 export { PermissionPolicyService, permissionPolicyService } from './permission-policy.js';
 export { ProofOfWorkService, proofOfWorkService } from './proof-of-work.js';
+export { RepositoryRulesService, repositoryRulesService } from './repository-rules.js';
 export {
   RepositoryTargetingService,
   type ResolvedRepositoryScope,
   repositoryTargetingService,
 } from './repository-targeting.js';
-export { RepositoryRulesService, repositoryRulesService } from './repository-rules.js';
 export { RunHistoryService, runHistoryService } from './run-history.js';
 export { type BinaryResolution, inspectBinaryOnPath } from './runtime-diagnostics.js';
 export type { SchedulerSyncResult } from './scheduler.js';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -19,6 +19,7 @@ export {
   type ResolvedRepositoryScope,
   repositoryTargetingService,
 } from './repository-targeting.js';
+export { RepositoryRulesService, repositoryRulesService } from './repository-rules.js';
 export { RunHistoryService, runHistoryService } from './run-history.js';
 export { type BinaryResolution, inspectBinaryOnPath } from './runtime-diagnostics.js';
 export type { SchedulerSyncResult } from './scheduler.js';

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import type { z } from 'zod';
+import { z } from 'zod';
 import {
   ImplementationDraftEnvelopeSchema,
   type IssueFeasibilityAssessment,
@@ -9,6 +9,7 @@ import {
   PatchDraftEnvelopeSchema,
   type PullRequestDraft,
   PullRequestDraftEnvelopeSchema,
+  RepositoryContributionRulesSchema,
   type RepositoryImprovementSuggestion,
   RepositorySuggestionListEnvelopeSchema,
   type StructuredOutputResult,
@@ -27,6 +28,7 @@ import {
   PATCH_DRAFT_PROMPT,
   PATCH_DRAFT_REPAIR_PROMPT,
   PR_DRAFT_PROMPT,
+  REPOSITORY_RULES_PROMPT,
   REPOSITORY_ANALYSIS_PROMPT,
   REPOSITORY_ANALYSIS_REPAIR_PROMPT,
   VALIDATION_REPAIR_PROMPT,
@@ -41,6 +43,7 @@ import type {
   RankedIssue,
   RepoFileSnippet,
   RepoMemory,
+  RepositoryRuleFile,
   RepoWorkspaceContext,
   TestResult,
   UserProfile,
@@ -195,6 +198,7 @@ Repo Stars: ${i.repoStars}`,
       issueContext: this.formatRankedIssue(issue),
       repoContext: contextAssemblerService.buildRepositoryContext(workspace),
       repoMemory: contextAssemblerService.buildRepoMemoryContext(memory),
+      repositoryRules: this.formatRepositoryRules(workspace.repositoryRules),
     });
 
     return this.generateStructuredOutput({
@@ -275,6 +279,7 @@ Repo Stars: ${i.repoStars}`,
       issueContext: this.formatRankedIssue(issue),
       patchDraft: JSON.stringify(patchDraft, null, 2),
       validationContext: contextAssemblerService.buildValidationContext(workspace),
+      repositoryRules: this.formatRepositoryRules(workspace.repositoryRules),
     });
 
     return this.generateStructuredOutput({
@@ -304,7 +309,20 @@ Repo Stars: ${i.repoStars}`,
     });
   }
 
-  private async chat(prompt: string, options: { temperature?: number } = {}): Promise<string> {
+  async extractRepositoryRules(repoFullName: string, files: RepositoryRuleFile[]) {
+    const prompt = fillPrompt(REPOSITORY_RULES_PROMPT, {
+      repoFullName,
+      ruleFiles:
+        files.length > 0
+          ? files.map((file) => `FILE: ${file.path}\n${file.content}`).join('\n\n')
+          : 'No repository rule files were provided.',
+    });
+
+    const content = await this.chat(prompt, { temperature: 0.1, jsonObject: true });
+    return this.parseStructuredJson(content, RepositoryContributionRulesSchema);
+  }
+
+  private async chat(prompt: string, options: { temperature?: number; jsonObject?: boolean } = {}): Promise<string> {
     if (!this.client) {
       throw new Error('LLM client not initialized');
     }
@@ -317,6 +335,7 @@ Repo Stars: ${i.repoStars}`,
           { role: 'user', content: prompt },
         ],
         temperature: options.temperature ?? 0.7,
+        ...(options.jsonObject ? this.getJsonObjectRequestParams() : {}),
         ...this.getStreamingRequestParams(),
         ...this.getReasoningRequestParams(),
       });
@@ -461,6 +480,18 @@ Repo Stars: ${i.repoStars}`,
     }
 
     return { reasoning_effort: this.reasoningEffort };
+  }
+
+  private getJsonObjectRequestParams(): { response_format?: { type: 'json_object' } } {
+    if (this.provider === 'gemini' || this.provider === 'claude') {
+      return {};
+    }
+
+    return {
+      response_format: {
+        type: 'json_object',
+      },
+    };
   }
 
   private getStreamingRequestParams(): { stream?: true; stream_options?: { include_usage: true } } {
@@ -611,6 +642,30 @@ Repo Stars: ${i.repoStars}`,
       `Missing Tools: ${missingTools || 'none detected'}`,
     ].join('\n');
   }
+
+  private formatRepositoryRules(rules?: RepoWorkspaceContext['repositoryRules']): string {
+    if (!rules) {
+      return 'No repository contribution rules were detected.';
+    }
+
+    return [
+      `Detected Files: ${rules.detectedFiles.join(', ') || 'none'}`,
+      `Summary: ${rules.summary.join(' | ') || 'none'}`,
+      `PR Title Rule: ${rules.prTitleRule || 'none'}`,
+      `Commit Message Rule: ${rules.commitMessageRule || 'none'}`,
+      `Branch Naming Rule: ${rules.branchNamingRule || 'none'}`,
+      `Required Checklist: ${rules.requiredChecklistItems.join(' | ') || 'none'}`,
+      `Required Validation Notes: ${rules.requiredValidationNotes.join(' | ') || 'none'}`,
+      `Required Issue Linking: ${rules.requiredIssueLinking || 'none'}`,
+      `Allows Draft PR: ${rules.allowsDraftPr === undefined ? 'unknown' : rules.allowsDraftPr ? 'yes' : 'no'}`,
+      `Requires Prior Discussion: ${rules.requiresPriorDiscussion ? 'yes' : 'no'}`,
+      `Required Release Notes: ${rules.requiredReleaseNotes ? 'yes' : 'no'}`,
+      `Required Discussion Evidence: ${rules.requiredDiscussionEvidence ? 'yes' : 'no'}`,
+      `Missing Requirements: ${rules.missingRequirements.join(' | ') || 'none'}`,
+      `Blocking Requirements: ${rules.blockingRequirements.join(' | ') || 'none'}`,
+    ].join('\n');
+  }
+
 
   private describeValidationError(error: unknown): string {
     if (this.isAbortError(error)) {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { z } from 'zod';
+import type { z } from 'zod';
 import {
   ImplementationDraftEnvelopeSchema,
   type IssueFeasibilityAssessment,
@@ -28,9 +28,9 @@ import {
   PATCH_DRAFT_PROMPT,
   PATCH_DRAFT_REPAIR_PROMPT,
   PR_DRAFT_PROMPT,
-  REPOSITORY_RULES_PROMPT,
   REPOSITORY_ANALYSIS_PROMPT,
   REPOSITORY_ANALYSIS_REPAIR_PROMPT,
+  REPOSITORY_RULES_PROMPT,
   VALIDATION_REPAIR_PROMPT,
 } from '../infra/prompt-templates.js';
 import type {
@@ -665,7 +665,6 @@ Repo Stars: ${i.repoStars}`,
       `Blocking Requirements: ${rules.blockingRequirements.join(' | ') || 'none'}`,
     ].join('\n');
   }
-
 
   private describeValidationError(error: unknown): string {
     if (this.isAbortError(error)) {

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -103,6 +103,7 @@ export class MemoryService {
         reviewRequired: issue.reviewRequired ?? false,
         status: issue.status ?? 'selected',
         validationSummary: issue.validationSummary ?? 'not run',
+        reviewReason: issue.reviewReason ?? '',
       })),
     };
   }
@@ -164,6 +165,7 @@ export class MemoryService {
     published: boolean;
     pullRequestUrl?: string;
     reviewRequired: boolean;
+    reviewReason?: string;
   }): RepoMemory {
     const current = this.load(input.issue.repoFullName);
     const now = new Date().toISOString();
@@ -213,6 +215,7 @@ export class MemoryService {
           reviewRequired: input.reviewRequired,
           validationSummary,
           pullRequestUrl: input.pullRequestUrl,
+          reviewReason: input.reviewReason,
         },
         ...current.recentIssues.filter((item) => item.reference !== issueReference),
       ].slice(0, 10),
@@ -291,7 +294,7 @@ export class MemoryService {
       ...(memory.recentIssues.length > 0
         ? memory.recentIssues.map(
             (issue) =>
-              `- ${issue.reference} | score ${issue.overallScore} | status ${issue.status} | changed ${issue.changedFiles.length} | published ${issue.published ? 'yes' : 'no'} | validation ${issue.validationSummary}`,
+              `- ${issue.reference} | score ${issue.overallScore} | status ${issue.status} | changed ${issue.changedFiles.length} | published ${issue.published ? 'yes' : 'no'} | validation ${issue.validationSummary}${issue.reviewReason ? ` | review ${issue.reviewReason}` : ''}`,
           )
         : ['- No issues recorded']),
       '',

--- a/src/services/proof-of-work.ts
+++ b/src/services/proof-of-work.ts
@@ -75,7 +75,7 @@ export class ProofOfWorkService {
             .slice(0, 10)
             .map(
               (record) =>
-                `- ${record.repoFullName}#${record.issueNumber} | overall ${record.overallScore} | published=${record.published}${record.pullRequestUrl ? ` | pr=${record.pullRequestUrl}` : ''}`,
+                `- ${record.repoFullName}#${record.issueNumber} | overall ${record.overallScore} | published=${record.published}${record.pullRequestUrl ? ` | pr=${record.pullRequestUrl}` : ''}${record.reviewReason ? ` | review=${record.reviewReason}` : ''}`,
             )
         : ['- No activity recorded']),
       '',

--- a/src/services/repository-rules.ts
+++ b/src/services/repository-rules.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { join, relative, resolve } from 'path';
 import type { RepositoryContributionRules as StructuredRepositoryContributionRules } from '../contracts/index.js';
 import { RepositoryContributionRulesSchema } from '../contracts/index.js';
@@ -157,7 +157,9 @@ export class RepositoryRulesService {
         raw.detectedFiles.length === currentEntries.length &&
         raw.detectedFiles.every((entry, index) => {
           const current = currentEntries[index];
-          return current && current.path === entry.path && current.mtimeMs === entry.mtimeMs && current.size === entry.size;
+          return (
+            current && current.path === entry.path && current.mtimeMs === entry.mtimeMs && current.size === entry.size
+          );
         });
       return matches ? raw : null;
     } catch (error) {

--- a/src/services/repository-rules.ts
+++ b/src/services/repository-rules.ts
@@ -1,0 +1,203 @@
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { join, relative, resolve } from 'path';
+import type { RepositoryContributionRules as StructuredRepositoryContributionRules } from '../contracts/index.js';
+import { RepositoryContributionRulesSchema } from '../contracts/index.js';
+import { ensureDirectory, getOpenMetaStateDir, logger } from '../infra/index.js';
+import type { RepositoryRuleFile, RepositoryRulesSnapshot } from '../types/index.js';
+import { llmService } from './llm.js';
+
+const RULE_CANDIDATE_PATHS = [
+  'CONTRIBUTING.md',
+  'contributing.md',
+  '.github/PULL_REQUEST_TEMPLATE.md',
+  '.github/pull_request_template.md',
+  'CODEOWNERS',
+  '.github/CODEOWNERS',
+  '.github/ISSUE_TEMPLATE/config.yml',
+  '.github/ISSUE_TEMPLATE/config.yaml',
+  '.github/ISSUE_TEMPLATE/bug_report.md',
+  '.github/ISSUE_TEMPLATE/feature_request.md',
+  '.github/ISSUE_TEMPLATE.md',
+  '.github/ISSUE_TEMPLATE.md',
+  '.github/DISCUSSION_TEMPLATE.md',
+  '.github/SECURITY.md',
+  '.github/SUPPORT.md',
+  'RELEASE.md',
+  'RELEASING.md',
+  'CHANGELOG.md',
+  'docs/release-notes.md',
+  'docs/release-note-policy.md',
+  'docs/pull_request_template.md',
+  'docs/pr-template.md',
+  'docs/discussion-policy.md',
+  'docs/CONTRIBUTING_GUIDE.md',
+  'docs/CONTRIBUTING.md',
+  'docs/contributing.md',
+];
+
+function sanitizeRepoName(repoFullName: string): string {
+  return repoFullName.replace(/\//g, '__');
+}
+
+function defaultRules(detectedFiles: string[] = []): StructuredRepositoryContributionRules {
+  return {
+    detectedFiles,
+    summary: detectedFiles.length > 0 ? [`Detected ${detectedFiles.length} contribution rule files.`] : [],
+    requiredChecklistItems: [],
+    requiredValidationNotes: [],
+    requiresPriorDiscussion: false,
+    missingRequirements: [],
+    blockingRequirements: [],
+    requiredReleaseNotes: false,
+    requiredDiscussionEvidence: false,
+  };
+}
+
+export class RepositoryRulesService {
+  private getCacheDir(): string {
+    return ensureDirectory(join(getOpenMetaStateDir(), 'cache', 'repository-rules'));
+  }
+
+  private getCachePath(repoFullName: string): string {
+    return join(this.getCacheDir(), `${sanitizeRepoName(repoFullName)}.json`);
+  }
+
+  async loadFromWorkspace(repoFullName: string, workspacePath: string): Promise<StructuredRepositoryContributionRules> {
+    const files = this.readRuleFiles(workspacePath);
+    if (files.length === 0) {
+      return defaultRules();
+    }
+
+    const cached = this.loadCachedRules(repoFullName, files, workspacePath);
+    if (cached) {
+      return cached.rules;
+    }
+
+    try {
+      const extracted = await llmService.extractRepositoryRules(repoFullName, files);
+      const parsed = RepositoryContributionRulesSchema.parse(extracted);
+      const normalized = {
+        ...defaultRules(files.map((file) => file.path)),
+        ...parsed,
+        detectedFiles: parsed.detectedFiles.length > 0 ? parsed.detectedFiles : files.map((file) => file.path),
+      };
+      this.saveCachedRules(repoFullName, workspacePath, files, normalized);
+      return normalized;
+    } catch (error) {
+      logger.debug(`Repository rules extraction failed for ${repoFullName}`, error);
+      const fallback = defaultRules(files.map((file) => file.path));
+      fallback.summary.push('Rule extraction fell back to file discovery only.');
+      this.saveCachedRules(repoFullName, workspacePath, files, fallback);
+      return fallback;
+    }
+  }
+
+  private readRuleFiles(workspacePath: string): RepositoryRuleFile[] {
+    const root = resolve(workspacePath);
+    const discovered = new Map<string, RepositoryRuleFile>();
+
+    for (const candidate of RULE_CANDIDATE_PATHS) {
+      const target = join(root, candidate);
+      if (!existsSync(target)) {
+        continue;
+      }
+      discovered.set(candidate, {
+        path: candidate,
+        content: readFileSync(target, 'utf-8').slice(0, 32_000),
+      });
+    }
+
+    const templateDir = join(root, '.github', 'PULL_REQUEST_TEMPLATE');
+    if (existsSync(templateDir)) {
+      for (const entry of readdirSync(templateDir)) {
+        const fullPath = join(templateDir, entry);
+        if (!statSync(fullPath).isFile()) {
+          continue;
+        }
+        const relPath = relative(root, fullPath).replace(/\\/g, '/');
+        discovered.set(relPath, {
+          path: relPath,
+          content: readFileSync(fullPath, 'utf-8').slice(0, 32_000),
+        });
+      }
+    }
+
+    const issueTemplateDir = join(root, '.github', 'ISSUE_TEMPLATE');
+    if (existsSync(issueTemplateDir)) {
+      for (const entry of readdirSync(issueTemplateDir)) {
+        const fullPath = join(issueTemplateDir, entry);
+        if (!statSync(fullPath).isFile()) {
+          continue;
+        }
+        const relPath = relative(root, fullPath).replace(/\\/g, '/');
+        discovered.set(relPath, {
+          path: relPath,
+          content: readFileSync(fullPath, 'utf-8').slice(0, 32_000),
+        });
+      }
+    }
+
+    return [...discovered.values()];
+  }
+
+  private loadCachedRules(
+    repoFullName: string,
+    files: RepositoryRuleFile[],
+    workspacePath: string,
+  ): RepositoryRulesSnapshot | null {
+    const cachePath = this.getCachePath(repoFullName);
+    if (!existsSync(cachePath)) {
+      return null;
+    }
+
+    try {
+      const raw = JSON.parse(readFileSync(cachePath, 'utf-8')) as RepositoryRulesSnapshot;
+      const currentEntries = this.buildFileEntries(files, workspacePath);
+      const matches =
+        raw.detectedFiles.length === currentEntries.length &&
+        raw.detectedFiles.every((entry, index) => {
+          const current = currentEntries[index];
+          return current && current.path === entry.path && current.mtimeMs === entry.mtimeMs && current.size === entry.size;
+        });
+      return matches ? raw : null;
+    } catch (error) {
+      logger.debug('Unable to read repository rules cache', error);
+      return null;
+    }
+  }
+
+  private saveCachedRules(
+    repoFullName: string,
+    workspacePath: string,
+    files: RepositoryRuleFile[],
+    rules: StructuredRepositoryContributionRules,
+  ): void {
+    const payload: RepositoryRulesSnapshot = {
+      repoFullName,
+      cacheKey: files.map((file) => file.path).join('|'),
+      cachedAt: new Date().toISOString(),
+      detectedFiles: this.buildFileEntries(files, workspacePath),
+      rules,
+    };
+
+    try {
+      writeFileSync(this.getCachePath(repoFullName), JSON.stringify(payload, null, 2), 'utf-8');
+    } catch (error) {
+      logger.debug('Unable to save repository rules cache', error);
+    }
+  }
+
+  private buildFileEntries(files: RepositoryRuleFile[], workspacePath: string) {
+    const root = resolve(workspacePath);
+    return files.map((file) => {
+      const stat = statSync(join(root, file.path));
+      return {
+        path: file.path,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      };
+    });
+  }
+}
+
+export const repositoryRulesService = new RepositoryRulesService();

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -579,7 +579,6 @@ export class WorkspaceService {
         }
 
         files.push(normalizeRepoRelativePath(relative(root, join(current, entry.name))));
-        files.push(normalizeRepoRelativePath(relative(root, join(current, entry.name))));
         if (files.length >= MAX_DISCOVERED_FILES) {
           break;
         }

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -15,6 +15,7 @@ import type {
   TestResult,
 } from '../types/index.js';
 import { permissionPolicyService } from './permission-policy.js';
+import { repositoryRulesService } from './repository-rules.js';
 
 const EXCLUDED_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.next', 'coverage', 'target', 'vendor']);
 
@@ -89,6 +90,7 @@ export class WorkspaceService {
       candidateFiles,
       runChecks,
       executionMode,
+      repoFullName: issue.repoFullName,
     });
   }
 
@@ -117,6 +119,7 @@ export class WorkspaceService {
       branchName: workspaceState.branchName,
       runChecks,
       executionMode,
+      repoFullName,
     });
   }
 
@@ -492,7 +495,8 @@ export class WorkspaceService {
     return 'main';
   }
 
-  private buildWorkspaceContext(input: {
+  private async buildWorkspaceContext(input: {
+    repoFullName: string;
     workspacePath: string;
     workspaceDirty: boolean;
     defaultBranch: string;
@@ -500,7 +504,7 @@ export class WorkspaceService {
     candidateFiles: string[];
     runChecks: boolean;
     executionMode: ExecutionMode;
-  }): RepoWorkspaceContext {
+  }): Promise<RepoWorkspaceContext> {
     const topLevelFiles = readdirSync(input.workspacePath).slice(0, 50);
     const snippets = input.candidateFiles.map((path) => ({
       path,
@@ -511,6 +515,7 @@ export class WorkspaceService {
       testCommands,
       input.executionMode,
     );
+    const repositoryRules = await repositoryRulesService.loadFromWorkspace(input.repoFullName, input.workspacePath);
     const testResults = input.runChecks
       ? this.runTestCommands(input.workspacePath, validationCommands.slice(0, 3))
       : [];
@@ -527,6 +532,7 @@ export class WorkspaceService {
       validationCommands,
       validationWarnings,
       testResults,
+      repositoryRules,
     };
   }
 
@@ -572,6 +578,7 @@ export class WorkspaceService {
           continue;
         }
 
+        files.push(normalizeRepoRelativePath(relative(root, join(current, entry.name))));
         files.push(normalizeRepoRelativePath(relative(root, join(current, entry.name))));
         if (files.length >= MAX_DISCOVERED_FILES) {
           break;

--- a/src/types/agent.types.ts
+++ b/src/types/agent.types.ts
@@ -63,6 +63,41 @@ export interface RepoFileSnippet {
   content: string;
 }
 
+export interface RepositoryRuleFile {
+  path: string;
+  content: string;
+}
+
+export interface RepositoryContributionRules {
+  detectedFiles: string[];
+  summary: string[];
+  prTemplateBody?: string;
+  prTitleRule?: string;
+  commitMessageRule?: string;
+  branchNamingRule?: string;
+  requiredChecklistItems: string[];
+  requiredValidationNotes: string[];
+  requiredIssueLinking?: string;
+  allowsDraftPr?: boolean;
+  requiresPriorDiscussion: boolean;
+  missingRequirements: string[];
+  blockingRequirements: string[];
+  requiredReleaseNotes: boolean;
+  requiredDiscussionEvidence: boolean;
+}
+
+export interface RepositoryRulesSnapshot {
+  repoFullName: string;
+  cacheKey: string;
+  cachedAt: string;
+  detectedFiles: Array<{
+    path: string;
+    mtimeMs: number;
+    size: number;
+  }>;
+  rules: RepositoryContributionRules;
+}
+
 export interface GeneratedFileChange {
   path: string;
   reason: string;
@@ -98,6 +133,7 @@ export interface RepoWorkspaceContext {
   validationCommands: TestCommand[];
   validationWarnings: string[];
   testResults: TestResult[];
+  repositoryRules?: RepositoryContributionRules;
 }
 
 export interface RepoMemoryIssueRecord {
@@ -111,6 +147,7 @@ export interface RepoMemoryIssueRecord {
   reviewRequired: boolean;
   validationSummary: string;
   pullRequestUrl?: string;
+  reviewReason?: string;
 }
 
 export interface RepoMemoryRunStats {
@@ -183,6 +220,7 @@ export interface ProofOfWorkRecord {
   published: boolean;
   pullRequestUrl?: string;
   pullRequestNumber?: number;
+  reviewReason?: string;
 }
 
 export interface ContributionArtifacts {

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -63,6 +63,7 @@ interface AgentOrchestratorInternals {
     number?: number;
     changedFiles: string[];
     validationResults: TestResult[];
+    reviewReason?: string;
   }>;
   publishArtifactsIfNeeded(input: {
     config: AppConfig;

--- a/test/agent-orchestrator.test.ts
+++ b/test/agent-orchestrator.test.ts
@@ -30,6 +30,7 @@ import {
   createProofRecord,
   createPullRequestDraft,
   createRankedIssue,
+  createRepositoryRules,
   createWorkspace,
 } from './helpers/factories.js';
 
@@ -525,7 +526,13 @@ describe('AgentOrchestrator support behavior', () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
     const issue = createRankedIssue();
     const prDraft = createPullRequestDraft();
-    const workspace = createWorkspace();
+    const workspace = createWorkspace({
+      repositoryRules: createRepositoryRules({
+        requiredIssueLinking: undefined,
+        requiredValidationNotes: [],
+        requiredChecklistItems: [],
+      }),
+    });
 
     const headlessBlocked = await orchestrator.submitContributionPullRequestIfPossible({
       config: createConfig(),
@@ -574,7 +581,13 @@ describe('AgentOrchestrator support behavior', () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentOrchestratorInternals;
     const issue = createRankedIssue();
     const prDraft = createPullRequestDraft();
-    const workspace = createWorkspace();
+    const workspace = createWorkspace({
+      repositoryRules: createRepositoryRules({
+        requiredIssueLinking: undefined,
+        requiredValidationNotes: [],
+        requiredChecklistItems: [],
+      }),
+    });
     spyOn(infra, 'prompt').mockResolvedValue({ confirmPr: true });
 
     const submitSpy = spyOn(contributionPrService, 'submitDraftPullRequest')

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -63,6 +63,7 @@ interface AgentRunInternals {
     number?: number;
     changedFiles: string[];
     validationResults: ReturnType<typeof createWorkspace>['testResults'];
+    reviewReason?: string;
   }>;
   publishArtifactsIfNeeded(input: unknown): Promise<{ published: boolean }>;
   prepareLocalArtifactPaths(issue: RankedIssue): ContributionAgentResult['artifacts'];

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -4,6 +4,7 @@ import { AgentOrchestrator } from '../src/orchestration/agent.js';
 import { AnalyzeOrchestrator } from '../src/orchestration/analyze.js';
 import {
   contentService,
+  contributionPrService,
   inboxService,
   issueRankingService,
   llmService,
@@ -352,7 +353,7 @@ describe('AgentOrchestrator run flow', () => {
 
     expect(result.url).toBeUndefined();
     expect(calloutSpy).toHaveBeenCalled();
-    expect(result.reviewReason).toContain('issue linking');
+    expect(result.reviewReason).toContain('associated issue link');
   });
 
   test('blocks PR creation when repository requires prior discussion evidence and none is present', async () => {
@@ -381,8 +382,13 @@ describe('AgentOrchestrator run flow', () => {
     expect(result.reviewReason).toContain('prior discussion');
   });
 
-  test('blocks PR creation when repository requires issue linking and release notes that the draft does not provide', async () => {
+  test('auto-fills issue linking and release notes before creating a PR when repository rules require them', async () => {
     const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+    const submitSpy = spyOn(contributionPrService, 'submitDraftPullRequest').mockResolvedValue({
+      branchName: 'openmeta/agent-42',
+      url: 'https://github.com/acme/demo/pull/42',
+      number: 42,
+    });
 
     const result = await orchestrator.submitContributionPullRequestIfPossible({
       config: createConfig(),
@@ -403,9 +409,59 @@ describe('AgentOrchestrator run flow', () => {
       validationResults: [{ command: 'bun test', exitCode: 0, passed: true, output: 'ok' }],
     });
 
-    expect(result.url).toBeUndefined();
-    expect(result.reviewReason).toContain('issue linking');
-    expect(result.reviewReason).toContain('release note');
+    expect(result.url).toBe('https://github.com/acme/demo/pull/42');
+    expect(submitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prDraft: expect.objectContaining({
+          body: expect.stringContaining('## Related Issue'),
+        }),
+      }),
+    );
+    expect(submitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prDraft: expect.objectContaining({
+          body: expect.stringContaining('## Release Notes'),
+        }),
+      }),
+    );
+  });
+
+  test('auto-fills required checklist items into the finalized PR body before PR submission', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+    const submitSpy = spyOn(contributionPrService, 'submitDraftPullRequest').mockResolvedValue({
+      branchName: 'openmeta/agent-42',
+      url: 'https://github.com/acme/demo/pull/42',
+      number: 42,
+    });
+
+    const result = await orchestrator.submitContributionPullRequestIfPossible({
+      config: createConfig(),
+      allowRealPr: true,
+      headless: true,
+      issue: createRankedIssue(),
+      prDraft: createPullRequestDraft({
+        body: '## Summary\n\nAccessibility fix only.',
+      }),
+      workspace: createWorkspace({
+        repositoryRules: createRepositoryRules({
+          prTemplateBody: undefined,
+          requiredChecklistItems: ['Sign off from maintainer'],
+          requiredIssueLinking: undefined,
+          requiredValidationNotes: [],
+        }),
+      }),
+      changedFiles: ['src/components/IconButton.tsx'],
+      validationResults: [],
+    });
+
+    expect(result.url).toBe('https://github.com/acme/demo/pull/42');
+    expect(submitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prDraft: expect.objectContaining({
+          body: expect.stringContaining('Sign off from maintainer'),
+        }),
+      }),
+    );
   });
 
   test('blocks PR creation when repository requires a conventional PR title and the draft title does not match', async () => {
@@ -555,7 +611,10 @@ describe('AgentOrchestrator run flow', () => {
         issue,
         workspace: expect.objectContaining({ workspacePath: workspace.workspacePath }),
         patchDraft,
-        prDraft,
+        prDraft: expect.objectContaining({
+          title: prDraft.title,
+          summary: prDraft.summary,
+        }),
         pullRequestUrl: 'https://github.com/acme/demo/pull/42',
         changedFiles: ['src/app.ts'],
       }),

--- a/test/agent-run.test.ts
+++ b/test/agent-run.test.ts
@@ -19,6 +19,7 @@ import {
   createProofRecord,
   createPullRequestDraft,
   createRankedIssue,
+  createRepositoryRules,
   createRepositorySuggestion,
   createWorkspace,
 } from './helpers/factories.js';
@@ -328,6 +329,109 @@ describe('AgentOrchestrator run flow', () => {
       'No issue met the automation threshold',
       'Top opportunities were below 75/100. Lower the threshold or widen your profile.',
     );
+  });
+
+  test('keeps the run in artifact mode when repository rules block automatic PR creation', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+    const calloutSpy = spyOn(infra.ui, 'callout').mockImplementation(() => {});
+
+    const result = await orchestrator.submitContributionPullRequestIfPossible({
+      config: createConfig(),
+      allowRealPr: true,
+      headless: true,
+      issue: createRankedIssue(),
+      prDraft: createPullRequestDraft(),
+      workspace: createWorkspace({
+        repositoryRules: createRepositoryRules({
+          blockingRequirements: ['Repository requires an associated issue link before raising a PR.'],
+        }),
+      }),
+      changedFiles: ['src/components/IconButton.tsx'],
+      validationResults: [],
+    });
+
+    expect(result.url).toBeUndefined();
+    expect(calloutSpy).toHaveBeenCalled();
+    expect(result.reviewReason).toContain('issue linking');
+  });
+
+  test('blocks PR creation when repository requires prior discussion evidence and none is present', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+
+    const result = await orchestrator.submitContributionPullRequestIfPossible({
+      config: createConfig(),
+      allowRealPr: true,
+      headless: true,
+      issue: createRankedIssue({ body: 'Bug report without maintainer discussion.' }),
+      prDraft: createPullRequestDraft(),
+      workspace: createWorkspace({
+        repositoryRules: createRepositoryRules({
+          requiredIssueLinking: undefined,
+          requiredValidationNotes: [],
+          requiredChecklistItems: [],
+          requiresPriorDiscussion: true,
+          requiredDiscussionEvidence: true,
+        }),
+      }),
+      changedFiles: ['src/components/IconButton.tsx'],
+      validationResults: [],
+    });
+
+    expect(result.url).toBeUndefined();
+    expect(result.reviewReason).toContain('prior discussion');
+  });
+
+  test('blocks PR creation when repository requires issue linking and release notes that the draft does not provide', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+
+    const result = await orchestrator.submitContributionPullRequestIfPossible({
+      config: createConfig(),
+      allowRealPr: true,
+      headless: true,
+      issue: createRankedIssue(),
+      prDraft: createPullRequestDraft({
+        body: '## Summary\n\nAccessibility fix only.',
+        validation: ['bun test passed'],
+      }),
+      workspace: createWorkspace({
+        repositoryRules: createRepositoryRules({
+          requiredIssueLinking: 'Reference the GitHub issue in the PR body.',
+          requiredReleaseNotes: true,
+        }),
+      }),
+      changedFiles: ['src/components/IconButton.tsx'],
+      validationResults: [{ command: 'bun test', exitCode: 0, passed: true, output: 'ok' }],
+    });
+
+    expect(result.url).toBeUndefined();
+    expect(result.reviewReason).toContain('issue linking');
+    expect(result.reviewReason).toContain('release note');
+  });
+
+  test('blocks PR creation when repository requires a conventional PR title and the draft title does not match', async () => {
+    const orchestrator = new AgentOrchestrator() as unknown as AgentRunInternals;
+
+    const result = await orchestrator.submitContributionPullRequestIfPossible({
+      config: createConfig(),
+      allowRealPr: true,
+      headless: true,
+      issue: createRankedIssue(),
+      prDraft: createPullRequestDraft({
+        title: 'Add aria-label handling to icon-only buttons',
+      }),
+      workspace: createWorkspace({
+        repositoryRules: createRepositoryRules({
+          prTitleRule: 'Use conventional commit style titles such as fix(scope): ...',
+          requiredIssueLinking: undefined,
+          requiredValidationNotes: [],
+        }),
+      }),
+      changedFiles: ['src/components/IconButton.tsx'],
+      validationResults: [],
+    });
+
+    expect(result.url).toBeUndefined();
+    expect(result.reviewReason).toContain('PR title');
   });
 
   test('runs the full interactive flow and records a published outcome', async () => {

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -140,7 +140,8 @@ describe('contentService', () => {
     );
 
     expect(finalized.body).toContain('Fixes acme/demo#42');
-    expect(contentService.hasRequiredIssueLinking(finalized.body, issue, 'Use Fixes #123 in the PR body.')).toBe(true);
+    expect(finalized.body).toBeDefined();
+    expect(contentService.hasRequiredIssueLinking(finalized.body!, issue, 'Use Fixes #123 in the PR body.')).toBe(true);
   });
 
   test('finalizes PR drafts for synthetic repository suggestions without fake issue numbers', () => {

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -8,6 +8,7 @@ import {
   createProofRecord,
   createPullRequestDraft,
   createRankedIssue,
+  createRepositoryRules,
   createRepositorySuggestion,
   createWorkspace,
 } from './helpers/factories.js';
@@ -40,6 +41,10 @@ describe('contentService', () => {
     expect(markdown).toContain('- `bun test` | Detected Bun tests | repo-script');
     expect(markdown).toContain('## Runnable Validation Commands');
     expect(markdown).toContain('## Validation Safety Notes');
+    expect(markdown).toContain('## Repository Contribution Rules');
+    expect(markdown).toContain('- PR Title Rule: Use a concise imperative title.');
+    expect(markdown).toContain('- Required Release Notes: no');
+    expect(markdown).toContain('- Required Discussion Evidence: no');
     expect(markdown).toContain('## Patch Draft');
     expect(markdown).toContain('## Goal');
     expect(markdown).toContain('Add accessible labels to icon-only buttons');
@@ -63,6 +68,37 @@ describe('contentService', () => {
     expect(markdown).toContain('## Summary');
     expect(markdown).toContain('## Changes');
     expect(markdown).toContain('## Validation');
+  });
+
+  test('uses template body when the PR draft already contains one', () => {
+    const markdown = contentService.formatPullRequestDraftBody(
+      createPullRequestDraft({
+        body: '## Template\n\n- [x] Linked issue',
+      }),
+    );
+
+    expect(markdown).toBe('## Template\n\n- [x] Linked issue');
+  });
+
+  test('fills repository PR template bodies when the draft body is absent', () => {
+    const markdown = contentService.formatPullRequestDraftBody(
+      createPullRequestDraft({
+        summary: 'Fix keyboard navigation for the settings menu.',
+        changes: ['Update menu focus management'],
+        validation: ['bun test'],
+        risks: ['Keyboard snapshots may change'],
+      }),
+      createRepositoryRules({
+        prTemplateBody: '## Summary\n\n{{summary}}\n\n## Changes\n\n{{changes}}\n\n## Validation\n\n{{validation}}',
+      }),
+    );
+
+    expect(markdown).toContain('## Summary');
+    expect(markdown).toContain('Fix keyboard navigation for the settings menu.');
+    expect(markdown).toContain('- Update menu focus management');
+    expect(markdown).toContain('- bun test');
+    expect(markdown).toContain('## Risks');
+    expect(markdown).toContain('- Keyboard snapshots may change');
   });
 
   test('formats repository analysis suggestions as markdown', () => {

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -101,6 +101,67 @@ describe('contentService', () => {
     expect(markdown).toContain('- Keyboard snapshots may change');
   });
 
+  test('finalizes PR drafts with required issue links, validation notes, and release notes', () => {
+    const issue = createRankedIssue();
+    const finalized = contentService.finalizePullRequestDraft(
+      createPullRequestDraft({
+        body: '## Summary\n\nAccessibility fix only.',
+        validation: [],
+        risks: [],
+      }),
+      issue,
+      createRepositoryRules({
+        requiredIssueLinking: 'Reference the GitHub issue in the PR body.',
+        requiredValidationNotes: ['Mention whether bun test passed'],
+        requiredReleaseNotes: true,
+      }),
+      [{ command: 'bun test', exitCode: 0, passed: true, output: 'ok' }],
+    );
+
+    expect(finalized.validation).toContain('Mention whether bun test passed: bun test passed');
+    expect(finalized.body).toContain('## Related Issue');
+    expect(finalized.body).toContain('acme/demo#42');
+    expect(finalized.body).toContain('https://github.com/acme/demo/issues/42');
+    expect(finalized.body).toContain('## Validation Notes');
+    expect(finalized.body).toContain('Mention whether bun test passed: bun test passed');
+    expect(finalized.body).toContain('## Release Notes');
+  });
+
+  test('finalizes PR drafts with explicit closing issue format when required', () => {
+    const issue = createRankedIssue();
+    const finalized = contentService.finalizePullRequestDraft(
+      createPullRequestDraft({
+        body: '## Summary\n\nAccessibility fix only.',
+      }),
+      issue,
+      createRepositoryRules({
+        requiredIssueLinking: 'Use Fixes #123 in the PR body.',
+      }),
+    );
+
+    expect(finalized.body).toContain('Fixes acme/demo#42');
+    expect(contentService.hasRequiredIssueLinking(finalized.body, issue, 'Use Fixes #123 in the PR body.')).toBe(true);
+  });
+
+  test('finalizes PR drafts for synthetic repository suggestions without fake issue numbers', () => {
+    const finalized = contentService.finalizePullRequestDraft(
+      createPullRequestDraft({
+        body: '## Summary\n\nRepository improvement.',
+      }),
+      createRankedIssue({
+        number: 0,
+        htmlUrl: 'https://github.com/acme/demo',
+      }),
+      createRepositoryRules({
+        requiredIssueLinking: 'Link the related issue or repository context in the PR body.',
+      }),
+    );
+
+    expect(finalized.body).toContain('## Related Issue');
+    expect(finalized.body).toContain('https://github.com/acme/demo');
+    expect(finalized.body).not.toContain('acme/demo#0');
+  });
+
   test('formats repository analysis suggestions as markdown', () => {
     const selectedSuggestion = createRepositorySuggestion({
       id: 'config-validation',

--- a/test/contribution-pr.test.ts
+++ b/test/contribution-pr.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ContributionPrService, contributionPrService, githubService } from '../src/services/index.js';
-import { createPullRequestDraft, createRankedIssue } from './helpers/factories.js';
+import { createPullRequestDraft, createRankedIssue, createRepositoryRules } from './helpers/factories.js';
 
 interface ContributionPrInternals {
   initialize(octokit: unknown): void;
@@ -12,6 +12,7 @@ interface ContributionPrInternals {
     prDraft: ReturnType<typeof createPullRequestDraft>;
     workspacePath: string;
     changedFiles: string[];
+    repositoryRules?: ReturnType<typeof createRepositoryRules>;
   }): Promise<{
     branchName: string;
     url: string;
@@ -39,6 +40,23 @@ describe('ContributionPrService', () => {
     expect(parsed.body).not.toContain('Title:');
   });
 
+  test('uses repository PR templates when building the pull request payload', () => {
+    const parsed = contributionPrService.buildDraftPullRequest(
+      createPullRequestDraft({
+        summary: 'Tighten keyboard accessibility around dialogs.',
+        changes: ['Update dialog focus trapping'],
+        validation: ['bun test'],
+      }),
+      createRepositoryRules({
+        prTemplateBody: '## Summary\n\n{{summary}}\n\n## Validation\n\n{{validation}}',
+      }),
+    );
+
+    expect(parsed.body).toContain('Tighten keyboard accessibility around dialogs.');
+    expect(parsed.body).toContain('- bun test');
+    expect(parsed.body).toContain('## Changes');
+  });
+
   test('builds bounded branch names and commit messages for generated contribution PRs', () => {
     const issue = createRankedIssue({
       repoFullName: 'acme/widgets',
@@ -46,11 +64,17 @@ describe('ContributionPrService', () => {
       title: 'Fix keyboard focus in icon-only widgets with an intentionally long title',
     });
 
-    const branchName = contributionPrService.buildPublishBranchName(issue);
-    const commitMessage = contributionPrService.buildContributionCommitMessage(issue);
+    const branchName = contributionPrService.buildPublishBranchName(
+      issue,
+      createRepositoryRules({ branchNamingRule: 'Use fix/... branch names for bug fixes.' }),
+    );
+    const commitMessage = contributionPrService.buildContributionCommitMessage(
+      issue,
+      createRepositoryRules({ commitMessageRule: 'Use fix: for bug-fix commits.' }),
+    );
 
-    expect(branchName).toMatch(/^openmeta\/agent-42-fix-keyboard-focus-in-icon-only-+\d+$/);
-    expect(commitMessage).toStartWith('feat: address acme/widgets#42 Fix keyboard focus');
+    expect(branchName).toMatch(/^fix\/42-fix-keyboard-focus-in-icon-only-+\d+$/);
+    expect(commitMessage).toStartWith('fix: address acme/widgets#42 Fix keyboard focus');
     expect(commitMessage.length).toBeLessThanOrEqual(120);
   });
 

--- a/test/contribution-pr.test.ts
+++ b/test/contribution-pr.test.ts
@@ -57,6 +57,35 @@ describe('ContributionPrService', () => {
     expect(parsed.body).toContain('## Changes');
   });
 
+  test('preserves finalized repository rule sections in the pull request payload', () => {
+    const parsed = contributionPrService.buildDraftPullRequest(
+      createPullRequestDraft({
+        body: [
+          '## Summary',
+          '',
+          'Accessibility fix only.',
+          '',
+          '## Related Issue',
+          '',
+          '- Related issue: acme/demo#42',
+          '- Link: https://github.com/acme/demo/issues/42',
+          '',
+          '## Release Notes',
+          '',
+          '- Accessibility fix only.',
+        ].join('\n'),
+      }),
+      createRepositoryRules({
+        requiredIssueLinking: 'Reference the GitHub issue in the PR body.',
+        requiredReleaseNotes: true,
+      }),
+    );
+
+    expect(parsed.body).toContain('## Related Issue');
+    expect(parsed.body).toContain('acme/demo#42');
+    expect(parsed.body).toContain('## Release Notes');
+  });
+
   test('builds bounded branch names and commit messages for generated contribution PRs', () => {
     const issue = createRankedIssue({
       repoFullName: 'acme/widgets',
@@ -76,6 +105,26 @@ describe('ContributionPrService', () => {
     expect(branchName).toMatch(/^fix\/42-fix-keyboard-focus-in-icon-only-+\d+$/);
     expect(commitMessage).toStartWith('fix: address acme/widgets#42 Fix keyboard focus');
     expect(commitMessage.length).toBeLessThanOrEqual(120);
+  });
+
+  test('reuses scoped commit headers and broader branch prefixes from repository rules', () => {
+    const issue = createRankedIssue({
+      repoFullName: 'acme/widgets',
+      number: 42,
+      title: 'Fix keyboard focus in icon-only widgets',
+    });
+
+    const branchName = contributionPrService.buildPublishBranchName(
+      issue,
+      createRepositoryRules({ branchNamingRule: 'Use bugfix/... branch names for bug fixes.' }),
+    );
+    const commitMessage = contributionPrService.buildContributionCommitMessage(
+      issue,
+      createRepositoryRules({ commitMessageRule: 'Use fix(accessibility): for accessibility bug-fix commits.' }),
+    );
+
+    expect(branchName).toMatch(/^bugfix\/42-fix-keyboard-focus-in-icon-only-+\d+$/);
+    expect(commitMessage).toStartWith('fix(accessibility): address acme/widgets#42');
   });
 
   test('submits a draft PR against an existing fork and reuses an open PR when present', async () => {

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -63,5 +63,5 @@ describe('gitService.writeAndPublish', () => {
     }
 
     expect(featureBranchHasArtifact).toBe(false);
-  });
+  }, 20_000);
 });

--- a/test/helpers/factories.ts
+++ b/test/helpers/factories.ts
@@ -5,8 +5,8 @@ import type {
   MatchedIssue,
   ProofOfWorkRecord,
   RankedIssue,
-  RepositoryContributionRules,
   RepoMemory,
+  RepositoryContributionRules,
   RepoWorkspaceContext,
 } from '../../src/types/index.js';
 

--- a/test/helpers/factories.ts
+++ b/test/helpers/factories.ts
@@ -5,6 +5,7 @@ import type {
   MatchedIssue,
   ProofOfWorkRecord,
   RankedIssue,
+  RepositoryContributionRules,
   RepoMemory,
   RepoWorkspaceContext,
 } from '../../src/types/index.js';
@@ -96,6 +97,30 @@ export function createWorkspace(overrides: Partial<RepoWorkspaceContext> = {}): 
       'Skipped bun test during headless validation because it comes from repository-defined scripts.',
     ],
     testResults: [{ command: 'bun test', exitCode: 0, passed: true, output: '2 passed' }],
+    repositoryRules: createRepositoryRules(),
+    ...overrides,
+  };
+}
+
+export function createRepositoryRules(
+  overrides: Partial<RepositoryContributionRules> = {},
+): RepositoryContributionRules {
+  return {
+    detectedFiles: ['CONTRIBUTING.md', '.github/PULL_REQUEST_TEMPLATE.md'],
+    summary: ['Use the PR template', 'Include issue references in PRs'],
+    prTemplateBody: '## Summary\n\n## Checklist\n- [ ] Tests',
+    prTitleRule: 'Use a concise imperative title.',
+    commitMessageRule: 'Use conventional commits, e.g. feat: ...',
+    branchNamingRule: 'Use fix/... branch names for bug fixes.',
+    requiredChecklistItems: ['Confirm tests ran'],
+    requiredValidationNotes: ['Mention whether bun test passed'],
+    requiredIssueLinking: 'Reference the GitHub issue in the PR body.',
+    allowsDraftPr: true,
+    requiresPriorDiscussion: false,
+    missingRequirements: [],
+    blockingRequirements: [],
+    requiredReleaseNotes: false,
+    requiredDiscussionEvidence: false,
     ...overrides,
   };
 }
@@ -197,6 +222,7 @@ export function createPullRequestDraft(overrides: Partial<PullRequestDraft> = {}
     ],
     validation: ['bun test (pending)'],
     risks: ['Consumers may need to update snapshots that cover button rendering'],
+    body: undefined,
     ...overrides,
   };
 }
@@ -254,6 +280,7 @@ export function createProofRecord(overrides: Partial<ProofOfWorkRecord> = {}): P
     published: true,
     pullRequestUrl: 'https://github.com/acme/demo/pull/123',
     pullRequestNumber: 123,
+    reviewReason: '',
     ...overrides,
   };
 }

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -6,6 +6,20 @@ import type { ImplementationDraft, MatchedIssue } from '../src/types/index.js';
 import { createIssue, createMemory, createRankedIssue, createWorkspace } from './helpers/factories.js';
 
 interface LLMServiceInternals {
+  extractRepositoryRules(
+    repoFullName: string,
+    files: Array<{ path: string; content: string }>,
+  ): Promise<{
+    detectedFiles: string[];
+    summary: string[];
+    requiredChecklistItems: string[];
+    requiredValidationNotes: string[];
+    requiresPriorDiscussion: boolean;
+    missingRequirements: string[];
+    blockingRequirements: string[];
+    requiredReleaseNotes: boolean;
+    requiredDiscussionEvidence: boolean;
+  }>;
   validateConnection(): Promise<boolean>;
   getLastValidationError(): string | null;
   generatePatchDraft(
@@ -80,6 +94,7 @@ interface LLMServiceInternals {
           model: string;
           messages: Array<{ role: string; content: string }>;
           temperature: number;
+          response_format?: { type: 'json_object' };
           reasoning_effort?: string;
           stream?: boolean;
           stream_options?: { include_usage?: boolean };
@@ -927,6 +942,59 @@ describe('LLMService pull request draft parsing', () => {
     expect(draft.status).toBe('success');
     expect(draft.data.title).toBe('Add aria-label handling to icon-only buttons');
     expect(draft.data.changes).toEqual(['Update the shared IconButton component']);
+  });
+
+  test('requests repository-rule extraction with json_object response formatting when supported', async () => {
+    const service = new LLMService() as unknown as LLMServiceInternals & {
+      initialize(
+        apiKey: string,
+        baseUrl: string,
+        modelName?: string,
+        apiHeaders?: Record<string, string>,
+        provider?: 'openai',
+      ): void;
+    };
+    const payloads: Array<{
+      response_format?: { type: 'json_object' };
+      messages: Array<{ role: string; content: string }>;
+    }> = [];
+
+    service.initialize('sk-test', 'https://api.openai.com/v1', 'gpt-4o-mini', {}, 'openai');
+    service.client = {
+      chat: {
+        completions: {
+          create: async (payload) => {
+            payloads.push(payload);
+            return {
+              choices: [
+                {
+                  message: {
+                    content: JSON.stringify({
+                      detectedFiles: ['CONTRIBUTING.md'],
+                      summary: ['Discuss changes before opening a PR'],
+                      requiredChecklistItems: [],
+                      requiredValidationNotes: [],
+                      requiresPriorDiscussion: true,
+                      missingRequirements: [],
+                      blockingRequirements: [],
+                      requiredReleaseNotes: false,
+                      requiredDiscussionEvidence: true,
+                    }),
+                  },
+                },
+              ],
+            };
+          },
+        },
+      },
+    };
+
+    const rules = await service.extractRepositoryRules('acme/demo', [
+      { path: 'CONTRIBUTING.md', content: 'Discuss major changes before opening a PR.' },
+    ]);
+
+    expect(rules.requiresPriorDiscussion).toBe(true);
+    expect(payloads[0]?.response_format).toEqual({ type: 'json_object' });
   });
 });
 

--- a/test/machine-agent.test.ts
+++ b/test/machine-agent.test.ts
@@ -47,6 +47,7 @@ interface AgentMachineInternals {
     validationResults: unknown[];
     url?: string;
     number?: number;
+    reviewReason?: string;
   }>;
   prepareLocalArtifactPaths(issue: unknown): ReturnType<typeof createArtifacts>;
   writeLocalArtifacts(input: unknown): void;

--- a/test/state-services.test.ts
+++ b/test/state-services.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ConfigService } from '../src/infra/config.js';
 import { agentEventLogService } from '../src/services/agent-event-log.js';
 import { inboxService } from '../src/services/inbox.js';
+import { llmService } from '../src/services/index.js';
 import { memoryService } from '../src/services/memory.js';
 import { proofOfWorkService } from '../src/services/proof-of-work.js';
+import { repositoryRulesService } from '../src/services/repository-rules.js';
 import { runHistoryService } from '../src/services/run-history.js';
 import { createInboxItem, createProofRecord, createRankedIssue, createWorkspace } from './helpers/factories.js';
 
@@ -128,6 +130,7 @@ describe('stateful services', () => {
       published: false,
       reviewRequired: true,
       pullRequestUrl: undefined,
+      reviewReason: 'Repository requires prior discussion.',
     });
 
     expect(nextMemory.runStats.totalRuns).toBe(1);
@@ -136,6 +139,8 @@ describe('stateful services', () => {
     expect(nextMemory.pathSignals[0]?.changedCount).toBe(1);
     expect(nextMemory.validationSignals[0]?.command).toBe('bun test');
     expect(nextMemory.recentIssues[0]?.status).toBe('review_required');
+    expect(nextMemory.recentIssues[0]?.reviewReason).toBe('Repository requires prior discussion.');
+    expect(memoryService.renderMarkdown(nextMemory)).toContain('review Repository requires prior discussion.');
     expect(memoryService.renderMarkdown(nextMemory)).toContain('## Validation Failure Signals');
   });
 
@@ -218,12 +223,13 @@ describe('stateful services', () => {
   });
 
   test('proof-of-work service records PR links in markdown output', () => {
-    const records = proofOfWorkService.record(createProofRecord());
+    const records = proofOfWorkService.record(createProofRecord({ reviewReason: 'Repository rules blocked PR opening.' }));
     const markdown = proofOfWorkService.renderMarkdown(records);
 
     expect(records).toHaveLength(1);
     expect(markdown).toContain('Published Runs: 1');
     expect(markdown).toContain('pr=https://github.com/acme/demo/pull/123');
+    expect(markdown).toContain('review=Repository rules blocked PR opening.');
   });
 
   test('proof-of-work service summarizes empty and unpublished activity correctly', () => {
@@ -278,5 +284,33 @@ describe('stateful services', () => {
   test('run history service returns undefined for unknown runs', () => {
     expect(runHistoryService.finish('missing-run', 'cancelled')).toBeUndefined();
     expect(runHistoryService.find('missing-run')).toBeUndefined();
+  });
+
+  test('repository rules service caches extracted rules and falls back safely when extraction fails', async () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'openmeta-rules-'));
+    writeFileSync(join(repoPath, 'CONTRIBUTING.md'), 'Discuss major changes before opening a PR.', 'utf-8');
+
+    const extractSpy = spyOn(llmService, 'extractRepositoryRules')
+      .mockResolvedValueOnce({
+        detectedFiles: ['CONTRIBUTING.md'],
+        summary: ['Discuss major changes before opening a PR.'],
+        requiredChecklistItems: [],
+        requiredValidationNotes: [],
+        requiresPriorDiscussion: true,
+        missingRequirements: [],
+        blockingRequirements: [],
+        requiredReleaseNotes: false,
+        requiredDiscussionEvidence: true,
+      } as never)
+      .mockRejectedValueOnce(new Error('should use cache'));
+
+    const first = await repositoryRulesService.loadFromWorkspace('acme/demo', repoPath);
+    const second = await repositoryRulesService.loadFromWorkspace('acme/demo', repoPath);
+
+    expect(first.requiresPriorDiscussion).toBe(true);
+    expect(second.requiresPriorDiscussion).toBe(true);
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+
+    rmSync(repoPath, { recursive: true, force: true });
   });
 });

--- a/test/state-services.test.ts
+++ b/test/state-services.test.ts
@@ -223,7 +223,9 @@ describe('stateful services', () => {
   });
 
   test('proof-of-work service records PR links in markdown output', () => {
-    const records = proofOfWorkService.record(createProofRecord({ reviewReason: 'Repository rules blocked PR opening.' }));
+    const records = proofOfWorkService.record(
+      createProofRecord({ reviewReason: 'Repository rules blocked PR opening.' }),
+    );
     const markdown = proofOfWorkService.renderMarkdown(records);
 
     expect(records).toHaveLength(1);

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, sep } from 'path';
 import { simpleGit } from 'simple-git';
 import { pathToFileURL } from 'url';
+import { llmService } from '../src/services/index.js';
 import { workspaceService } from '../src/services/workspace.js';
 import { createMemory, createRankedIssue, createWorkspace } from './helpers/factories.js';
 
@@ -236,6 +237,7 @@ describe('workspaceService.detectTestCommands', () => {
       };
       const originalBuildRepoUrl = service.buildRepoUrl;
       service.buildRepoUrl = () => pathToFileURL(remotePath).href;
+      const extractSpy = spyOn(llmService, 'extractRepositoryRules').mockRejectedValue(new Error('llm unavailable'));
 
       try {
         const workspace = await service.prepareRepositoryWorkspace(
@@ -254,7 +256,9 @@ describe('workspaceService.detectTestCommands', () => {
         expect(workspace.candidateFiles.map(normalizePathForAssertion)).toContain('src/index.ts');
         expect(workspace.snippets.some((snippet) => snippet.path === 'README.md')).toBe(true);
         expect(workspace.testCommands.map((command) => command.command)).toContain('bun run test');
+        expect(workspace.repositoryRules?.detectedFiles).toEqual([]);
       } finally {
+        extractSpy.mockRestore();
         service.buildRepoUrl = originalBuildRepoUrl;
         delete process.env['OPENMETA_HOME'];
       }

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -233,6 +233,7 @@ describe('workspaceService.detectTestCommands', () => {
           candidateFiles: string[];
           snippets: Array<{ path: string; content: string }>;
           testCommands: Array<{ command: string }>;
+          repositoryRules?: { detectedFiles: string[] };
         }>;
       };
       const originalBuildRepoUrl = service.buildRepoUrl;


### PR DESCRIPTION
## What this changes

This PR teaches OpenMeta to read repository contribution rules before it tries to open an automatic PR, and to back off into review/artifact mode when those rules are not safely satisfied.

It adds lightweight repository rule discovery and caching, uses structured LLM extraction for freeform contribution docs, and threads the detected rules through PR drafting, branch/commit naming, and final PR submission gating.

## Why

Issue #77 is really about one thing: OpenMeta should stop treating every repository as if contribution workflows are the same.

A lot of repositories require issue links, prior discussion, validation notes, PR templates, release note context, or specific naming conventions. Before this change, those rules were mostly invisible to the agent, which meant it could generate artifacts that looked plausible but still violated the repository's actual contribution process.

## Highlights

- discover contribution-related files such as `CONTRIBUTING.md`, PR templates, CODEOWNERS, and issue templates
- cache extracted repository rules locally to avoid repeating the same scan
- use structured LLM extraction to turn freeform docs into a normalized repository rules object
- include repository rules in patch drafting and PR drafting context
- reuse detected PR template bodies when building PR content
- apply deterministic rule-gate checks before opening a real PR
- show explicit CLI blocking reasons when automatic PR creation is skipped
- record review reasons in artifacts and memory outputs

## Testing

- `bun test test/content.test.ts test/contribution-pr.test.ts test/llm.test.ts test/agent-run.test.ts`
- `bun test test/agent-orchestrator.test.ts test/state-services.test.ts test/workspace.test.ts`