### PR TITLE
feat(security): sandbox repository validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ OpenMeta 会在本地维护自己的工作目录与状态：
 
 这使它非常适合个人长期使用：状态明确、路径稳定、可审计、可备份。
 
+### 沙箱执行
+
+OpenMeta 使用与 Claude Code 相同的 `@anthropic-ai/sandbox-runtime` 隔离仓库验证命令：macOS 使用 Seatbelt，Linux 和 WSL2 使用 bubblewrap。沙箱只允许写入当前 worktree 和临时目录，默认禁止网络访问，并隐藏 OpenMeta、GitHub、SSH 和云服务凭据路径及宿主进程中的敏感环境变量。
+
+验证执行采用 fail-closed 策略：沙箱不受支持、依赖缺失或初始化失败时，OpenMeta 会把验证报告为 unavailable，不会在宿主机上直接运行仓库代码。原生 Windows 当前不支持该运行时，请使用 WSL2 执行 `--run-checks`。
+
 ### 安全与边界
 
 OpenMeta 的卖点不是“替你托管一切”，而是**在你可控的本地环境里，把贡献流程自动化**。
@@ -735,6 +741,12 @@ OpenMeta keeps a clear local footprint:
 - repo memory and proof-of-work state: stored in the local OpenMeta state area
 
 This makes the tool practical for long-term individual use: stable paths, inspectable state, and easy backup.
+
+### Sandboxed Validation
+
+OpenMeta isolates repository validation commands with the same `@anthropic-ai/sandbox-runtime` used by Claude Code: Seatbelt on macOS and bubblewrap on Linux and WSL2. Commands may write only to the active worktree and a temporary directory, network access is denied by default, and OpenMeta, GitHub, SSH, cloud credential paths, and sensitive host environment variables are withheld.
+
+Validation fails closed. If the sandbox is unsupported, missing dependencies, or cannot initialize, validation is reported as unavailable instead of running repository code directly on the host. Native Windows is not supported by this runtime; use WSL2 for `--run-checks`.
 
 ### Security and Operating Model
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "openmeta-cli",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "^0.0.44",
         "@clack/prompts": "^1.2.0",
         "@octokit/rest": "^22.0.1",
         "boxen": "^8.0.1",
@@ -27,6 +28,8 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.44", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "@types/lodash-es": "^4.17.12", "commander": "^12.1.0", "lodash-es": "^4.17.23", "shell-quote": "^1.8.3", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-mmyjq0mzsHnQZyiU+FGYyaiJcPckuQpP78VB8iqFi2IOu8rcb9i5SmaOKyJENJNfY8l/1grzLMQgWq4Apvmozw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -81,6 +84,8 @@
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
+    "@pondwader/socks5-server": ["@pondwader/socks5-server@1.0.10", "", {}, "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg=="],
+
     "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.2", "", {}, "sha512-nEFVejViHUoL8wU8GTcwqrvqfUG40S5ts6S4fr1u1Ki5CklXlRDYThPVA/qurTmCYFGnaX3XpVUmICLHdvhLaA=="],
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.0.3", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.2" } }, "sha512-NMKv9sJcSN2VvnPT9Ja7eKfGy8Q8mMFLwPTCcuZMtv3+mYcLIZflg31S/tp2XCCyiY7YAx6cgBHQ0fwA2fWHpQ=="],
@@ -88,6 +93,10 @@
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/crypto-js": ["@types/crypto-js@4.2.2", "", {}, "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="],
+
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
+
+    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
@@ -177,6 +186,8 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
@@ -188,6 +199,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "shell-quote": ["shell-quote@1.9.0", "", {}, "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA=="],
 
     "simple-git": ["simple-git@3.35.2", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.2", "@simple-git/argv-parser": "^1.0.3", "debug": "^4.4.0" } }, "sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA=="],
 
@@ -214,6 +227,10 @@
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@anthropic-ai/sandbox-runtime/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@anthropic-ai/sandbox-runtime/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20260608.1"
   },
   "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "^0.0.44",
     "@clack/prompts": "^1.2.0",
     "@octokit/rest": "^22.0.1",
     "boxen": "^8.0.1",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,12 @@
 import { execFileSync } from 'node:child_process';
 
-const args = ['build', '--target=bun', '--outfile=bin/openmeta.js', './src/cli.ts'];
+const args = [
+  'build',
+  '--target=bun',
+  '--outfile=bin/openmeta.js',
+  '--external=@anthropic-ai/sandbox-runtime',
+  './src/cli.ts',
+];
 
 function run(command, commandArgs) {
   execFileSync(command, commandArgs, {

--- a/src/orchestration/doctor.ts
+++ b/src/orchestration/doctor.ts
@@ -13,6 +13,7 @@ import {
   type BinaryResolution,
   inspectBinaryOnPath,
   repositoryTargetingService,
+  sandboxService,
   schedulerService,
 } from '../services/index.js';
 import type { AppConfig } from '../types/index.js';
@@ -115,6 +116,7 @@ export class DoctorOrchestrator {
         ['--version'],
         'Install Git and ensure it is available on PATH.',
       ),
+      this.checkSandboxRuntime(),
       this.checkGitHubConfig(resolvedConfig),
       this.checkLlmConfig(resolvedConfig),
       this.checkProfileConfig(resolvedConfig),
@@ -292,6 +294,29 @@ export class DoctorOrchestrator {
       ['--version'],
       'Install Bun 1.0+ and ensure it is available on PATH.',
     );
+  }
+
+  private checkSandboxRuntime(): DoctorCheck {
+    const availability = sandboxService.getAvailability();
+    if (!availability.available) {
+      return {
+        id: 'runtime-sandbox',
+        label: 'Validation sandbox',
+        status: 'warn',
+        summary: 'Repository validation commands will be skipped instead of running on the host.',
+        detail: availability.reason,
+        remediation:
+          'Use macOS, Linux, or WSL2 and install the sandbox runtime dependencies before using --run-checks.',
+      };
+    }
+
+    return {
+      id: 'runtime-sandbox',
+      label: 'Validation sandbox',
+      status: 'pass',
+      summary: 'OS-level isolation is available for repository validation commands.',
+      detail: availability.warnings.length > 0 ? availability.warnings.join('; ') : undefined,
+    };
   }
 
   private checkGitHubConfig(config: AppConfig): DoctorCheck {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -21,6 +21,7 @@ export {
 } from './repository-targeting.js';
 export { RunHistoryService, runHistoryService } from './run-history.js';
 export { type BinaryResolution, inspectBinaryOnPath } from './runtime-diagnostics.js';
+export { type SandboxAvailability, SandboxService, sandboxService } from './sandbox.js';
 export type { SchedulerSyncResult } from './scheduler.js';
 export { SchedulerService, schedulerService } from './scheduler.js';
 export {

--- a/src/services/sandbox.ts
+++ b/src/services/sandbox.ts
@@ -1,0 +1,192 @@
+import { SandboxManager, type SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
+import { type SpawnSyncOptionsWithStringEncoding, spawnSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join, resolve } from 'path';
+import type { TestCommand, TestResult } from '../types/index.js';
+
+const SANDBOX_TIMEOUT_MS = 120_000;
+
+interface SandboxRuntime {
+  initialize(config: SandboxRuntimeConfig): Promise<void>;
+  isSupportedPlatform(): boolean;
+  checkDependencies(): { errors: string[]; warnings: string[] };
+  wrapWithSandbox(command: string): Promise<string>;
+  annotateStderrWithSandboxFailures(command: string, stderr: string): string;
+  cleanupAfterCommand(): void;
+  reset(): Promise<void>;
+}
+
+interface CommandResult {
+  status: number | null;
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+  error?: Error;
+}
+
+type CommandRunner = (command: string, options: SpawnSyncOptionsWithStringEncoding) => CommandResult;
+
+export interface SandboxAvailability {
+  available: boolean;
+  reason?: string;
+  warnings: string[];
+}
+
+export class SandboxService {
+  constructor(
+    private readonly runtime: SandboxRuntime = SandboxManager,
+    private readonly commandRunner: CommandRunner = spawnSync,
+  ) {}
+
+  getAvailability(): SandboxAvailability {
+    if (!this.runtime.isSupportedPlatform()) {
+      return {
+        available: false,
+        reason: `Sandboxed validation is not supported on ${process.platform}. Use Linux, WSL2, or macOS.`,
+        warnings: [],
+      };
+    }
+
+    const dependencies = this.runtime.checkDependencies();
+    if (dependencies.errors.length > 0) {
+      return {
+        available: false,
+        reason: `Sandbox dependencies are unavailable: ${dependencies.errors.join('; ')}`,
+        warnings: dependencies.warnings,
+      };
+    }
+
+    return { available: true, warnings: dependencies.warnings };
+  }
+
+  async runValidationCommands(workspacePath: string, commands: TestCommand[]): Promise<TestResult[]> {
+    if (commands.length === 0) return [];
+
+    const availability = this.getAvailability();
+    if (!availability.available) {
+      return commands.map((command) => this.unavailableResult(command, availability.reason || 'Sandbox unavailable.'));
+    }
+
+    const rootPath = resolve(workspacePath);
+    const sandboxTemp = mkdtempSync(join(tmpdir(), 'openmeta-sandbox-'));
+
+    try {
+      await this.runtime.initialize(this.buildConfig(rootPath, sandboxTemp));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      await this.safeReset();
+      rmSync(sandboxTemp, { recursive: true, force: true });
+      return commands.map((command) => this.unavailableResult(command, `Sandbox initialization failed: ${reason}`));
+    }
+
+    try {
+      const results: TestResult[] = [];
+      for (const command of commands) {
+        results.push(await this.runCommand(rootPath, sandboxTemp, command));
+      }
+      return results;
+    } finally {
+      await this.safeReset();
+      rmSync(sandboxTemp, { recursive: true, force: true });
+    }
+  }
+
+  private buildConfig(workspacePath: string, sandboxTemp: string): SandboxRuntimeConfig {
+    const home = homedir();
+    return {
+      network: {
+        allowedDomains: [],
+        deniedDomains: [],
+        allowUnixSockets: [],
+        allowLocalBinding: false,
+      },
+      filesystem: {
+        denyRead: [
+          join(home, '.ssh'),
+          join(home, '.aws'),
+          join(home, '.azure'),
+          join(home, '.config', 'gh'),
+          join(home, '.config', 'openmeta'),
+          join(home, '.openmeta'),
+          join(home, '.git-credentials'),
+          join(home, '.netrc'),
+          join(home, '.npmrc'),
+          join(home, '.pypirc'),
+        ],
+        allowRead: [workspacePath, sandboxTemp],
+        allowWrite: [workspacePath, sandboxTemp],
+        denyWrite: [join(workspacePath, '.git'), join(home, '.config', 'openmeta'), join(home, '.openmeta')],
+        allowGitConfig: false,
+      },
+    };
+  }
+
+  private async runCommand(workspacePath: string, sandboxTemp: string, command: TestCommand): Promise<TestResult> {
+    let wrappedCommand: string;
+    try {
+      wrappedCommand = await this.runtime.wrapWithSandbox(command.command);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return this.unavailableResult(command, `Sandbox command preparation failed: ${reason}`);
+    }
+
+    try {
+      const result = this.commandRunner(wrappedCommand, {
+        cwd: workspacePath,
+        encoding: 'utf-8',
+        shell: true,
+        timeout: SANDBOX_TIMEOUT_MS,
+        env: this.buildEnvironment(sandboxTemp),
+      });
+      const stdout = String(result.stdout || '');
+      const stderr = this.runtime.annotateStderrWithSandboxFailures(command.command, String(result.stderr || ''));
+      const errorText = result.error ? `\n${result.error.message}` : '';
+      const output = `${stdout}\n${stderr}${errorText}`.trim().slice(0, 2000);
+
+      return {
+        command: command.command,
+        exitCode: typeof result.status === 'number' ? result.status : null,
+        passed: result.status === 0,
+        output,
+      };
+    } finally {
+      this.runtime.cleanupAfterCommand();
+    }
+  }
+
+  private buildEnvironment(sandboxTemp: string): NodeJS.ProcessEnv {
+    const names = ['PATH', 'Path', 'PATHEXT', 'SystemRoot', 'WINDIR', 'COMSPEC', 'LANG', 'LC_ALL', 'TERM'];
+    const env: NodeJS.ProcessEnv = {};
+    for (const name of names) {
+      const value = process.env[name];
+      if (value !== undefined) env[name] = value;
+    }
+
+    env['HOME'] = sandboxTemp;
+    env['USERPROFILE'] = sandboxTemp;
+    env['TMPDIR'] = sandboxTemp;
+    env['TMP'] = sandboxTemp;
+    env['TEMP'] = sandboxTemp;
+    env['CI'] = '1';
+    return env;
+  }
+
+  private unavailableResult(command: TestCommand, reason: string): TestResult {
+    return {
+      command: command.command,
+      exitCode: 127,
+      passed: false,
+      output: `Validation was not executed because a secure sandbox is unavailable. ${reason}`,
+    };
+  }
+
+  private async safeReset(): Promise<void> {
+    try {
+      await this.runtime.reset();
+    } catch {
+      // Preserve the validation result when sandbox cleanup itself fails.
+    }
+  }
+}
+
+export const sandboxService = new SandboxService();

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -15,6 +15,7 @@ import type {
   TestResult,
 } from '../types/index.js';
 import { permissionPolicyService } from './permission-policy.js';
+import { sandboxService } from './sandbox.js';
 
 const EXCLUDED_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.next', 'coverage', 'target', 'vendor']);
 
@@ -81,7 +82,7 @@ export class WorkspaceService {
       this.discoverFiles(workspaceState.workspacePath),
     ).slice(0, 8);
 
-    return this.buildWorkspaceContext({
+    return await this.buildWorkspaceContext({
       workspacePath: workspaceState.workspacePath,
       workspaceDirty: workspaceState.workspaceDirty,
       defaultBranch: workspaceState.defaultBranch,
@@ -109,7 +110,7 @@ export class WorkspaceService {
       this.discoverFiles(workspaceState.workspacePath),
     ).slice(0, 12);
 
-    return this.buildWorkspaceContext({
+    return await this.buildWorkspaceContext({
       workspacePath: workspaceState.workspacePath,
       candidateFiles,
       workspaceDirty: workspaceState.workspaceDirty,
@@ -209,8 +210,8 @@ export class WorkspaceService {
     };
   }
 
-  runValidationCommands(workspacePath: string, commands: TestCommand[]): TestResult[] {
-    return this.runTestCommands(workspacePath, commands);
+  async runValidationCommands(workspacePath: string, commands: TestCommand[]): Promise<TestResult[]> {
+    return await sandboxService.runValidationCommands(workspacePath, commands);
   }
 
   readWorkspaceFiles(workspacePath: string, filePaths: string[]): RepoFileSnippet[] {
@@ -492,7 +493,7 @@ export class WorkspaceService {
     return 'main';
   }
 
-  private buildWorkspaceContext(input: {
+  private async buildWorkspaceContext(input: {
     workspacePath: string;
     workspaceDirty: boolean;
     defaultBranch: string;
@@ -500,7 +501,7 @@ export class WorkspaceService {
     candidateFiles: string[];
     runChecks: boolean;
     executionMode: ExecutionMode;
-  }): RepoWorkspaceContext {
+  }): Promise<RepoWorkspaceContext> {
     const topLevelFiles = readdirSync(input.workspacePath).slice(0, 50);
     const snippets = input.candidateFiles.map((path) => ({
       path,
@@ -512,7 +513,7 @@ export class WorkspaceService {
       input.executionMode,
     );
     const testResults = input.runChecks
-      ? this.runTestCommands(input.workspacePath, validationCommands.slice(0, 3))
+      ? await this.runTestCommands(input.workspacePath, validationCommands.slice(0, 3))
       : [];
 
     return {
@@ -913,47 +914,8 @@ export class WorkspaceService {
     return `${runner} run ${scriptName}`;
   }
 
-  private runTestCommands(workspacePath: string, commands: TestCommand[]): TestResult[] {
-    return commands.map((item) => {
-      const toolDefault = this.resolveToolDefaultCommand(item);
-      const result = toolDefault
-        ? spawnSync(toolDefault.command, toolDefault.args, {
-            cwd: workspacePath,
-            encoding: 'utf-8',
-            timeout: 120000,
-          })
-        : spawnSync(item.command, {
-            cwd: workspacePath,
-            encoding: 'utf-8',
-            shell: true,
-            timeout: 120000,
-          });
-
-      const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim().slice(0, 2000);
-      return {
-        command: item.command,
-        exitCode: typeof result.status === 'number' ? result.status : null,
-        passed: result.status === 0,
-        output,
-      };
-    });
-  }
-
-  private resolveToolDefaultCommand(command: TestCommand): { command: string; args: string[] } | null {
-    if (command.source !== 'tool-default') {
-      return null;
-    }
-
-    switch (command.command) {
-      case 'cargo test':
-        return { command: 'cargo', args: ['test'] };
-      case 'go test ./...':
-        return { command: 'go', args: ['test', './...'] };
-      case 'pytest':
-        return { command: 'pytest', args: [] };
-      default:
-        return null;
-    }
+  private async runTestCommands(workspacePath: string, commands: TestCommand[]): Promise<TestResult[]> {
+    return await sandboxService.runValidationCommands(workspacePath, commands);
   }
 }
 

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -205,7 +205,7 @@ describe('AgentOrchestrator patch workflow', () => {
         },
       });
 
-      workspaceService.runValidationCommands = () => {
+      workspaceService.runValidationCommands = async () => {
         validationRuns += 1;
         return validationRuns === 1
           ? [{ command: 'pytest', exitCode: 1, passed: false, output: 'AssertionError: expected version 2' }]
@@ -544,7 +544,7 @@ describe('AgentOrchestrator patch workflow', () => {
         },
       });
 
-      workspaceService.runValidationCommands = () => {
+      workspaceService.runValidationCommands = async () => {
         validationRuns += 1;
         return [{ command: 'pytest', exitCode: 1, passed: false, output: 'AssertionError: expected version 2' }];
       };

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { DoctorOrchestrator } from '../src/orchestration/doctor.js';
 import * as runtimeDiagnosticsModule from '../src/services/runtime-diagnostics.js';
+import { sandboxService } from '../src/services/sandbox.js';
 import { schedulerService } from '../src/services/scheduler.js';
 import type { AppConfig } from '../src/types/index.js';
 
@@ -142,6 +143,27 @@ describe('DoctorOrchestrator', () => {
     expect(report.ready).toBe(false);
     expect(report.checks.find((check) => check.id === 'github-config')?.status).toBe('fail');
     expect(report.checks.find((check) => check.id === 'llm-config')?.status).toBe('fail');
+  });
+
+  test('reports an unavailable sandbox as a non-blocking warning', async () => {
+    const originalGetAvailability = sandboxService.getAvailability;
+    sandboxService.getAvailability = () => ({
+      available: false,
+      reason: 'Native Windows is unsupported.',
+      warnings: [],
+    });
+
+    try {
+      const report = await new DoctorOrchestrator().inspect(createConfig());
+      expect(report.checks.find((check) => check.id === 'runtime-sandbox')).toEqual(
+        expect.objectContaining({
+          status: 'warn',
+          detail: 'Native Windows is unsupported.',
+        }),
+      );
+    } finally {
+      sandboxService.getAvailability = originalGetAvailability;
+    }
   });
 
   test('fails when a configured artifact repository path does not exist', async () => {

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SandboxService } from '../src/services/sandbox.js';
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(): string {
+  const path = mkdtempSync(join(tmpdir(), 'openmeta-sandbox-test-'));
+  tempDirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe('SandboxService', () => {
+  test('fails closed when the current platform cannot provide a sandbox', async () => {
+    let executed = false;
+    const runtime = {
+      initialize: async (_config: SandboxRuntimeConfig) => {},
+      isSupportedPlatform: () => false,
+      checkDependencies: () => ({ errors: [], warnings: [] }),
+      wrapWithSandbox: async (command: string) => command,
+      annotateStderrWithSandboxFailures: (_command: string, stderr: string) => stderr,
+      cleanupAfterCommand: () => {},
+      reset: async () => {},
+    };
+    const service = new SandboxService(runtime, () => {
+      executed = true;
+      return { status: 0 };
+    });
+
+    const results = await service.runValidationCommands(makeWorkspace(), [
+      { command: 'pytest', reason: 'Detected pyproject.toml', source: 'tool-default' },
+    ]);
+
+    expect(executed).toBe(false);
+    expect(results[0]?.exitCode).toBe(127);
+    expect(results[0]?.output).toContain('secure sandbox is unavailable');
+  });
+
+  test('uses a deny-by-default network policy and a sanitized child environment', async () => {
+    let config: SandboxRuntimeConfig | undefined;
+    let childEnvironment: NodeJS.ProcessEnv | undefined;
+    let cleaned = 0;
+    let reset = 0;
+    const runtime = {
+      initialize: async (value: SandboxRuntimeConfig) => {
+        config = value;
+      },
+      isSupportedPlatform: () => true,
+      checkDependencies: () => ({ errors: [], warnings: [] }),
+      wrapWithSandbox: async (command: string) => `sandboxed ${command}`,
+      annotateStderrWithSandboxFailures: (_command: string, stderr: string) => stderr,
+      cleanupAfterCommand: () => {
+        cleaned += 1;
+      },
+      reset: async () => {
+        reset += 1;
+      },
+    };
+    const service = new SandboxService(runtime, (_command, options) => {
+      childEnvironment = options.env;
+      return { status: 0, stdout: 'passed', stderr: '' };
+    });
+
+    const results = await service.runValidationCommands(makeWorkspace(), [
+      { command: 'go test ./...', reason: 'Detected go.mod', source: 'tool-default' },
+    ]);
+
+    expect(results[0]?.passed).toBe(true);
+    expect(config?.network.allowedDomains).toEqual([]);
+    expect(config?.filesystem.allowWrite).toHaveLength(2);
+    expect(config?.filesystem.denyWrite.some((path) => path.endsWith('.git'))).toBe(true);
+    expect(childEnvironment?.['GITHUB_TOKEN']).toBeUndefined();
+    expect(childEnvironment?.['OPENAI_API_KEY']).toBeUndefined();
+    expect(childEnvironment?.['CI']).toBe('1');
+    expect(cleaned).toBe(1);
+    expect(reset).toBe(1);
+  });
+
+  test('does not execute commands when sandbox initialization fails', async () => {
+    let executed = false;
+    const runtime = {
+      initialize: async (_config: SandboxRuntimeConfig) => {
+        throw new Error('proxy failed');
+      },
+      isSupportedPlatform: () => true,
+      checkDependencies: () => ({ errors: [], warnings: [] }),
+      wrapWithSandbox: async (command: string) => command,
+      annotateStderrWithSandboxFailures: (_command: string, stderr: string) => stderr,
+      cleanupAfterCommand: () => {},
+      reset: async () => {},
+    };
+    const service = new SandboxService(runtime, () => {
+      executed = true;
+      return { status: 0 };
+    });
+
+    const results = await service.runValidationCommands(makeWorkspace(), [
+      { command: 'cargo test', reason: 'Detected Cargo.toml', source: 'tool-default' },
+    ]);
+
+    expect(executed).toBe(false);
+    expect(results[0]?.output).toContain('Sandbox initialization failed: proxy failed');
+  });
+});


### PR DESCRIPTION
## Summary

- isolate repository validation commands with Anthropic Sandbox Runtime
- deny network access and sensitive credential paths by default
- fail closed when sandboxing is unavailable and expose the status through doctor
- document platform support and add sandbox policy tests


## Why

OpenMeta works with unfamiliar third-party repositories and can run their test, build, and package scripts, including in unattended agent flows. Commands such as `pytest`, `go test`, and `cargo test` execute repository-controlled code even when the command itself comes from a trusted tool-default list.

Without OS-level isolation, that code inherits the current user's permissions and may read local credentials, modify files outside the worktree, or exfiltrate data over the network. Application-level command selection and path validation cannot reliably constrain subprocess behavior once execution begins.

This change adds a runtime boundary around repository code while keeping GitHub, LLM, and artifact operations outside the sandbox where their credentials are required. Failing closed when isolation is unavailable is especially important for headless automation, where no user is present to review an unsafe fallback.

## Validation

- bun run check
- bun run typecheck
- bun test (290 passed)